### PR TITLE
Fix rolling cache freshness and candidate fallback for today signals

### DIFF
--- a/core/system1.py
+++ b/core/system1.py
@@ -330,13 +330,36 @@ def prepare_data_vectorized_system1(
         df = _rename_ohlcv(df)
 
         try:
-            nan_rate = df.isnull().mean().mean() if df.size > 0 else 0
-            if nan_rate > 0.05:
-                msg = f"⚠️ {sym} cache: NaN率高 ({nan_rate:.2%})"
+            base_cols = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in df.columns]
+            if base_cols:
+                base_nan_rate = df[base_cols].isnull().mean().mean()
+            else:
+                base_nan_rate = df.isnull().mean().mean() if df.size > 0 else 0.0
+            if base_nan_rate >= 0.30:
+                msg = f"⚠️ {sym} cache: OHLCV欠損率高 ({base_nan_rate:.2%})"
                 if log_callback:
                     log_callback(msg)
                 if skip_callback:
                     skip_callback(sym, msg)
+                _on_symbol_done()
+                continue
+            if base_nan_rate > 0.10 and log_callback:
+                log_callback(f"⚠️ {sym} cache: OHLCV欠損率注意 ({base_nan_rate:.2%})")
+
+            indicator_cols = [
+                c
+                for c in df.columns
+                if c not in base_cols
+                and str(c).lower() not in {"date", "symbol"}
+                and pd.api.types.is_numeric_dtype(df[c])
+            ]
+            if indicator_cols:
+                indicator_nan_rate = df[indicator_cols].isnull().mean().mean()
+                if indicator_nan_rate > 0.45 and log_callback:
+                    log_callback(
+                        f"⚠️ {sym} cache: 指標NaN率高 ({indicator_nan_rate:.2%})"
+                    )
+
             for col in ["Open", "High", "Low", "Close", "Volume"]:
                 if col in df.columns and not pd.api.types.is_numeric_dtype(df[col]):
                     msg = f"⚠️ {sym} cache: {col}型不一致 ({df[col].dtype})"
@@ -359,6 +382,8 @@ def prepare_data_vectorized_system1(
                 log_callback(msg)
             if skip_callback:
                 skip_callback(sym, msg)
+            _on_symbol_done()
+            continue
 
         cache_path = os.path.join(cache_dir, f"{sym}.feather")
         cached: pd.DataFrame | None = None

--- a/core/system4.py
+++ b/core/system4.py
@@ -239,13 +239,37 @@ def prepare_data_vectorized_system4(
 
         # --- 健全性チェック: NaN・型不一致・異常値 ---
         try:
-            nan_rate = df.isnull().mean().mean() if df.size > 0 else 0
-            if nan_rate > 0.05:
-                msg = f"⚠️ {sym} cache: NaN率高 ({nan_rate:.2%})"
+            base_cols = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in df.columns]
+            if base_cols:
+                base_nan_rate = df[base_cols].isnull().mean().mean()
+            else:
+                base_nan_rate = df.isnull().mean().mean() if df.size > 0 else 0.0
+            if base_nan_rate >= 0.30:
+                msg = f"⚠️ {sym} cache: OHLCV欠損率高 ({base_nan_rate:.2%})"
                 if log_callback:
                     log_callback(msg)
                 if skip_callback:
                     skip_callback(sym, msg)
+                skipped += 1
+                _on_symbol_done()
+                continue
+            if base_nan_rate > 0.10 and log_callback:
+                log_callback(f"⚠️ {sym} cache: OHLCV欠損率注意 ({base_nan_rate:.2%})")
+
+            indicator_cols = [
+                c
+                for c in df.columns
+                if c not in base_cols
+                and str(c).lower() not in {"date", "symbol"}
+                and pd.api.types.is_numeric_dtype(df[c])
+            ]
+            if indicator_cols:
+                indicator_nan_rate = df[indicator_cols].isnull().mean().mean()
+                if indicator_nan_rate > 0.45 and log_callback:
+                    log_callback(
+                        f"⚠️ {sym} cache: 指標NaN率高 ({indicator_nan_rate:.2%})"
+                    )
+
             for col in ["Open", "High", "Low", "Close", "Volume"]:
                 if col in df.columns:
                     if not pd.api.types.is_numeric_dtype(df[col]):
@@ -269,6 +293,9 @@ def prepare_data_vectorized_system4(
                 log_callback(msg)
             if skip_callback:
                 skip_callback(sym, msg)
+            skipped += 1
+            _on_symbol_done()
+            continue
 
         cache_path = os.path.join(cache_dir, f"{sym}.feather")
         cached: pd.DataFrame | None = None

--- a/core/system5.py
+++ b/core/system5.py
@@ -269,13 +269,37 @@ def prepare_data_vectorized_system5(
 
         # --- 健全性チェック: NaN・型不一致・異常値 ---
         try:
-            nan_rate = df.isnull().mean().mean() if df.size > 0 else 0
-            if nan_rate > 0.05:
-                msg = f"⚠️ {sym} cache: NaN率高 ({nan_rate:.2%})"
+            base_cols = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in df.columns]
+            if base_cols:
+                base_nan_rate = df[base_cols].isnull().mean().mean()
+            else:
+                base_nan_rate = df.isnull().mean().mean() if df.size > 0 else 0.0
+            if base_nan_rate >= 0.30:
+                msg = f"⚠️ {sym} cache: OHLCV欠損率高 ({base_nan_rate:.2%})"
                 if log_callback:
                     log_callback(msg)
                 if skip_callback:
                     skip_callback(sym, msg)
+                skipped += 1
+                _on_symbol_done()
+                continue
+            if base_nan_rate > 0.10 and log_callback:
+                log_callback(f"⚠️ {sym} cache: OHLCV欠損率注意 ({base_nan_rate:.2%})")
+
+            indicator_cols = [
+                c
+                for c in df.columns
+                if c not in base_cols
+                and str(c).lower() not in {"date", "symbol"}
+                and pd.api.types.is_numeric_dtype(df[c])
+            ]
+            if indicator_cols:
+                indicator_nan_rate = df[indicator_cols].isnull().mean().mean()
+                if indicator_nan_rate > 0.45 and log_callback:
+                    log_callback(
+                        f"⚠️ {sym} cache: 指標NaN率高 ({indicator_nan_rate:.2%})"
+                    )
+
             for col in ["Open", "High", "Low", "Close", "Volume"]:
                 if col in df.columns:
                     if not pd.api.types.is_numeric_dtype(df[col]):
@@ -299,6 +323,9 @@ def prepare_data_vectorized_system5(
                 log_callback(msg)
             if skip_callback:
                 skip_callback(sym, msg)
+            skipped += 1
+            _on_symbol_done()
+            continue
 
         cache_path = os.path.join(cache_dir, f"{sym}.feather")
         cached: pd.DataFrame | None = None


### PR DESCRIPTION
## Summary
- rebuild rolling cache data from base when staleness exceeds configured tolerance and log refresh details
- update today signal candidate selection to prioritize the latest available trading day and add diagnostics for fallbacks
- relax OHLCV NaN screening in systems 1/3/4/5 to avoid discarding symbols for moderate indicator gaps while still skipping severe cases

## Testing
- flake8
- pytest -q -p no:flake8
- pre-commit run --files tests/test_headless_app.py tests/test_utils.py tests/app_smoke.py
- pytest tests/test_headless_app.py tests/test_utils.py -q -p no:flake8

------
https://chatgpt.com/codex/tasks/task_e_68cab7fad76c83329d34c5b81546a425