### PR TITLE
feat(core): auto-tune batch size based on processing time

### DIFF
--- a/core/system3.py
+++ b/core/system3.py
@@ -7,7 +7,7 @@ from ta.trend import SMAIndicator
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
-from common.utils import resolve_batch_size
+from common.utils import BatchSizeMonitor, resolve_batch_size
 
 # Trading thresholds - Default values for business rules
 DEFAULT_ATR_RATIO_THRESHOLD = 0.05  # 5% ATR ratio threshold for filtering
@@ -31,6 +31,8 @@ def prepare_data_vectorized_system3(
             batch_size = 100
         batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
+    batch_monitor = BatchSizeMonitor(batch_size)
+    batch_start = time.time()
     processed, skipped = 0, 0
     buffer = []
 
@@ -88,8 +90,18 @@ def prepare_data_vectorized_system3(
             )
             if buffer:
                 msg += "\n" + tr("symbols: {names}", names=", ".join(buffer))
+            batch_duration = time.time() - batch_start
+            batch_size = batch_monitor.update(batch_duration)
+            batch_start = time.time()
             try:
                 log_callback(msg)
+                log_callback(
+                    tr(
+                        "⏱️ batch time: {sec:.2f}s | next batch size: {size}",
+                        sec=batch_duration,
+                        size=batch_size,
+                    )
+                )
             except Exception:
                 pass
             buffer.clear()

--- a/core/system4.py
+++ b/core/system4.py
@@ -9,7 +9,7 @@ from ta.trend import SMAIndicator
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
-from common.utils import resolve_batch_size
+from common.utils import BatchSizeMonitor, resolve_batch_size
 
 
 def prepare_data_vectorized_system4(
@@ -30,6 +30,8 @@ def prepare_data_vectorized_system4(
             batch_size = 100
         batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
+    batch_monitor = BatchSizeMonitor(batch_size)
+    batch_start = time.time()
     processed, skipped = 0, 0
     buffer: list[str] = []
 
@@ -75,8 +77,18 @@ def prepare_data_vectorized_system4(
             )
             if buffer:
                 msg += "\n" + tr("symbols: {names}", names=", ".join(buffer))
+            batch_duration = time.time() - batch_start
+            batch_size = batch_monitor.update(batch_duration)
+            batch_start = time.time()
             try:
                 log_callback(msg)
+                log_callback(
+                    tr(
+                        "⏱️ batch time: {sec:.2f}s | next batch size: {size}",
+                        sec=batch_duration,
+                        size=batch_size,
+                    )
+                )
             except Exception:
                 pass
             buffer.clear()

--- a/core/system6.py
+++ b/core/system6.py
@@ -6,7 +6,7 @@ import pandas as pd
 from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
-from common.utils import resolve_batch_size
+from common.utils import BatchSizeMonitor, resolve_batch_size
 
 
 def prepare_data_vectorized_system6(
@@ -28,6 +28,8 @@ def prepare_data_vectorized_system6(
             batch_size = 100
         batch_size = resolve_batch_size(total, batch_size)
     start_time = time.time()
+    batch_monitor = BatchSizeMonitor(batch_size)
+    batch_start = time.time()
     processed, skipped = 0, 0
     buffer: list[str] = []
 
@@ -76,8 +78,18 @@ def prepare_data_vectorized_system6(
             )
             if buffer:
                 msg += "\n" + tr("symbols: {names}", names=", ".join(buffer))
+            batch_duration = time.time() - batch_start
+            batch_size = batch_monitor.update(batch_duration)
+            batch_start = time.time()
             try:
                 log_callback(msg)
+                log_callback(
+                    tr(
+                        "⏱️ batch time: {sec:.2f}s | next batch size: {size}",
+                        sec=batch_duration,
+                        size=batch_size,
+                    )
+                )
             except Exception:
                 pass
             buffer.clear()

--- a/core/system7.py
+++ b/core/system7.py
@@ -4,8 +4,11 @@ System7 は SPY 専用のため、prepare_data/generate_candidates のみ共通�
 run_backtest は strategy 側にカスタム実装が残る。
 """
 
+import time
 import pandas as pd
 from ta.volatility import AverageTrueRange
+
+from common.utils import BatchSizeMonitor, resolve_batch_size
 
 
 def prepare_data_vectorized_system7(
@@ -14,38 +17,64 @@ def prepare_data_vectorized_system7(
     progress_callback=None,
     log_callback=None,
     skip_callback=None,
+    batch_size: int | None = None,
 ) -> dict[str, pd.DataFrame]:
     prepared_dict: dict[str, pd.DataFrame] = {}
-    try:
-        df = raw_data_dict.get("SPY").copy()
-        df["ATR50"] = AverageTrueRange(
-            df["High"], df["Low"], df["Close"], window=50
-        ).average_true_range()
-        df["min_50"] = df["Low"].rolling(window=50).min().round(4)
-        df["setup"] = (df["Low"] <= df["min_50"]).astype(int)
-        
-        # Check if max_70 already exists (from cached data with indicators)
-        # Only calculate if not present to avoid redundant computation
-        if "max_70" not in df.columns:
-            df["max_70"] = df["Close"].rolling(window=70).max()
-        
-        prepared_dict["SPY"] = df
-    except Exception as e:
-        if skip_callback:
+    total = len(raw_data_dict) or 1
+    if batch_size is None:
+        try:
+            from config.settings import get_settings
+
+            batch_size = get_settings(create_dirs=False).data.batch_size
+        except Exception:
+            batch_size = 1
+        batch_size = resolve_batch_size(total, batch_size)
+    batch_monitor = BatchSizeMonitor(batch_size)
+    batch_start = time.time()
+    processed = 0
+
+    for sym, df in raw_data_dict.items():
+        if sym != "SPY":
+            continue
+        try:
+            df = df.copy()
+            df["ATR50"] = AverageTrueRange(
+                df["High"], df["Low"], df["Close"], window=50
+            ).average_true_range()
+            df["min_50"] = df["Low"].rolling(window=50).min().round(4)
+            df["setup"] = (df["Low"] <= df["min_50"]).astype(int)
+
+            if "max_70" not in df.columns:
+                df["max_70"] = df["Close"].rolling(window=70).max()
+
+            prepared_dict["SPY"] = df
+        except Exception as e:
+            if skip_callback:
+                try:
+                    skip_callback(f"SPY の処理をスキップしました: {e}")
+                except Exception:
+                    pass
+        processed += 1
+
+        if progress_callback:
             try:
-                skip_callback(f"SPY の処理をスキップしました: {e}")
+                progress_callback(processed, total)
             except Exception:
                 pass
-    if log_callback:
-        try:
-            log_callback("SPY インジケーター計算完了(ATR50, min_50, max_70, setup)")
-        except Exception:
-            pass
-    if progress_callback:
-        try:
-            progress_callback(1, 1)
-        except Exception:
-            pass
+        if (processed % batch_size == 0 or processed == total) and log_callback:
+            batch_duration = time.time() - batch_start
+            batch_size = batch_monitor.update(batch_duration)
+            batch_start = time.time()
+            try:
+                log_callback(
+                    "SPY インジケーター計算完了(ATR50, min_50, max_70, setup)"
+                )
+                log_callback(
+                    f"⏱️ バッチ時間: {batch_duration:.2f}秒 | 次バッチサイズ: {batch_size}"
+                )
+            except Exception:
+                pass
+
     return prepared_dict
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from common.utils import clamp01
+from common.utils import BatchSizeMonitor, clamp01
 
 
 @pytest.mark.parametrize(
@@ -11,3 +11,20 @@ from common.utils import clamp01
 )
 def test_clamp01(value: float | str, expected: float) -> None:
     assert clamp01(value) == expected
+
+
+def test_batch_size_monitor_adjustment() -> None:
+    monitor = BatchSizeMonitor(
+        100,
+        target_time=1.0,
+        patience=2,
+        min_batch_size=10,
+        max_batch_size=200,
+    )
+    monitor.update(2.0)
+    assert monitor.batch_size == 100
+    monitor.update(2.0)
+    assert monitor.batch_size == 50
+    monitor.update(0.1)
+    monitor.update(0.1)
+    assert monitor.batch_size == 100


### PR DESCRIPTION
## Summary
- add `BatchSizeMonitor` to track batch duration and adjust size
- integrate automatic batch size tuning into System1
- extend batch tuning to Systems2-7
- test batch size monitor behavior

## Testing
- `flake8 core/system2.py core/system3.py core/system4.py core/system5.py core/system6.py core/system7.py`
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py tests/test_system7_max70_optimization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17aef4e78833295aa462c873b15a7