### PR TITLE
fix(common): handle 70-day high check failure

### DIFF
--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -55,3 +55,18 @@ def test_evaluate_positions(monkeypatch):
     assert judge["EEE"] == "5%利益→翌日大引けで手仕舞い"
     assert judge["FFF"] == "3日経過→大引けで手仕舞い"
     assert judge["GGG"] == "2日経過→大引けで手仕舞い"
+
+
+def test_evaluate_positions_load_failure(monkeypatch):
+    """Data load failure should result in judgement failure."""
+
+    def raise_load_price(symbol: str, cache_profile: str = "rolling") -> pd.DataFrame:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("common.profit_protection.load_price", raise_load_price)
+
+    positions = [DummyPos("SPY", side="short")]
+
+    df = evaluate_positions(positions)
+    judge = dict(zip(df["symbol"], df["judgement"], strict=True))
+    assert judge["SPY"] == "判定失敗"


### PR DESCRIPTION
## Summary
- guard 70-day high check to surface data load failures
- mark SPY judgement as indeterminate when price data is missing
- test profit protection failure path

## Testing
- `flake8`
- `flake8 common/profit_protection.py tests/test_profit_protection.py`
- `pre-commit run --files common/profit_protection.py tests/test_profit_protection.py tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_profit_protection.py tests/test_headless_app.py tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c211ed67108332a02a0b8da9e2ba47