### PR TITLE
feat(cache): add two-tier cache management

### DIFF
--- a/app_today_signals.py
+++ b/app_today_signals.py
@@ -12,6 +12,7 @@ from common.universe import (
     load_universe_file,
 )
 from common.notifier import create_notifier
+from common.data_loader import load_price
 
 
 st.set_page_config(page_title="本日のシグナル", layout="wide")
@@ -162,8 +163,8 @@ if st.button("▶ 本日のシグナル実行", type="primary"):
         max_days = max(indicator_days.values())
         # 銘柄ごとのヒストリカルCSVを最大必要日数分だけロード
         try:
-            data = pd.read_csv(f"data_cache/{symbol}.csv")
-            data = data.tail(max_days)
+            df = load_price(symbol, cache_profile="rolling")
+            data = df.tail(max_days)
         except Exception:
             data = pd.DataFrame()
         return data

--- a/common/data_loader.py
+++ b/common/data_loader.py
@@ -50,5 +50,21 @@ def load_symbols(
     return out
 
 
-__all__ = ["load_symbols"]
+def load_price(ticker: str, cache_profile: str = "full") -> pd.DataFrame:
+    """
+    cache_profile: "full" | "rolling"
+    読み出しは CacheManager 経由に統一。既存仕様で常にDataFrameを返す。
+    """
+    from config.settings import get_settings
+    from common.cache_manager import CacheManager
+
+    settings = get_settings(create_dirs=False)
+    cm = CacheManager(settings)
+    df = cm.read(ticker, cache_profile)
+    if df is None:
+        return pd.DataFrame(columns=["date", "open", "high", "low", "close", "volume"])
+    return df
+
+
+__all__ = ["load_symbols", "load_price"]
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,16 @@ data:
   download_retries: 3
   api_throttle_seconds: 1.5
 
+cache:
+  full_dir: "data_cache/full"
+  rolling_dir: "data_cache/rolling"
+  file_format: "auto"
+  rolling:
+    base_lookback_days: 200
+    buffer_days: 40
+    prune_chunk_days: 30
+    meta_file: "_meta.json"
+
 backtest:
   start_date: 2018-01-01
   end_date: 2024-12-31

--- a/tools/cache_daily_data.py
+++ b/tools/cache_daily_data.py
@@ -1,0 +1,29 @@
+"""日次の株価データをフル/ローリング両キャッシュに反映するツール."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+import pandas as pd
+
+from config.settings import get_settings
+from common.cache_manager import CacheManager
+
+logger = logging.getLogger(__name__)
+
+
+def main(fetched: Dict[str, pd.DataFrame]) -> None:
+    """EODHD等から取得した日次データをキャッシュへ書き込む."""
+    settings = get_settings(create_dirs=True)
+    cm = CacheManager(settings)
+    logger.info("[cache_daily_data] ⏳ upsert開始: items=%s", len(fetched))
+    for ticker, df in fetched.items():
+        cm.upsert_both(ticker, df)
+    cm.prune_rolling_if_needed(anchor_ticker="SPY")
+    logger.info("[cache_daily_data] ✅ 完了: items=%s", len(fetched))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main({})
+


### PR DESCRIPTION
## Summary
- introduce cache config with full and rolling directories and pruning settings
- add CacheManager for atomic read/write and rolling window maintenance
- load rolling data for daily signals and stub daily cache updater

## Testing
- `flake8` *(fails: many style violations across repository)*
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be19ba4c388332b19f3f913f6374d8