### PR TITLE
feat(scripts): migrate legacy csv caches

### DIFF
--- a/scripts/cache_daily_data.py
+++ b/scripts/cache_daily_data.py
@@ -18,46 +18,42 @@ import requests
 
 
 def _migrate_root_csv_to_full() -> None:
-    """旧構成のキャッシュ(csv)を CacheManager 配下に移行する。"""
+    """レガシーな CSV キャッシュを ``CacheManager`` の構成へ移行する。
+
+    旧バージョンでは ``data_cache/`` や ``data_cache_recent/`` 直下に
+    シンボルごとの CSV を配置していた。現在は ``CacheManager`` により
+    ``data_cache/full/`` と ``data_cache/rolling/`` に整理されているため、
+    既存ファイルがあればこの関数で移動する。移行に失敗してもログを
+    出力するのみで処理を継続する。
+    """
+
     global DATA_CACHE_DIR, DATA_CACHE_RECENT_DIR
 
     try:
         full_dir = cm.full_dir
         rolling_dir = cm.rolling_dir
-    except Exception:
+    except Exception:  # pragma: no cover - セットアップ失敗時は移行不要
         return
 
-    # data_cache/*.csv -> data_cache/full/
-    if DATA_CACHE_DIR != full_dir:
-        full_dir.mkdir(parents=True, exist_ok=True)
-        for src in Path(DATA_CACHE_DIR).glob("*.csv"):
-            dest = full_dir / src.name
+    def _move_csv(src_dir: Path, dest_dir: Path) -> Path:
+        if src_dir == dest_dir:
+            return dest_dir
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        for src in src_dir.glob("*.csv"):
+            dest = dest_dir / src.name
             if dest.exists():
                 continue
             try:
                 src.rename(dest)
-            except Exception:
+            except Exception:  # pragma: no cover - Windows などで rename 失敗
                 try:
                     shutil.move(str(src), str(dest))
                 except Exception as e:  # pragma: no cover - logging only
                     logging.warning("移行失敗: %s -> %s (%s)", src, dest, e)
-        DATA_CACHE_DIR = full_dir
+        return dest_dir
 
-    # data_cache_recent/*.csv -> data_cache/rolling/
-    if DATA_CACHE_RECENT_DIR != rolling_dir:
-        rolling_dir.mkdir(parents=True, exist_ok=True)
-        for src in Path(DATA_CACHE_RECENT_DIR).glob("*.csv"):
-            dest = rolling_dir / src.name
-            if dest.exists():
-                continue
-            try:
-                src.rename(dest)
-            except Exception:
-                try:
-                    shutil.move(str(src), str(dest))
-                except Exception as e:  # pragma: no cover - logging only
-                    logging.warning("移行失敗: %s -> %s (%s)", src, dest, e)
-        DATA_CACHE_RECENT_DIR = rolling_dir
+    DATA_CACHE_DIR = _move_csv(DATA_CACHE_DIR, full_dir)
+    DATA_CACHE_RECENT_DIR = _move_csv(DATA_CACHE_RECENT_DIR, rolling_dir)
 
 
 # 親ディレクトリ（リポジトリ ルート）を import パスに追加して、


### PR DESCRIPTION
## Summary
- migrate legacy CSV caches into CacheManager-managed directories
- deduplicate cache migration logic via helper function

## Testing
- `pre-commit run --files scripts/cache_daily_data.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `flake8 scripts/cache_daily_data.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5d0073c8332936064158ce15500