### PR TITLE
feat(strategies): implement entry rules across Systems1-7

### DIFF
--- a/tests/test_system1.py
+++ b/tests/test_system1.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system1_strategy import System1Strategy
 
 
@@ -48,3 +49,16 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_compute_entry_basic(dummy_data):
+    strategy = System1Strategy()
+    df = dummy_data["DUMMY"].copy()
+    df["ATR20"] = 2.0
+    entry_date = df.index[1]
+    candidate = {"symbol": "DUMMY", "entry_date": entry_date}
+    res = strategy.compute_entry(df, candidate, 10_000)
+    assert res is not None
+    entry_price, stop_price = res
+    assert entry_price == pytest.approx(float(df.loc[entry_date, "Open"]))
+    assert stop_price == pytest.approx(entry_price - 10.0)

--- a/tests/test_system2.py
+++ b/tests/test_system2.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system2_strategy import System2Strategy
 
 
@@ -47,3 +48,21 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_entry_rule_short_gap():
+    strategy = System2Strategy()
+    dates = pd.date_range("2024-01-01", periods=2, freq="B")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 105],
+            "High": [101, 106],
+            "Low": [99, 104],
+            "Close": [100, 104],
+            "ATR10": [1, 1],
+        },
+        index=dates,
+    )
+    candidate = {"symbol": "DUMMY", "entry_date": dates[1]}
+    entry = strategy.compute_entry(df, candidate, current_capital=10_000)
+    assert entry == (105.0, 108.0)

--- a/tests/test_system3.py
+++ b/tests/test_system3.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system3_strategy import System3Strategy
 
 
@@ -45,3 +46,21 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_entry_rule_limit_buy():
+    strategy = System3Strategy()
+    dates = pd.date_range("2024-01-01", periods=2, freq="B")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100],
+            "High": [101, 101],
+            "Low": [99, 99],
+            "Close": [100, 100],
+            "ATR10": [1, 1],
+        },
+        index=dates,
+    )
+    candidate = {"symbol": "DUMMY", "entry_date": dates[1]}
+    entry = strategy.compute_entry(df, candidate, current_capital=10_000)
+    assert entry == (93.0, pytest.approx(90.5))

--- a/tests/test_system4.py
+++ b/tests/test_system4.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system4_strategy import System4Strategy
 
 
@@ -45,3 +46,21 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_entry_rule_market_open():
+    strategy = System4Strategy()
+    dates = pd.date_range("2024-01-01", periods=2, freq="B")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100],
+            "High": [101, 101],
+            "Low": [99, 99],
+            "Close": [100, 100],
+            "ATR40": [1, 1],
+        },
+        index=dates,
+    )
+    candidate = {"symbol": "DUMMY", "entry_date": dates[1]}
+    entry = strategy.compute_entry(df, candidate, current_capital=10_000)
+    assert entry == (100.0, pytest.approx(98.5))

--- a/tests/test_system5.py
+++ b/tests/test_system5.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system5_strategy import System5Strategy
 
 
@@ -45,3 +46,21 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_entry_rule_limit_buy():
+    strategy = System5Strategy()
+    dates = pd.date_range("2024-01-01", periods=2, freq="B")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100],
+            "High": [101, 101],
+            "Low": [99, 99],
+            "Close": [100, 100],
+            "ATR10": [1, 1],
+        },
+        index=dates,
+    )
+    candidate = {"symbol": "DUMMY", "entry_date": dates[1]}
+    entry = strategy.compute_entry(df, candidate, current_capital=10_000)
+    assert entry == (97.0, pytest.approx(94.0))

--- a/tests/test_system6.py
+++ b/tests/test_system6.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system6_strategy import System6Strategy
 
 
@@ -45,3 +46,21 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_entry_rule_limit_short():
+    strategy = System6Strategy()
+    dates = pd.date_range("2024-01-01", periods=2, freq="B")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100],
+            "High": [101, 101],
+            "Low": [99, 99],
+            "Close": [100, 100],
+            "ATR10": [1, 1],
+        },
+        index=dates,
+    )
+    candidate = {"symbol": "DUMMY", "entry_date": dates[1]}
+    entry = strategy.compute_entry(df, candidate, current_capital=10_000)
+    assert entry == (105.0, 108.0)

--- a/tests/test_system7.py
+++ b/tests/test_system7.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from strategies.system7_strategy import System7Strategy
 
 
@@ -46,3 +47,21 @@ def test_placeholder_run(dummy_data):
     trades = strategy.run_backtest(prepared, candidates, capital=10_000)
     assert not trades.empty
     assert "pnl" in trades.columns
+
+
+def test_entry_rule_market_short():
+    strategy = System7Strategy()
+    dates = pd.date_range("2024-01-01", periods=2, freq="B")
+    df = pd.DataFrame(
+        {
+            "Open": [100, 100],
+            "High": [101, 101],
+            "Low": [99, 99],
+            "Close": [100, 100],
+            "ATR50": [1, 1],
+        },
+        index=dates,
+    )
+    candidate = {"symbol": "SPY", "entry_date": dates[1]}
+    entry = strategy.compute_entry(df, candidate, current_capital=10_000)
+    assert entry == (100.0, 103.0)


### PR DESCRIPTION
## Summary
- implement System7 `compute_entry` leveraging ATR50-based stop
- add unit tests verifying entry pricing for Systems2-7

## Testing
- `flake8 strategies/system7_strategy.py tests/test_system2.py tests/test_system3.py tests/test_system4.py tests/test_system5.py tests/test_system6.py tests/test_system7.py`
- `pre-commit run --files strategies/system7_strategy.py tests/test_system2.py tests/test_system3.py tests/test_system4.py tests/test_system5.py tests/test_system6.py tests/test_system7.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_system2.py tests/test_system3.py tests/test_system4.py tests/test_system5.py tests/test_system6.py tests/test_system7.py tests/test_headless_app.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed60b060883328ae20a99038ae430