### PR TITLE
feat(dashboard): add system allocation pie charts

### DIFF
--- a/tests/test_alpaca_dashboard.py
+++ b/tests/test_alpaca_dashboard.py
@@ -1,19 +1,43 @@
 from types import SimpleNamespace
 
-from app_alpaca_dashboard import _positions_to_df
+from app_alpaca_dashboard import _group_by_system, _positions_to_df
 import pandas as pd
 
 
 def test_positions_to_df():
     positions = [
         SimpleNamespace(
-            symbol="AAPL", qty="10", avg_entry_price="100", current_price="110", unrealized_pl="100"
+            symbol="AAPL",
+            qty="10",
+            avg_entry_price="100",
+            current_price="110",
+            unrealized_pl="100",
         ),
         SimpleNamespace(
-            symbol="MSFT", qty="5", avg_entry_price="200", current_price="190", unrealized_pl="-50"
+            symbol="MSFT",
+            qty="5",
+            avg_entry_price="200",
+            current_price="190",
+            unrealized_pl="-50",
         ),
     ]
     df = _positions_to_df(positions)
     assert isinstance(df, pd.DataFrame)
-    assert list(df["symbol"]) == ["AAPL", "MSFT"]
-    assert list(df["qty"]) == ["10", "5"]
+    assert list(df["銘柄"]) == ["AAPL", "MSFT"]
+    assert list(df["数量"]) == ["10", "5"]
+
+
+def test_group_by_system():
+    df = pd.DataFrame(
+        {
+            "銘柄": ["AAPL", "MSFT", "AAPL"],
+            "数量": ["10", "5", "2"],
+            "現在値": ["110", "190", "100"],
+        }
+    )
+    mapping = {"AAPL": "system1", "MSFT": "system2"}
+    grouped = _group_by_system(df, mapping)
+    assert set(grouped) == {"system1", "system2"}
+    s1 = grouped["system1"]
+    # 10*110 + 2*100 = 1300
+    assert s1["評価額"].sum() == 1300.0


### PR DESCRIPTION
## Summary
- visualize current positions per system with pie charts
- factor out helper to aggregate positions by system
- cover system mapping logic with unit tests

## Testing
- `flake8 app_alpaca_dashboard.py tests/test_alpaca_dashboard.py`
- `pre-commit run --files app_alpaca_dashboard.py tests/test_alpaca_dashboard.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py tests/test_alpaca_dashboard.py -q --no-cov`
- `streamlit run app_alpaca_dashboard.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_68c01245e990833289ddc9c89ae25216