### PR TITLE
feat(ui): show progress for Systems 2-7

### DIFF
--- a/app_system3.py
+++ b/app_system3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
+import time
 
 import pandas as pd
 import streamlit as st
@@ -16,6 +17,7 @@ from common.ui_components import (
     show_signal_trade_summary,
 )
 from common.ui_manager import UIManager
+from common.logging_utils import log_with_progress
 import common.ui_patch  # noqa: F401
 from strategies.system3_strategy import System3Strategy
 
@@ -39,8 +41,12 @@ def display_drop3d_ranking(
     if not candidates_by_date:
         st.warning(tr("3日下落率ランキングが空です"))
         return
-    rows = []
-    for date, cands in candidates_by_date.items():
+    rows: list[dict[str, Any]] = []
+    total = len(candidates_by_date)
+    progress = st.progress(0)
+    log_area = st.empty()
+    start = time.time()
+    for i, (date, cands) in enumerate(candidates_by_date.items(), 1):
         for c in cands:
             rows.append(
                 {
@@ -49,6 +55,17 @@ def display_drop3d_ranking(
                     "DropRate_3D": c.get("DropRate_3D"),
                 }
             )
+        log_with_progress(
+            i,
+            total,
+            start,
+            prefix="3日下落率ランキング",
+            log_func=log_area.write,
+            progress_func=progress.progress,
+            unit=tr("days"),
+        )
+    progress.empty()
+    log_area.write(tr("3日下落率ランキング完了"))
     df = pd.DataFrame(rows)
     df["Date"] = pd.to_datetime(df["Date"])  # type: ignore[arg-type]
     start_date = pd.Timestamp.now() - pd.DateOffset(years=years)
@@ -79,7 +96,12 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             display_name=DISPLAY_NAME,
         )
     )
-    ui: UIManager = ui_manager or UIManager()
+    ui_base: UIManager = (
+        ui_manager.system(SYSTEM_NAME) if ui_manager else UIManager().system(SYSTEM_NAME)
+    )
+    fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
+    ind_phase = ui_base.phase("indicators", title=tr("インジケーター計算"))
+    cand_phase = ui_base.phase("candidates", title=tr("候補選定"))
     # 通知トグルは共通UI(run_backtest_app)内に配置して順序を統一
     notify_key = f"{SYSTEM_NAME}_notify_backtest"
     _rb = cast(
@@ -94,10 +116,13 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             strategy,
             system_name=SYSTEM_NAME,
             limit_symbols=100,
-            ui_manager=ui,
+            ui_manager=ui_base,
         ),
     )
     results_df, _, data_dict, capital, candidates_by_date = _rb
+    fetch_phase.log_area.write(tr("データ取得完了"))
+    ind_phase.log_area.write(tr("インジケーター計算完了"))
+    cand_phase.log_area.write(tr("候補選定完了"))
     if results_df is not None and candidates_by_date is not None:
         display_drop3d_ranking(candidates_by_date)
         summary_df = show_signal_trade_summary(

--- a/app_system4.py
+++ b/app_system4.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
+import time
 
 import pandas as pd
 import streamlit as st
@@ -15,6 +16,7 @@ from common.ui_components import (
     show_signal_trade_summary,
 )
 from common.ui_manager import UIManager
+from common.logging_utils import log_with_progress
 import common.ui_patch  # noqa: F401
 from common.utils_spy import get_spy_data_cached
 from strategies.system4_strategy import System4Strategy
@@ -39,9 +41,12 @@ def display_rsi4_ranking(
     if not candidates_by_date:
         st.warning(tr("RSI4ランキングデータがありません"))
         return
-
-    rows = []
-    for date, cands in candidates_by_date.items():
+    rows: list[dict[str, Any]] = []
+    total = len(candidates_by_date)
+    progress = st.progress(0)
+    log_area = st.empty()
+    start = time.time()
+    for i, (date, cands) in enumerate(candidates_by_date.items(), 1):
         for c in cands:
             rows.append(
                 {
@@ -50,6 +55,17 @@ def display_rsi4_ranking(
                     "RSI4": c.get("RSI4"),
                 }
             )
+        log_with_progress(
+            i,
+            total,
+            start,
+            prefix="RSI4ランキング",
+            log_func=log_area.write,
+            progress_func=progress.progress,
+            unit=tr("days"),
+        )
+    progress.empty()
+    log_area.write(tr("RSI4ランキング完了"))
     df = pd.DataFrame(rows)
     df["Date"] = pd.to_datetime(df["Date"])  # type: ignore[arg-type]
     start_date = pd.Timestamp.now() - pd.DateOffset(years=years)
@@ -86,7 +102,12 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
         st.error(tr("SPYの取得に失敗しました。キャッシュの更新をご確認ください。"))
         return
 
-    ui: UIManager = ui_manager or UIManager()
+    ui_base: UIManager = (
+        ui_manager.system(SYSTEM_NAME) if ui_manager else UIManager().system(SYSTEM_NAME)
+    )
+    fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
+    ind_phase = ui_base.phase("indicators", title=tr("インジケーター計算"))
+    cand_phase = ui_base.phase("candidates", title=tr("候補選定"))
     # 通知トグルは共通UI(run_backtest_app)内に配置して順序を統一
     notify_key = f"{SYSTEM_NAME}_notify_backtest"
     _rb = cast(
@@ -102,10 +123,13 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             system_name=SYSTEM_NAME,
             limit_symbols=100,
             spy_df=spy_df,
-            ui_manager=ui,
+            ui_manager=ui_base,
         ),
     )
     results_df, _, data_dict, capital, candidates_by_date = _rb
+    fetch_phase.log_area.write(tr("データ取得完了"))
+    ind_phase.log_area.write(tr("インジケーター計算完了"))
+    cand_phase.log_area.write(tr("候補選定完了"))
     if results_df is not None and candidates_by_date is not None:
         display_rsi4_ranking(candidates_by_date)
         summary_df = show_signal_trade_summary(

--- a/app_system5.py
+++ b/app_system5.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
+import time
 
 import pandas as pd
 import streamlit as st
@@ -16,6 +17,7 @@ from common.ui_components import (
     show_signal_trade_summary,
 )
 from common.ui_manager import UIManager
+from common.logging_utils import log_with_progress
 import common.ui_patch  # noqa: F401
 from strategies.system5_strategy import System5Strategy
 
@@ -40,8 +42,12 @@ def display_adx_ranking(
     if not candidates_by_date:
         st.warning(tr("ADX7ランキングデータがありません"))
         return
-    rows = []
-    for date, cands in candidates_by_date.items():
+    rows: list[dict[str, Any]] = []
+    total = len(candidates_by_date)
+    progress = st.progress(0)
+    log_area = st.empty()
+    start = time.time()
+    for i, (date, cands) in enumerate(candidates_by_date.items(), 1):
         for c in cands:
             rows.append(
                 {
@@ -50,6 +56,17 @@ def display_adx_ranking(
                     "ADX7": c.get("ADX7"),
                 }
             )
+        log_with_progress(
+            i,
+            total,
+            start,
+            prefix="ADX7ランキング",
+            log_func=log_area.write,
+            progress_func=progress.progress,
+            unit=tr("days"),
+        )
+    progress.empty()
+    log_area.write(tr("ADX7ランキング完了"))
     df = pd.DataFrame(rows)
     df["Date"] = pd.to_datetime(df["Date"])  # type: ignore[arg-type]
     start_date = pd.Timestamp.now() - pd.DateOffset(years=years)
@@ -80,7 +97,12 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             display_name=DISPLAY_NAME,
         )
     )
-    ui: UIManager = ui_manager or UIManager()
+    ui_base: UIManager = (
+        ui_manager.system(SYSTEM_NAME) if ui_manager else UIManager().system(SYSTEM_NAME)
+    )
+    fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
+    ind_phase = ui_base.phase("indicators", title=tr("インジケーター計算"))
+    cand_phase = ui_base.phase("candidates", title=tr("候補選定"))
     # 通知トグルは共通UI(run_backtest_app)内に配置して順序を統一
     notify_key = f"{SYSTEM_NAME}_notify_backtest"
     _rb = cast(
@@ -95,10 +117,13 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             strategy,
             system_name=SYSTEM_NAME,
             limit_symbols=100,
-            ui_manager=ui,
+            ui_manager=ui_base,
         ),
     )
     results_df, _, data_dict, capital, candidates_by_date = _rb
+    fetch_phase.log_area.write(tr("データ取得完了"))
+    ind_phase.log_area.write(tr("インジケーター計算完了"))
+    cand_phase.log_area.write(tr("候補選定完了"))
     if results_df is not None and candidates_by_date is not None:
         display_adx_ranking(candidates_by_date)
         summary_df = show_signal_trade_summary(

--- a/app_system6.py
+++ b/app_system6.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
+import time
 
 import pandas as pd
 import streamlit as st
@@ -16,6 +17,7 @@ from common.ui_components import (
     show_signal_trade_summary,
 )
 from common.ui_manager import UIManager
+from common.logging_utils import log_with_progress
 import common.ui_patch  # noqa: F401
 from strategies.system6_strategy import System6Strategy
 
@@ -39,8 +41,12 @@ def display_return6d_ranking(
     if not candidates_by_date:
         st.warning(tr("Return6Dランキングデータがありません"))
         return
-    rows = []
-    for date, cands in candidates_by_date.items():
+    rows: list[dict[str, Any]] = []
+    total = len(candidates_by_date)
+    progress = st.progress(0)
+    log_area = st.empty()
+    start = time.time()
+    for i, (date, cands) in enumerate(candidates_by_date.items(), 1):
         for c in cands:
             rows.append(
                 {
@@ -49,6 +55,17 @@ def display_return6d_ranking(
                     "Return6D": c.get("Return6D"),
                 }
             )
+        log_with_progress(
+            i,
+            total,
+            start,
+            prefix="Return6Dランキング",
+            log_func=log_area.write,
+            progress_func=progress.progress,
+            unit=tr("days"),
+        )
+    progress.empty()
+    log_area.write(tr("Return6Dランキング完了"))
     df = pd.DataFrame(rows)
     df["Date"] = pd.to_datetime(df["Date"])  # type: ignore[arg-type]
     start_date = pd.Timestamp.now() - pd.DateOffset(years=years)
@@ -79,7 +96,12 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             display_name=DISPLAY_NAME,
         )
     )
-    ui: UIManager = ui_manager or UIManager()
+    ui_base: UIManager = (
+        ui_manager.system(SYSTEM_NAME) if ui_manager else UIManager().system(SYSTEM_NAME)
+    )
+    fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
+    ind_phase = ui_base.phase("indicators", title=tr("インジケーター計算"))
+    cand_phase = ui_base.phase("candidates", title=tr("候補選定"))
     # 通知トグルは共通UI(run_backtest_app)内に配置して順序を統一
     notify_key = f"{SYSTEM_NAME}_notify_backtest"
     _rb = cast(
@@ -94,10 +116,13 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
             strategy,
             system_name=SYSTEM_NAME,
             limit_symbols=100,
-            ui_manager=ui,
+            ui_manager=ui_base,
         ),
     )
     results_df, _, data_dict, capital, candidates_by_date = _rb
+    fetch_phase.log_area.write(tr("データ取得完了"))
+    ind_phase.log_area.write(tr("インジケーター計算完了"))
+    cand_phase.log_area.write(tr("候補選定完了"))
     if results_df is not None and candidates_by_date is not None:
         display_return6d_ranking(candidates_by_date)
         summary_df = show_signal_trade_summary(

--- a/app_system7.py
+++ b/app_system7.py
@@ -45,7 +45,12 @@ def run_tab(
     )
     single_mode = st.checkbox(tr("単体モード（資金100%を使用）"), value=False)
 
-    ui: UIManager = ui_manager or UIManager()
+    ui_base: UIManager = (
+        ui_manager.system(SYSTEM_NAME) if ui_manager else UIManager().system(SYSTEM_NAME)
+    )
+    fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
+    ind_phase = ui_base.phase("indicators", title=tr("インジケーター計算"))
+    cand_phase = ui_base.phase("candidates", title=tr("候補選定"))
     # 通知トグルは共通UI(run_backtest_app)内に配置して順序を統一
     notify_key = f"{SYSTEM_NAME}_notify_backtest"
     _rb = cast(
@@ -60,11 +65,14 @@ def run_tab(
             strategy,
             system_name=SYSTEM_NAME,
             limit_symbols=1,
-            ui_manager=ui,
+            ui_manager=ui_base,
             single_mode=single_mode,
         ),
     )
     results_df, _, data_dict, capital, candidates_by_date = _rb
+    fetch_phase.log_area.write(tr("データ取得完了"))
+    ind_phase.log_area.write(tr("インジケーター計算完了"))
+    cand_phase.log_area.write(tr("候補選定完了"))
 
     if results_df is not None and candidates_by_date is not None:
         summary_df = show_signal_trade_summary(


### PR DESCRIPTION
## Summary
- add per-phase progress bars and logs to Systems 2–7
- show progress for system-specific ranking displays

## Testing
- `flake8 app_system2.py app_system3.py app_system4.py app_system5.py app_system6.py app_system7.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `streamlit run app_system2.py --server.headless true --server.port 8502`
- `streamlit run app_system3.py --server.headless true --server.port 8503`
- `streamlit run app_system4.py --server.headless true --server.port 8504`
- `streamlit run app_system5.py --server.headless true --server.port 8505`
- `streamlit run app_system6.py --server.headless true --server.port 8506`
- `streamlit run app_system7.py --server.headless true --server.port 8507`


------
https://chatgpt.com/codex/tasks/task_e_68bcd2a482b48332b2a492b016bb75fd