### PR TITLE
refactor: separate filter and setup evaluation in core systems

### DIFF
--- a/core/system7.py
+++ b/core/system7.py
@@ -4,23 +4,24 @@ System7 は SPY 専用のため、prepare_data/generate_candidates のみ共通�
 run_backtest は strategy 側にカスタム実装が残る。
 """
 
-from typing import Dict, Tuple
 import pandas as pd
 from ta.volatility import AverageTrueRange
 
 
 def prepare_data_vectorized_system7(
-    raw_data_dict: Dict[str, pd.DataFrame],
+    raw_data_dict: dict[str, pd.DataFrame],
     *,
     progress_callback=None,
     log_callback=None,
     skip_callback=None,
-) -> Dict[str, pd.DataFrame]:
-    prepared_dict: Dict[str, pd.DataFrame] = {}
+) -> dict[str, pd.DataFrame]:
+    prepared_dict: dict[str, pd.DataFrame] = {}
     try:
         df = raw_data_dict.get("SPY").copy()
-        df["ATR50"] = AverageTrueRange(df["High"], df["Low"], df["Close"], window=50).average_true_range()
-        df["min_50"] = df["Close"].rolling(window=50).min().round(4)
+        df["ATR50"] = AverageTrueRange(
+            df["High"], df["Low"], df["Close"], window=50
+        ).average_true_range()
+        df["min_50"] = df["Low"].rolling(window=50).min().round(4)
         df["setup"] = (df["Low"] <= df["min_50"]).astype(int)
         df["max_70"] = df["Close"].rolling(window=70).max()
         prepared_dict["SPY"] = df
@@ -44,12 +45,12 @@ def prepare_data_vectorized_system7(
 
 
 def generate_candidates_system7(
-    prepared_dict: Dict[str, pd.DataFrame],
+    prepared_dict: dict[str, pd.DataFrame],
     *,
     progress_callback=None,
     log_callback=None,
-) -> Tuple[dict, pd.DataFrame | None]:
-    candidates_by_date: Dict[pd.Timestamp, list] = {}
+) -> tuple[dict, pd.DataFrame | None]:
+    candidates_by_date: dict[pd.Timestamp, list] = {}
     if "SPY" not in prepared_dict:
         return {}, None
     df = prepared_dict["SPY"]
@@ -74,7 +75,7 @@ def generate_candidates_system7(
     return candidates_by_date, None
 
 
-def get_total_days_system7(data_dict: Dict[str, pd.DataFrame]) -> int:
+def get_total_days_system7(data_dict: dict[str, pd.DataFrame]) -> int:
     all_dates = set()
     for df in data_dict.values():
         if df is None or df.empty:

--- a/docs/required_indicators.md
+++ b/docs/required_indicators.md
@@ -18,6 +18,7 @@
 14. **Return6D**：6日リターン（Return6D ランキング・バッテスト）
 15. **return_pct**：総リターン
 16. **Drop3D**：3日ドロップ
+17. **HV50**：50日ヒストリカルボラティリティ（年率換算）
 
 ## 指標と使用システム対応表
 
@@ -39,6 +40,7 @@
 | Return6D | System6 | 列として実装済 (`Return6D`) |
 | return_pct | System1, System2, System3, System4, System5, System6, System7 | 列として実装済 (`return_pct`) |
 | Drop3D | System3 | 列として実装済 (`DropRate_3D`) |
+| HV50 | System4 | 列として実装済 (`HV50`) |
 
 ## 補足
 
@@ -47,3 +49,65 @@
 - ADX は「7日」「7日ADX が高い順」「55 以上」などの条件で利用される。
 - RETURN は「6日」「6日D」「総リターン」「return_pct」などの指標を含む。
 - Drop3D は「3日ドロップ」として使用される。
+
+## システム別フィルター
+
+### System1
+- `avg_dollar_volume_20 > 50_000_000`
+- `low >= 5`
+
+### System2
+- `low >= 5`
+- `avg_dollar_volume_20 > 25_000_000`
+- `ATR10 / close > 0.03`
+
+### System3
+- `low >= 1`
+- `avg_volume_50 >= 1_000_000`
+- `ATR10 / close >= 0.05`
+
+### System4
+- `avg_dollar_volume_50 > 100_000_000`
+- `0.10 <= HV50 <= 0.40`
+
+### System5
+- `avg_volume_50 > 500_000`
+- `avg_dollar_volume_50 > 2_500_000`
+- `ATR10 / close > 0.04`
+
+### System6
+- `low >= 5`
+- `avg_dollar_volume_50 > 10_000_000`
+
+### System7
+- フィルターなし
+
+## システム別セットアップ
+
+### System1
+- `SPY_close > SPY_SMA100`
+- `SMA25 > SMA50`
+
+### System2
+- `RSI3 > 90`
+- `close[-1] > close[-2]` かつ `close[-2] > close[-3]`
+
+### System3
+- `close > SMA150`
+- `(close[-3] - close) / close[-3] <= -0.125`
+
+### System4
+- `SPX_close > SPX_SMA200`
+- `close > SMA200`
+
+### System5
+- `close > SMA100 + ATR10`
+- `ADX7 > 55`
+- `RSI3 < 50`
+
+### System6
+- `(close / close[-6]) - 1 >= 0.20`
+- `close[-1] > close[-2]` かつ `close[-2] > close[-3]`
+
+### System7
+- `SPY_low == rolling_min(SPY_low, window=50)`

--- a/indicators_common.py
+++ b/indicators_common.py
@@ -1,14 +1,13 @@
-from ta.trend import SMAIndicator, ADXIndicator
-from ta.momentum import ROCIndicator, RSIIndicator
-from ta.volatility import AverageTrueRange
 import numpy as np
-import pandas as pd
+from ta.momentum import ROCIndicator, RSIIndicator
+from ta.trend import ADXIndicator, SMAIndicator
+from ta.volatility import AverageTrueRange
 
 
 def add_indicators(df):
     df = df.copy()
 
-    # 0終値をNaNに変換（HV20計算用）
+    # 0終値をNaNに変換（HV50計算用）
     close_nozero = df["Close"].replace(0, np.nan)
 
     # === 基本 ===
@@ -46,7 +45,7 @@ def add_indicators(df):
         if len(df) >= w * 2:
             df[f"ADX{w}"] = ADXIndicator(
                 df["High"], df["Low"], df["Close"], window=w
-            ).adx()
+            ).adx()  # noqa: E501
         else:
             df[f"ADX{w}"] = np.nan
 
@@ -55,7 +54,7 @@ def add_indicators(df):
         if len(df) >= w + 1:
             df[f"DollarVolume{w}"] = (
                 (df["Close"] * df["Volume"]).rolling(window=w).mean()
-            )
+            )  # noqa: E501
         else:
             df[f"DollarVolume{w}"] = np.nan
 
@@ -68,30 +67,30 @@ def add_indicators(df):
 
     # ATR割合
     if "ATR10" in df:
-        df[f"ATR_Ratio"] = df[f"ATR10"] / df["Close"]
-        df[f"ATR_Pct"] = df[f"ATR10"] / df["Close"]
+        df["ATR_Ratio"] = df["ATR10"] / df["Close"]
+        df["ATR_Pct"] = df["ATR10"] / df["Close"]
     else:
-        df[f"ATR_Ratio"] = np.nan
-        df[f"ATR_Pct"] = np.nan
+        df["ATR_Ratio"] = np.nan
+        df["ATR_Pct"] = np.nan
 
     # その他戦略固有
     df["Return_3D"] = df["Close"].pct_change(3) if len(df) >= 3 else np.nan
     df["6D_Return"] = df["Close"].pct_change(6) if len(df) >= 6 else np.nan
     df["UpTwoDays"] = (
         (df["Close"] > df["Close"].shift(1))
-        & (df["Close"].shift(1) > df["Close"].shift(2))
+        & (df["Close"].shift(1) > df["Close"].shift(2))  # noqa: E501
         if len(df) >= 3
         else False
     )
     df["TwoDayUp"] = df["UpTwoDays"]
-    if len(df) >= 20:
-        df["HV20"] = (
-            np.log(close_nozero / close_nozero.shift(1)).rolling(window=20).std()
+    if len(df) >= 50:
+        df["HV50"] = (
+            np.log(close_nozero / close_nozero.shift(1)).rolling(window=50).std()
             * np.sqrt(252)
             * 100
         )
     else:
-        df["HV20"] = np.nan
+        df["HV50"] = np.nan
     df["min_50"] = df["Close"].rolling(window=50).min() if len(df) >= 50 else np.nan
     df["max_70"] = df["Close"].rolling(window=70).max() if len(df) >= 70 else np.nan
 


### PR DESCRIPTION
## Summary
- enforce setup-gated ranking in Systems3-6 candidate generation
- allow System7 setup to trigger when SPY's low breaches its 50-day rolling minimum
- align volatility docs and indicators to use HV50 for System4

## Testing
- `pre-commit run --files indicators_common.py common/cache_manager.py docs/required_indicators.md tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `flake8 indicators_common.py common/cache_manager.py`
- `pytest -q` *(fails: tests/test_alpaca_dashboard.py::test_positions_to_df, tests/test_ui_contracts.py::test_trade_logs_are_in_expander_in_common_ui_components)*

------
https://chatgpt.com/codex/tasks/task_e_68be484fb3d88332971b5dee9d4b5827