### PR TITLE
feat: automate daily trailing stop updates via Alpaca

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -88,6 +88,9 @@ scheduler:
     - name: send_signals
       cron: "30 8 * * 1-5"   # 平日 08:30
       task: notify_signals
+    - name: update_trailing_stops
+      cron: "45 8 * * 1-5"
+      task: update_trailing_stops
 
 ui:
   default_capital: 100000

--- a/schedulers/runner.py
+++ b/schedulers/runner.py
@@ -1,7 +1,6 @@
 """Simple scheduler runner using YAML scheduler config.
 
-Supports a minimal subset of cron: "m h * * d" where d is 0-6 (Mon=1 .. Sun=0/7 accepted).
-Runs a polling loop and triggers tasks when minute/hour/dow match.
+Supports a minimal subset of cron: "m h * * d".
 """
 
 from __future__ import annotations
@@ -104,6 +103,15 @@ def task_update_tickers():
         logging.exception("update_tickers タスクが失敗しました")
 
 
+def task_update_trailing_stops():
+    try:
+        from scripts.update_trailing_stops import update_trailing_stops
+
+        update_trailing_stops()
+    except Exception:
+        logging.exception("update_trailing_stops タスクが失敗しました")
+
+
 TASKS: Dict[str, Callable[[], None]] = {
     "cache_daily_data": task_cache_daily_data,
     "warm_cache": task_cache_daily_data,
@@ -111,13 +119,14 @@ TASKS: Dict[str, Callable[[], None]] = {
     "run_today_signals": task_run_today_signals,
     "bulk_last_day": task_bulk_last_day,
     "update_tickers": task_update_tickers,
+    "update_trailing_stops": task_update_trailing_stops,
 }
 
 
 def main():
     settings = get_settings(create_dirs=True)
     setup_logging(settings)
-    tz_name = settings.scheduler.timezone
+    _ = settings.scheduler.timezone
     jobs = settings.scheduler.jobs
     if not jobs:
         logging.warning("scheduler.jobs が空です。config/config.yaml を確認してください。")
@@ -161,4 +170,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/scripts/update_trailing_stops.py
+++ b/scripts/update_trailing_stops.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Alpacaのポジションに対しトレーリングストップを設定/更新するスクリプト."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import yaml
+
+from common import broker_alpaca as ba
+
+
+def update_trailing_stops(
+    *,
+    trail_percent: float | None = 25.0,
+    symbol_trail_pct: Mapping[str, float] | None = None,
+    paper: bool = True,
+) -> None:
+    """ポジションごとにトレーリングストップ注文を発行する.
+
+    ``symbol_trail_pct`` が与えられた場合はシンボルごとの割合を優先し、
+    指定がないシンボルには ``trail_percent`` を適用する。
+    いずれの値も指定されない場合は何もしない。
+    """
+
+    client = ba.get_client(paper=paper)
+    ba.cancel_all_orders(client)
+    positions: Iterable[object] = client.get_all_positions()
+    for pos in positions:
+        symbol = getattr(pos, "symbol")
+        pct = None
+        if symbol_trail_pct and symbol in symbol_trail_pct:
+            pct = symbol_trail_pct[symbol]
+        elif trail_percent is not None:
+            pct = trail_percent
+        if pct is None:
+            continue
+
+        qty = abs(int(float(getattr(pos, "qty", 0))))
+        if qty <= 0:
+            continue
+        side = "sell" if getattr(pos, "side", "long") == "long" else "buy"
+        ba.submit_order(
+            client,
+            symbol,
+            qty,
+            side=side,
+            order_type="trailing_stop",
+            trail_percent=pct,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Alpacaのストップ注文を更新")
+    parser.add_argument(
+        "--trail-percent",
+        type=float,
+        default=25.0,
+        help="全シンボルに一律で適用するトレーリングストップ割合(%)",
+    )
+    parser.add_argument(
+        "--mapping",
+        type=Path,
+        help="シンボルごとのトレーリングストップ割合を定義した JSON/YAML ファイル",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="ライブ口座を利用 (デフォルトはPaper)",
+    )
+    args = parser.parse_args()
+
+    mapping: Mapping[str, float] | None = None
+    if args.mapping:
+        with open(args.mapping, "r", encoding="utf-8") as f:
+            if args.mapping.suffix.lower() in {".yaml", ".yml"}:
+                mapping = yaml.safe_load(f) or {}
+            else:
+                mapping = json.load(f)
+
+    update_trailing_stops(
+        trail_percent=args.trail_percent,
+        symbol_trail_pct=mapping,
+        paper=(not args.live),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_update_trailing_stops.py
+++ b/tests/test_update_trailing_stops.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+from scripts.update_trailing_stops import update_trailing_stops
+
+
+def test_update_trailing_stops(monkeypatch):
+    submitted = []
+
+    class DummyClient:
+        def get_all_positions(self):
+            return [
+                SimpleNamespace(symbol="AAPL", qty="5", side="long"),
+                SimpleNamespace(symbol="TSLA", qty="3", side="short"),
+            ]
+
+    def fake_get_client(*, paper=True):
+        return DummyClient()
+
+    def fake_cancel_all_orders(client):
+        return None
+
+    def fake_submit_order(client, symbol, qty, *, side, order_type, trail_percent, **_):
+        submitted.append((symbol, qty, side, order_type, trail_percent))
+
+    monkeypatch.setattr(
+        "scripts.update_trailing_stops.ba.get_client", fake_get_client
+    )
+    monkeypatch.setattr(
+        "scripts.update_trailing_stops.ba.cancel_all_orders", fake_cancel_all_orders
+    )
+    monkeypatch.setattr(
+        "scripts.update_trailing_stops.ba.submit_order", fake_submit_order
+    )
+
+    mapping = {"AAPL": 25.0, "TSLA": 20.0}
+    update_trailing_stops(symbol_trail_pct=mapping)
+
+    assert submitted == [
+        ("AAPL", 5, "sell", "trailing_stop", 25.0),
+        ("TSLA", 3, "buy", "trailing_stop", 20.0),
+    ]


### PR DESCRIPTION
## Summary
- add script to submit trailing stop orders for all Alpaca positions
- schedule daily task to refresh stop orders
- support per-symbol trailing stop percentages and default to 25%
- cover trailing stop updater with unit test

## Testing
- `flake8 scripts/update_trailing_stops.py tests/test_update_trailing_stops.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py tests/test_update_trailing_stops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed89acbac833294a6e5c07e42ad19