### PR TITLE
feat: handle UUID keys during JSON serialization

### DIFF
--- a/fix_uuid_json.py
+++ b/fix_uuid_json.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+
+def make_json_serializable(obj: Any) -> Any:
+    """Recursively convert UUID keys and values to strings for JSON serialization."""
+    if isinstance(obj, dict):
+        return {
+            (str(k) if isinstance(k, UUID) else k): make_json_serializable(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [make_json_serializable(item) for item in obj]
+    if isinstance(obj, UUID):
+        return str(obj)
+    return obj
+
+
+def dumps(obj: Any, **kwargs: Any) -> str:
+    """Serialize obj to JSON, converting UUID keys and values to strings."""
+    return json.dumps(make_json_serializable(obj), **kwargs)
+
+
+if __name__ == "__main__":
+    import uuid
+
+    sample = {uuid.uuid4(): {"id": uuid.uuid4()}}
+    print(dumps(sample))

--- a/tests/test_fix_uuid_json.py
+++ b/tests/test_fix_uuid_json.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import uuid
+
+from fix_uuid_json import make_json_serializable
+
+
+def test_make_json_serializable_converts_uuid_keys_and_values() -> None:
+    k1 = uuid.uuid4()
+    data = {k1: {"inner": [k1]}}
+    result = make_json_serializable(data)
+    assert list(result.keys()) == [str(k1)]
+    assert result[str(k1)]["inner"] == [str(k1)]


### PR DESCRIPTION
## Summary
- add helper to convert UUID keys/values to strings before JSON dumping
- cover UUID conversion with unit test

## Testing
- `flake8 fix_uuid_json.py tests/test_fix_uuid_json.py`
- `pre-commit run --files fix_uuid_json.py tests/test_fix_uuid_json.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `pytest tests/test_fix_uuid_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5f9550b4833296193dc2fcff3a85