### PR TITLE
feat(common): auto-scale batch size for small universes

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -1,7 +1,6 @@
 # common/utils.py
 import os
 import pandas as pd
-from datetime import datetime
 
 # Windows予約語（safe_filename用）
 RESERVED_WORDS = {
@@ -82,3 +81,14 @@ def clamp01(value: float) -> float:
         return max(0.0, min(1.0, float(value)))
     except Exception:
         return 0.0
+
+
+def resolve_batch_size(total_symbols: int, configured: int) -> int:
+    """Return effective batch size.
+
+    If `total_symbols` is 500 以下, バッチサイズを総銘柄数の10% (切り捨て) とし、
+    最低でも10件になるよう調整する。それ以外は `configured` をそのまま返す。
+    """
+    if total_symbols <= 500:
+        return max(total_symbols // 10, 10)
+    return configured

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,8 @@ data:
   api_key_env: EODHD_API_KEY
   cache_dir: data_cache
   max_workers: 8
+  # バッチ処理で一度に扱う銘柄数（調整可能）
+  batch_size: 100
   request_timeout: 10
   download_retries: 3
   api_throttle_seconds: 1.5

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,6 +43,7 @@ class DataConfig:
     cache_dir: Path = Path("data_cache")
     cache_recent_dir: Path = Path("data_cache_recent")
     max_workers: int = 8
+    batch_size: int = 100
     request_timeout: int = 10
     download_retries: int = 3
     api_throttle_seconds: float = 1.5
@@ -296,6 +297,7 @@ def get_settings(create_dirs: bool = False) -> Settings:
             ),
         ),
         max_workers=_env_int("THREADS_DEFAULT", int(data_cfg.get("max_workers", 8))),
+        batch_size=_env_int("BATCH_SIZE", int(data_cfg.get("batch_size", 100))),
         request_timeout=_env_int(
             "REQUEST_TIMEOUT", int(data_cfg.get("request_timeout", 10))
         ),

--- a/core/system1.py
+++ b/core/system1.py
@@ -6,13 +6,15 @@ Provides data preparation, ROC200 ranking, and total-days helpers.
 import time
 import pandas as pd
 
+from common.utils import resolve_batch_size
+
 
 def prepare_data_vectorized_system1(
     raw_data_dict,
     progress_callback=None,
     log_callback=None,
     skip_callback=None,
-    batch_size=50,
+    batch_size: int | None = None,
     reuse_indicators=True,
     **kwargs,
 ):
@@ -22,6 +24,14 @@ def prepare_data_vectorized_system1(
     cache_dir = "data_cache/indicators_system1_cache"
     os.makedirs(cache_dir, exist_ok=True)
     total_symbols = len(raw_data_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total_symbols, batch_size)
     processed = 0
     symbol_buffer = []
     start_time = time.time()

--- a/core/system2.py
+++ b/core/system2.py
@@ -12,15 +12,25 @@ from ta.momentum import RSIIndicator
 from ta.trend import ADXIndicator
 from ta.volatility import AverageTrueRange
 
+from common.utils import resolve_batch_size
+
 
 def prepare_data_vectorized_system2(
     raw_data_dict: Dict[str, pd.DataFrame],
     *,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> Dict[str, pd.DataFrame]:
     total = len(raw_data_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     processed = 0
     start_time = time.time()
     buffer = []

--- a/core/system3.py
+++ b/core/system3.py
@@ -7,6 +7,7 @@ from ta.trend import SMAIndicator
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
+from common.utils import resolve_batch_size
 
 # Trading thresholds - Default values for business rules
 DEFAULT_ATR_RATIO_THRESHOLD = 0.05  # 5% ATR ratio threshold for filtering
@@ -17,10 +18,18 @@ def prepare_data_vectorized_system3(
     *,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> dict[str, pd.DataFrame]:
     result_dict: dict[str, pd.DataFrame] = {}
     total = len(raw_data_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
     processed, skipped = 0, 0
     buffer = []
@@ -100,10 +109,18 @@ def generate_candidates_system3(
     top_n: int = 10,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> tuple[dict, pd.DataFrame | None]:
     all_signals = []
     total = len(prepared_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     processed, skipped = 0, 0
     buffer = []
     start_time = time.time()

--- a/core/system4.py
+++ b/core/system4.py
@@ -9,6 +9,7 @@ from ta.trend import SMAIndicator
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
+from common.utils import resolve_batch_size
 
 
 def prepare_data_vectorized_system4(
@@ -16,10 +17,18 @@ def prepare_data_vectorized_system4(
     *,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> dict[str, pd.DataFrame]:
     result_dict: dict[str, pd.DataFrame] = {}
     total = len(raw_data_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
     processed, skipped = 0, 0
     buffer: list[str] = []
@@ -87,10 +96,18 @@ def generate_candidates_system4(
     top_n: int = 10,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> tuple[dict, pd.DataFrame | None]:
     candidates_by_date: dict[pd.Timestamp, list] = {}
     total = len(prepared_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
     processed, skipped = 0, 0
     buffer: list[str] = []

--- a/core/system5.py
+++ b/core/system5.py
@@ -8,6 +8,7 @@ from ta.trend import ADXIndicator, SMAIndicator
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
+from common.utils import resolve_batch_size
 
 # Trading thresholds - Default values for business rules
 DEFAULT_ATR_PCT_THRESHOLD = 0.04  # 4% ATR percentage threshold for filtering
@@ -18,10 +19,18 @@ def prepare_data_vectorized_system5(
     *,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> dict[str, pd.DataFrame]:
     result_dict: dict[str, pd.DataFrame] = {}
     total = len(raw_data_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     processed, skipped = 0, 0
     buffer: list[str] = []
     start_time = time.time()
@@ -103,10 +112,18 @@ def generate_candidates_system5(
     top_n: int = 10,
     progress_callback=None,
     log_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> tuple[dict, pd.DataFrame | None]:
     candidates_by_date: dict[pd.Timestamp, list] = {}
     total = len(prepared_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     processed, skipped = 0, 0
     buffer: list[str] = []
     start_time = time.time()

--- a/core/system6.py
+++ b/core/system6.py
@@ -6,6 +6,7 @@ import pandas as pd
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
+from common.utils import resolve_batch_size
 
 
 def prepare_data_vectorized_system6(
@@ -14,10 +15,18 @@ def prepare_data_vectorized_system6(
     progress_callback=None,
     log_callback=None,
     skip_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> dict[str, pd.DataFrame]:
     result_dict: dict[str, pd.DataFrame] = {}
     total = len(raw_data_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
     processed, skipped = 0, 0
     buffer: list[str] = []
@@ -93,10 +102,18 @@ def generate_candidates_system6(
     progress_callback=None,
     log_callback=None,
     skip_callback=None,
-    batch_size: int = 50,
+    batch_size: int | None = None,
 ) -> tuple[dict, pd.DataFrame | None]:
     candidates_by_date: dict[pd.Timestamp, list] = {}
     total = len(prepared_dict)
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 100
+        batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
     processed, skipped = 0, 0
     buffer: list[str] = []

--- a/strategies/system3_strategy.py
+++ b/strategies/system3_strategy.py
@@ -11,6 +11,7 @@ from .constants import (
 )
 from common.alpaca_order import AlpacaOrderMixin
 from common.backtest_utils import simulate_trades_with_risk
+from common.utils import resolve_batch_size
 from core.system3 import (
     prepare_data_vectorized_system3,
     generate_candidates_system3,
@@ -31,8 +32,16 @@ class System3Strategy(AlpacaOrderMixin, StrategyBase):
         progress_callback=None,
         log_callback=None,
         skip_callback=None,
-        batch_size=50,
+        batch_size: int | None = None,
     ):
+        if batch_size is None:
+            try:
+                from config.settings import get_settings
+
+                batch_size = get_settings(create_dirs=False).data.batch_size
+            except Exception:
+                batch_size = 100
+            batch_size = resolve_batch_size(len(raw_data_dict), batch_size)
         return prepare_data_vectorized_system3(
             raw_data_dict,
             progress_callback=progress_callback,
@@ -46,7 +55,7 @@ class System3Strategy(AlpacaOrderMixin, StrategyBase):
         prepared_dict,
         progress_callback=None,
         log_callback=None,
-        batch_size=50,
+        batch_size: int | None = None,
         **kwargs,
     ):
         try:
@@ -55,6 +64,14 @@ class System3Strategy(AlpacaOrderMixin, StrategyBase):
             top_n = int(get_settings(create_dirs=False).backtest.top_n_rank)
         except Exception:
             top_n = 10
+        if batch_size is None:
+            try:
+                from config.settings import get_settings
+
+                batch_size = get_settings(create_dirs=False).data.batch_size
+            except Exception:
+                batch_size = 100
+            batch_size = resolve_batch_size(len(prepared_dict), batch_size)
         return generate_candidates_system3(
             prepared_dict,
             top_n=top_n,

--- a/strategies/system6_strategy.py
+++ b/strategies/system6_strategy.py
@@ -10,6 +10,7 @@ from .constants import (
 )
 from common.alpaca_order import AlpacaOrderMixin
 from common.backtest_utils import simulate_trades_with_risk
+from common.utils import resolve_batch_size
 from core.system6 import (
     prepare_data_vectorized_system6,
     generate_candidates_system6,
@@ -29,8 +30,16 @@ class System6Strategy(AlpacaOrderMixin, StrategyBase):
         progress_callback=None,
         log_callback=None,
         skip_callback=None,
-        batch_size=50,
+        batch_size: int | None = None,
     ):
+        if batch_size is None:
+            try:
+                from config.settings import get_settings
+
+                batch_size = get_settings(create_dirs=False).data.batch_size
+            except Exception:
+                batch_size = 100
+            batch_size = resolve_batch_size(len(raw_data_dict), batch_size)
         return prepare_data_vectorized_system6(
             raw_data_dict,
             progress_callback=progress_callback,
@@ -45,7 +54,7 @@ class System6Strategy(AlpacaOrderMixin, StrategyBase):
         progress_callback=None,
         log_callback=None,
         skip_callback=None,
-        batch_size=50,
+        batch_size: int | None = None,
     ):
         try:
             from config.settings import get_settings
@@ -53,6 +62,14 @@ class System6Strategy(AlpacaOrderMixin, StrategyBase):
             top_n = int(get_settings(create_dirs=False).backtest.top_n_rank)
         except Exception:
             top_n = 10
+        if batch_size is None:
+            try:
+                from config.settings import get_settings
+
+                batch_size = get_settings(create_dirs=False).data.batch_size
+            except Exception:
+                batch_size = 100
+            batch_size = resolve_batch_size(len(prepared_dict), batch_size)
         return generate_candidates_system6(
             prepared_dict,
             top_n=top_n,


### PR DESCRIPTION
## Summary
- compute batch size dynamically for small symbol universes
- use `resolve_batch_size` across system cores and strategies

## Testing
- `flake8 common/utils.py core/system1.py core/system2.py core/system3.py core/system4.py core/system5.py core/system6.py strategies/system2_strategy.py strategies/system3_strategy.py strategies/system4_strategy.py strategies/system5_strategy.py strategies/system6_strategy.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1679d523083329f8e243855befd96