### PR TITLE
fix: make positions df resilient and preserve max_70

### DIFF
--- a/app_alpaca_dashboard.py
+++ b/app_alpaca_dashboard.py
@@ -130,10 +130,13 @@ def _fetch_entry_dates(client, symbols: list[str]) -> dict[str, pd.Timestamp]:
     return out
 
 
-def _positions_to_df(positions, client) -> pd.DataFrame:
-    """Convert positions to DataFrame and append holding days and exit hints."""
+def _positions_to_df(positions, client=None) -> pd.DataFrame:
+    """Convert positions to DataFrame and append holding days and exit hints.
+
+    client が指定されない場合はエントリー日の取得をスキップする。
+    """
     symbols = [getattr(p, "symbol", "") for p in positions]
-    entry_map = _fetch_entry_dates(client, symbols)
+    entry_map = _fetch_entry_dates(client, symbols) if client else {}
 
     mapping_path = Path("data/symbol_system_map.json")
     symbol_map: dict[str, str] = {}

--- a/common/ui_components.py
+++ b/common/ui_components.py
@@ -67,17 +67,6 @@ def prepare_backtest_data(
 
 
 @overload
-def run_backtest_with_logging(
-    strategy: Any,
-    prepared_dict: dict[str, pd.DataFrame] | None,
-    candidates_by_date: Any,
-    capital: float,
-    system_name: str = "SystemX",
-    ui_manager: object | None = None,
-) -> pd.DataFrame: ...
-
-
-@overload
 def run_backtest_app(
     strategy: Any,
     system_name: str = "SystemX",
@@ -500,17 +489,6 @@ def prepare_backtest_data(
 # ------------------------------
 # Backtest execution (common wrapper)
 # ------------------------------
-@overload
-def run_backtest_with_logging(
-    strategy: Any,
-    prepared_dict: dict[str, pd.DataFrame] | None,
-    candidates_by_date: Any,
-    capital: float,
-    system_name: str = "SystemX",
-    ui_manager: object | None = None,
-) -> pd.DataFrame: ...
-
-
 def run_backtest_with_logging(
     strategy,
     prepared_dict,

--- a/core/system7.py
+++ b/core/system7.py
@@ -52,7 +52,8 @@ def prepare_data_vectorized_system7(
             ).average_true_range()
             x["min_50"] = x["Low"].rolling(50).min().round(4)
             x["setup"] = (x["Low"] <= x["min_50"]).astype(int)
-            x["max_70"] = x["Close"].rolling(70).max()
+            if "max_70" not in x.columns or not x["max_70"].notna().all():
+                x["max_70"] = x["Close"].rolling(70).max()
             return x
 
         if cached is not None and not cached.empty:


### PR DESCRIPTION
## Summary
- allow `_positions_to_df` to work without an API client
- skip recalculating `max_70` when already present
- clean up duplicate backtest wrapper definitions so expander logs are detected

## Testing
- `flake8 app_alpaca_dashboard.py core/system7.py common/ui_components.py` *(fails: unused imports and other pre-existing issues in common/ui_components.py)*
- `pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py`
- `pytest tests/test_headless_app.py tests/test_utils.py -q`
- `pytest tests/test_alpaca_dashboard.py::test_positions_to_df tests/test_system7_max70_optimization.py::test_max70_preserved_when_present tests/test_system7_max70_optimization.py::test_optimization_prevents_redundant_calculation tests/test_ui_contracts.py::test_trade_logs_are_in_expander_in_common_ui_components -q`

------
https://chatgpt.com/codex/tasks/task_e_68c21497f2888332b4c1edcc8da98c01