### PR TITLE
fix: normalize cache date column

### DIFF
--- a/scripts/cache_daily_data.py
+++ b/scripts/cache_daily_data.py
@@ -400,12 +400,12 @@ def cache_single(
     df = get_eodhd_data(symbol)
     if df is not None and not df.empty:
         df = add_indicators(df)
-        df.to_csv(filepath)
+        df_reset = df.reset_index().rename(columns=str.lower)
+        df_reset.to_csv(filepath, index=False)
         if recentpath:
             if recent_dir is not None:
                 recent_dir.mkdir(parents=True, exist_ok=True)
-            # Date 列を欠落させないように index を列へ戻してから保存
-            df.reset_index().tail(recent_days).to_csv(recentpath, index=False)
+            df_reset.tail(recent_days).to_csv(recentpath, index=False)
         return (f"{symbol}: saved", True, True)
     else:
         return (f"{symbol}: failed to fetch", True, False)

--- a/tests/test_cache_manager_read.py
+++ b/tests/test_cache_manager_read.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from common.cache_manager import CacheManager
+
+
+class DummyRolling(SimpleNamespace):
+    base_lookback_days = 200
+    buffer_days = 40
+    prune_chunk_days = 30
+    meta_file = "_meta.json"
+
+
+def _build_cm(tmp_path):
+    cache = SimpleNamespace(
+        full_dir=tmp_path,
+        rolling_dir=tmp_path,
+        rolling=DummyRolling(),
+        file_format="csv",
+    )
+    settings = SimpleNamespace(cache=cache)
+    return CacheManager(settings)
+
+
+def test_read_handles_uppercase_date(tmp_path):
+    cm = _build_cm(tmp_path)
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2024-01-01", periods=2),
+            "Open": [1, 2],
+            "High": [1, 2],
+            "Low": [1, 2],
+            "Close": [1, 2],
+            "Volume": [100, 200],
+        }
+    )
+    df.to_csv(tmp_path / "AAA.csv", index=False)
+    out = cm.read("AAA", "full")
+    assert out is not None
+    assert list(out.columns)[:6] == ["date", "open", "high", "low", "close", "volume"]
+    assert pd.api.types.is_datetime64_any_dtype(out["date"])


### PR DESCRIPTION
## Summary
- normalize date column when writing daily cache
- handle legacy CSVs missing lowercase date in CacheManager
- add regression test for legacy Date column

## Testing
- `flake8 common/cache_manager.py scripts/cache_daily_data.py tests/test_cache_manager_read.py`
- `pre-commit run --files common/cache_manager.py scripts/cache_daily_data.py tests/test_cache_manager_read.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_cache_manager_read.py tests/test_headless_app.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2041faf64833281d91a8f9ab9d362