### PR TITLE
feat(ui): add cancel-all-orders button

### DIFF
--- a/app_today_signals.py
+++ b/app_today_signals.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 import pandas as pd
 import streamlit as st
 
@@ -43,9 +42,6 @@ with st.sidebar:
     if "today_cap_short" not in st.session_state:
         st.session_state["today_cap_short"] = 0.0
 
-    # --- 削除: 青いinfo表示（資産の現在値） ---
-    # st.info(f"long資産: {st.session_state['today_cap_long']:.2f} / short資産: {st.session_state['today_cap_short']:.2f}")
-
     # Alpacaから取得してフォームに反映
     if st.button("🔍 Alpacaから資産取得してフォームに反映"):
         try:
@@ -59,7 +55,8 @@ with st.sidebar:
                 st.session_state["today_cap_long"] = round(bp / 2.0, 2)
                 st.session_state["today_cap_short"] = round(bp / 2.0, 2)
                 st.success(
-                    f"long資産/short資産を{st.session_state['today_cap_long']}ずつに設定（buying_powerの半分={bp}）"
+                    f"long資産/short資産を{st.session_state['today_cap_long']}ずつに設定"
+                    f"（buying_powerの半分={bp}）"
                 )
             else:
                 st.warning("Alpaca口座情報: buying_power/cashが取得できません")
@@ -100,6 +97,14 @@ with st.sidebar:
     if st.button("キャッシュクリア"):
         st.cache_data.clear()
         st.success("キャッシュをクリアしました")
+
+    if st.button("全注文キャンセル"):
+        try:
+            client = ba.get_client(paper=paper_mode)
+            ba.cancel_all_orders(client)
+            st.success("すべての未約定注文をキャンセルしました")
+        except Exception as e:
+            st.error(f"注文キャンセルエラー: {e}")
 
 if st.button("▶ 本日のシグナル実行", type="primary"):
     # prepare live log display


### PR DESCRIPTION
## Summary
- add helper to cancel all open orders via Alpaca client
- add "cancel all orders" button to today signals Streamlit app for testing

## Testing
- `flake8 common/broker_alpaca.py app_today_signals.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `streamlit run app_today_signals.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd63dc6da88332a27cabf4355a66f7