### PR TITLE
Merge PR #19 and rename DropRate_3D to Drop3D

### DIFF
--- a/app_system3.py
+++ b/app_system3.py
@@ -52,7 +52,7 @@ def display_drop3d_ranking(
                 {
                     "Date": date,
                     "symbol": c.get("symbol"),
-                    "DropRate_3D": c.get("DropRate_3D"),
+                    "Drop3D": c.get("Drop3D"),
                 }
             )
         log_with_progress(
@@ -70,11 +70,11 @@ def display_drop3d_ranking(
     df["Date"] = pd.to_datetime(df["Date"])  # type: ignore[arg-type]
     start_date = pd.Timestamp.now() - pd.DateOffset(years=years)
     df = df[df["Date"] >= start_date]
-    df["DropRate_3D_Rank"] = df.groupby("Date")["DropRate_3D"].rank(
+    df["Drop3D_Rank"] = df.groupby("Date")["Drop3D"].rank(
         ascending=False,
         method="first",
     )
-    df = df.sort_values(["Date", "DropRate_3D_Rank"], ascending=[True, True])
+    df = df.sort_values(["Date", "Drop3D_Rank"], ascending=[True, True])
     df = df.groupby("Date").head(top_n)
     title = tr(
         "{display_name} 日別 3日下落率 ランキング（直近{years}年 / 上位{top_n}銘柄）",
@@ -84,9 +84,7 @@ def display_drop3d_ranking(
     )
     with st.expander(title, expanded=False):
         st.dataframe(
-            df.reset_index(drop=True)[
-                ["Date", "DropRate_3D_Rank", "symbol", "DropRate_3D"]
-            ],
+            df.reset_index(drop=True)[["Date", "Drop3D_Rank", "symbol", "Drop3D"]],
             hide_index=False,
         )
 
@@ -99,9 +97,7 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
         )
     )
     ui_base: UIManager = (
-        ui_manager.system(SYSTEM_NAME)
-        if ui_manager
-        else UIManager().system(SYSTEM_NAME)
+        ui_manager.system(SYSTEM_NAME) if ui_manager else UIManager().system(SYSTEM_NAME)
     )
     fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
     ind_phase = ui_base.phase("indicators", title=tr("インジケーター計算"))
@@ -150,9 +146,7 @@ def run_tab(ui_manager: UIManager | None = None) -> None:
         except Exception:
             _max_dd = float(getattr(summary, "max_drawdown", 0.0))
         try:
-            _dd_pct = float(
-                (df2["drawdown"] / (float(capital) + df2["cum_max"])).min() * 100
-            )
+            _dd_pct = float((df2["drawdown"] / (float(capital) + df2["cum_max"])).min() * 100)
         except Exception:
             _dd_pct = 0.0
         stats: dict[str, Any] = {

--- a/common/today_signals.py
+++ b/common/today_signals.py
@@ -45,7 +45,7 @@ def _score_from_candidate(
     key_order: List[Tuple[List[str], bool]] = [
         (["ROC200"], False),  # s1: 大きいほど良い
         (["ADX7"], False),  # s2,s5: 大きいほど良い
-        (["DropRate_3D"], False),  # s3: 大きいほど良い（下落率）
+        (["Drop3D"], False),  # s3: 大きいほど良い（下落率）
         (["RSI4"], True),  # s4: 小さいほど良い
         (["Return6D"], False),  # s6: 大きいほど良い
         (["ATR50"], False),  # s7: 参考
@@ -131,7 +131,9 @@ def get_today_signals_for_strategy(
     最新営業日の候補のみを DataFrame で返す。
 
     戻り値カラム:
-      - symbol, system, side, signal_type, entry_date, entry_price, stop_price, score_key, score
+        - symbol, system, side, signal_type,
+          entry_date, entry_price, stop_price,
+          score_key, score
     """
     from common.utils_spy import get_latest_nyse_trading_day
 
@@ -223,7 +225,6 @@ def get_today_signals_for_strategy(
                 for psym, pdf in prepared.items():
                     # try to get the score value at the same entry date
                     try:
-                        # if Date column exists
                         if "Date" in pdf.columns:
                             row = pdf[pd.to_datetime(pdf["Date"]).dt.normalize() == entry_date_norm]
                         else:
@@ -249,7 +250,7 @@ def get_today_signals_for_strategy(
                         try:
                             rank = sorted_vals.index(candidate_val) + 1
                         except ValueError:
-                            # candidate_val might not exactly match due to float precision
+                            # candidate_val might not match exactly due to float precision
                             # approximate by finding nearest
                             diffs = [abs(candidate_val - x) for x in sorted_vals]
                             rank = diffs.index(min(diffs)) + 1

--- a/common/ui_bridge.py
+++ b/common/ui_bridge.py
@@ -159,9 +159,9 @@ def prepare_backtest_data_ui(
     indicators_per_system = {
         "System1": "ROC200, Rank, setup",
         "System2": "RSI3, ADX7, ATR10, DollarVolume20, ATR_Ratio, TwoDayUp, setup",
-        "System3": "SMA150, ATR10, DropRate_3D, AvgVolume50, ATR_Ratio, setup",
+        "System3": "SMA150, ATR10, Drop3D, AvgVolume50, ATR_Ratio, setup",
         "System4": "SMA200, ATR40, HV50, RSI4, DollarVolume50, setup",
-        "System5": "SMA100, ATR10, ADX7, RSI3, AvgVolume50, DollarVolume50, ATR_Pct, setup",
+        "System5": ("SMA100, ATR10, ADX7, RSI3, AvgVolume50, " "DollarVolume50, ATR_Pct, setup"),
         "System6": "ATR10, DollarVolume50, Return6D, UpTwoDays, setup",
         "System7": "ATR50, min_50, max_70, setup",
     }

--- a/core/system3.py
+++ b/core/system3.py
@@ -34,7 +34,7 @@ def prepare_data_vectorized_system3(
             x["ATR10"] = AverageTrueRange(
                 x["High"], x["Low"], x["Close"], window=10
             ).average_true_range()
-            x["DropRate_3D"] = -(x["Close"].pct_change(3))
+            x["Drop3D"] = -(x["Close"].pct_change(3))
             x["AvgVolume50"] = x["Volume"].rolling(50).mean()
             x["ATR_Ratio"] = x["ATR10"] / x["Close"]
 
@@ -43,7 +43,7 @@ def prepare_data_vectorized_system3(
             cond_atr = x["ATR_Ratio"] >= 0.05
             x["filter"] = cond_price & cond_volume & cond_atr
             cond_close = x["Close"] > x["SMA150"]
-            cond_drop = x["DropRate_3D"] >= 0.125
+            cond_drop = x["Drop3D"] >= 0.125
             cond_setup = x["filter"] & cond_close & cond_drop
             x["setup"] = cond_setup.astype(int)
 
@@ -113,7 +113,7 @@ def generate_candidates_system3(
         setup_df = df[df["setup"] == 1].copy()
         setup_df["symbol"] = sym
         setup_df["entry_date"] = setup_df.index + pd.Timedelta(days=1)
-        setup_df = setup_df[["symbol", "entry_date", "DropRate_3D", "ATR10"]]
+        setup_df = setup_df[["symbol", "entry_date", "Drop3D", "ATR10"]]
         all_signals.append(setup_df)
         buffer.append(sym)
 
@@ -157,7 +157,7 @@ def generate_candidates_system3(
     all_df = pd.concat(all_signals)
     candidates_by_date = {}
     for date, group in all_df.groupby("entry_date"):
-        ranked = group.sort_values("DropRate_3D", ascending=False)
+        ranked = group.sort_values("Drop3D", ascending=False)
         candidates_by_date[date] = ranked.head(int(top_n)).to_dict("records")
     return candidates_by_date, None
 

--- a/docs/required_indicators.md
+++ b/docs/required_indicators.md
@@ -13,12 +13,10 @@
 9. **ATR2.5**：2.5ATR。過去10日などで使用
 10. **ATR**：過去10日、過去50日、過去40日、4%ATR など複数期間で使用
 11. **ADX7**：7日ADX
-12. **ADX7_High**：7日ADX が高い順のランキング（55 以上など）
-13. **RETURN6**：6日リターン
-14. **Return6D**：6日リターン（Return6D ランキング・バッテスト）
-15. **return_pct**：総リターン
-16. **Drop3D**：3日ドロップ
-17. **HV50**：50日ヒストリカルボラティリティ（年率換算）
+12. **Return6D（旧称 RETURN6）**：6日リターン
+13. **return_pct**：総リターン
+14. **Drop3D**：3日ドロップ
+15. **HV50**：50日ヒストリカルボラティリティ（年率換算）
 
 ## 指標と使用システム対応表
 
@@ -35,19 +33,17 @@
 | ATR2.5 | System3 | 未実装（`ATR`列の2.5倍で計算） |
 | ATR（10日・20日・40日・50日など） | System1, System2, System3, System4, System5, System6, System7 | 列として実装済 (`ATR10` 等) |
 | ADX7 | System2, System5 | 列として実装済 (`ADX7`) |
-| ADX7_High | System5 | 未実装（`ADX7`ランキングで判定） |
-| RETURN6 | System6 | 未実装（`Return6D`で代替） |
-| Return6D | System6 | 列として実装済 (`Return6D`) |
+| Return6D（旧称 RETURN6） | System6 | 列として実装済 (`Return6D`) |
 | return_pct | System1, System2, System3, System4, System5, System6, System7 | 列として実装済 (`return_pct`) |
-| Drop3D | System3 | 列として実装済 (`DropRate_3D`) |
+| Drop3D | System3 | 列として実装済 (`Drop3D`) |
 | HV50 | System4 | 列として実装済 (`HV50`) |
 
 ## 補足
 
 - ATR は「過去10日」「過去40日」「過去50日」「3ATR」「1.5ATR」「2.5ATR」「1ATR」「4%ATR」など複数パターンが存在する。
 - SMA は「25日」「50日」「100日」「150日」「200日」など複数の期間を参照する。
-- ADX は「7日」「7日ADX が高い順」「55 以上」などの条件で利用される。
-- RETURN は「6日」「6日D」「総リターン」「return_pct」などの指標を含む。
+- ADX は 7 日値を使用し、必要に応じて高い順ランキング（`ADX7_High`）や 55 以上の閾値判定を行う。
+- Return 系指標は「Return6D（旧称 RETURN6）」「return_pct」などを含む。
 - Drop3D は「3日ドロップ」として使用される。
 
 ## システム別フィルター


### PR DESCRIPTION
## Summary
- merge PR #19 into branch0906 and adopt Drop3D nomenclature across System3
- update required indicator documentation and remove duplicate ADX7_High entry

## Testing
- `flake8 --max-line-length=100 app_system3.py common/today_signals.py common/ui_bridge.py core/system3.py`
- `ALLOW_CRITICAL_CHANGES=1 pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `streamlit run app_system3.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_68bf6803bfe08332bf42cf6f35f07619