### PR TITLE
fix: ensure all systems log in today signal run

### DIFF
--- a/app_integrated.py
+++ b/app_integrated.py
@@ -71,8 +71,9 @@ def main() -> None:
 
     system_tabs = tabs[2:]
     for sys_idx, tab in enumerate(system_tabs, start=1):
+        sys_name = f"System{sys_idx}"
         with tab:
-            sys_name = f"System{sys_idx}"
+            logger.info("%s tab start", sys_name)
             try:
                 app_mod = __import__(f"app_system{sys_idx}")
                 if sys_idx == 1:
@@ -83,6 +84,8 @@ def main() -> None:
             except Exception as e:  # noqa: BLE001
                 logger.exception("%s tab error", sys_name)
                 st.exception(e)
+            finally:
+                logger.info("%s tab done", sys_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log start and completion of each system tab in integrated Streamlit app

## Testing
- `python -m flake8 app_integrated.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `streamlit run app_integrated.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcd1b47e5483329cc2841a8705eb65