### PR TITLE
Adjust rolling cache window to 300-day base

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -49,8 +49,8 @@ cache:
   rolling_dir: "data_cache/rolling"
   file_format: "auto"
   rolling:
-    base_lookback_days: 200
-    buffer_days: 100
+    base_lookback_days: 300
+    buffer_days: 30
     prune_chunk_days: 30
     meta_file: "_meta.json"
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -68,8 +68,8 @@ class OutputConfig:
 
 @dataclass(frozen=True)
 class CacheRollingConfig:
-    base_lookback_days: int = 200
-    buffer_days: int = 100
+    base_lookback_days: int = 300
+    buffer_days: int = 30
     max_staleness_days: int = 2
     prune_chunk_days: int = 30
     meta_file: str = "_meta.json"
@@ -323,8 +323,8 @@ def get_settings(create_dirs: bool = False) -> Settings:
         rolling_dir=_as_path(root, cache_cfg.get("rolling_dir", "data_cache/rolling")),
         file_format=str(cache_cfg.get("file_format", "auto")),
         rolling=CacheRollingConfig(
-            base_lookback_days=int(rolling_cfg.get("base_lookback_days", 200)),
-            buffer_days=int(rolling_cfg.get("buffer_days", 40)),
+            base_lookback_days=int(rolling_cfg.get("base_lookback_days", 300)),
+            buffer_days=int(rolling_cfg.get("buffer_days", 30)),
             prune_chunk_days=int(rolling_cfg.get("prune_chunk_days", 30)),
             meta_file=str(rolling_cfg.get("meta_file", "_meta.json")),
             max_stale_days=int(rolling_cfg.get("max_stale_days", 2)),

--- a/tests/test_cache_manager_read.py
+++ b/tests/test_cache_manager_read.py
@@ -7,8 +7,8 @@ from common.cache_manager import CacheManager
 
 
 class DummyRolling(SimpleNamespace):
-    base_lookback_days = 200
-    buffer_days = 100
+    base_lookback_days = 300
+    buffer_days = 30
     prune_chunk_days = 30
     meta_file = "_meta.json"
 


### PR DESCRIPTION
## Summary
- extend the rolling cache base lookback to 300 days with a 30-day buffer in the default configuration
- align the settings loader defaults and cache manager test stub with the new rolling window length

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb3a82b4888332822ad319342744d7