### PR TITLE
fix: reset index in today signals app

### DIFF
--- a/app_today_signals.py
+++ b/app_today_signals.py
@@ -181,6 +181,10 @@ if st.button("▶ 本日のシグナル実行", type="primary"):
             symbol_data=symbol_data,  # 追加: 必要日数分だけのデータ
         )
 
+    # DataFrameのインデックスをリセットしてf1などの疑似インデックスを排除
+    final_df = final_df.reset_index(drop=True)
+    per_system = {name: df.reset_index(drop=True) for name, df in per_system.items()}
+
     # 処理終了時に総経過時間を表示
     total_elapsed = time.time() - start_time
     st.info(f"総経過時間: {total_elapsed:.1f}秒")


### PR DESCRIPTION
## Summary
- reset DataFrame indices in today signals Streamlit app to avoid unexpected label lookups

## Testing
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `flake8 app_today_signals.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `streamlit run app_today_signals.py`

------
https://chatgpt.com/codex/tasks/task_e_68be1855923483329099532109737533