### PR TITLE
feat(common): add async prefetch loader

### DIFF
--- a/common/data_loader.py
+++ b/common/data_loader.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, Iterable, Tuple
+from queue import Queue
+from threading import Thread
 
 import pandas as pd
 
 from common.cache_manager import load_base_cache
-from common.utils import get_cached_data, safe_filename
+from common.utils import get_cached_data
 
 
-def _load_one(symbol: str, cache_dir: Path) -> Tuple[str, pd.DataFrame | None]:
+def _load_one(symbol: str, cache_dir: Path) -> tuple[str, pd.DataFrame | None]:
     # 1) 新キャッシュ（base_cache）優先
     try:
         df = load_base_cache(symbol, rebuild_if_missing=True)
@@ -31,14 +33,14 @@ def load_symbols(
     symbols: Iterable[str],
     cache_dir: Path | str = Path("data_cache"),
     max_workers: int = 8,
-) -> Dict[str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """共通データローダー。
     - base_cache を優先し、無ければ旧CSVキャッシュから読み込む
     - 存在しない/空データは除外
     戻り値: { symbol: DataFrame }
     """
     cache_dir = Path(cache_dir)
-    out: Dict[str, pd.DataFrame] = {}
+    out: dict[str, pd.DataFrame] = {}
     symbols = list(dict.fromkeys(symbols))  # 重複除去 + 順序維持
 
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
@@ -50,13 +52,55 @@ def load_symbols(
     return out
 
 
+def iter_load_symbols(
+    symbols: Iterable[str],
+    cache_dir: Path | str = Path("data_cache"),
+    max_workers: int = 8,
+    prefetch: int = 2,
+) -> Iterator[tuple[str, pd.DataFrame]]:
+    """非同期先読み付きのシンボルローダー。
+
+    背景スレッドで次の銘柄データを読み込み、CPU 計算と I/O を重複させる。
+
+    Args:
+        symbols: 読み込む銘柄リスト。
+        cache_dir: キャッシュディレクトリ。
+        max_workers: 同時読み込みワーカー数。
+        prefetch: 先読みキューの最大サイズ。
+
+    Yields:
+        (symbol, DataFrame) タプルを逐次返す。
+    """
+
+    cache_dir = Path(cache_dir)
+    symbols = list(dict.fromkeys(symbols))
+    queue: Queue[tuple[str, pd.DataFrame | None] | None] = Queue(max(prefetch, 1))
+
+    def producer() -> None:
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = [ex.submit(_load_one, s, cache_dir) for s in symbols]
+            for fut in as_completed(futures):
+                queue.put(fut.result())
+        queue.put(None)
+
+    Thread(target=producer, daemon=True).start()
+
+    while True:
+        item = queue.get()
+        if item is None:
+            break
+        sym, df = item
+        if df is not None and not df.empty:
+            yield sym, df
+
+
 def load_price(ticker: str, cache_profile: str = "full") -> pd.DataFrame:
     """
     cache_profile: "full" | "rolling"
     読み出しは CacheManager 経由に統一。既存仕様で常にDataFrameを返す。
     """
-    from config.settings import get_settings
     from common.cache_manager import CacheManager
+    from config.settings import get_settings
 
     settings = get_settings(create_dirs=False)
     cm = CacheManager(settings)
@@ -66,5 +110,4 @@ def load_price(ticker: str, cache_profile: str = "full") -> pd.DataFrame:
     return df
 
 
-__all__ = ["load_symbols", "load_price"]
-
+__all__ = ["load_symbols", "load_price", "iter_load_symbols"]

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,9 +1,42 @@
-from common.data_loader import load_symbols
+import pandas as pd
+
+from common.data_loader import iter_load_symbols, load_symbols
 
 
 def test_load_symbols_empty_when_not_cached(tmp_path, monkeypatch):
     # キャッシュディレクトリを空の一時フォルダに差し替え
     out = load_symbols(["NO_SUCH_SYMBOL"], cache_dir=tmp_path, max_workers=2)
     assert isinstance(out, dict)
-    assert len(out) in (0, )
+    assert len(out) in (0,)
 
+
+def test_iter_load_symbols_prefetch(tmp_path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Date": ["2020-01-01"],
+            "Open": [1],
+            "High": [1],
+            "Low": [1],
+            "Close": [1],
+            "Volume": [100],
+        }
+    )
+    df.to_csv(tmp_path / "AAA.csv", index=False)
+    df.to_csv(tmp_path / "BBB.csv", index=False)
+
+    monkeypatch.setattr(
+        "common.data_loader.load_base_cache",
+        lambda symbol, rebuild_if_missing=True: None,
+    )
+
+    loaded = dict(
+        iter_load_symbols(
+            ["AAA", "BBB"],
+            cache_dir=tmp_path,
+            max_workers=2,
+            prefetch=1,
+        ),
+    )
+    assert set(loaded.keys()) == {"AAA", "BBB"}
+    for df_loaded in loaded.values():
+        assert not df_loaded.empty


### PR DESCRIPTION
## Summary
- add `iter_load_symbols` to prefetch symbol data in background
- cover asynchronous loading with a dedicated unit test

## Testing
- `flake8 common/data_loader.py tests/test_data_loader.py`
- `pre-commit run --files common/data_loader.py tests/test_data_loader.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py tests/test_data_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17afd6bec8332a2e00b5dfc922eb3