### PR TITLE
chore(dev): add flake8 formatting hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 100
+max-line-length = 88
 extend-ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 pre-commit>=3.8,<4
 ruff>=0.6,<1
 black>=24.8,<25
+flake8>=7,<8
 isort>=5.13,<6
 mypy>=1.11,<2
 bandit>=1.7,<2


### PR DESCRIPTION
## Summary
- enforce 88-char lines via flake8
- add flake8 hook to pre-commit and dev requirements

## Testing
- `flake8 tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd85a5a88c833293c20dbe2e3e7c5d