### PR TITLE
refactor: derive entry dates from calendar

### DIFF
--- a/core/system4.py
+++ b/core/system4.py
@@ -13,6 +13,7 @@ from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
 from common.utils import get_cached_data, resolve_batch_size, BatchSizeMonitor
+from common.utils_spy import resolve_signal_entry_date
 
 REQUIRED_COLUMNS = ("Open", "High", "Low", "Close", "Volume")
 MIN_ROWS = 200
@@ -463,16 +464,9 @@ def generate_candidates_system4(
                 if "Close" in x.columns and not x["Close"].empty:
                     last_price = x["Close"].iloc[-1]
                 # 翌営業日に補正
-                try:
-                    idx = pd.DatetimeIndex(pd.to_datetime(x.index, errors="coerce").normalize())
-                    pos = idx.searchsorted(ts, side="right")
-                    if pos >= len(idx):
-                        continue
-                    entry_date = pd.to_datetime(idx[pos]).tz_localize(None)
-                except Exception:
-                    entry_date = ts + pd.Timedelta(days=1)
-                    if entry_date not in x.index:
-                        continue
+                entry_date = resolve_signal_entry_date(ts)
+                if pd.isna(entry_date):
+                    continue
                 rec = {
                     "symbol": sym,
                     "entry_date": entry_date,

--- a/core/system5.py
+++ b/core/system5.py
@@ -11,6 +11,7 @@ from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
 from common.utils import get_cached_data, resolve_batch_size, BatchSizeMonitor
+from common.utils_spy import resolve_signal_entry_date
 
 # Trading thresholds - Default values for business rules
 DEFAULT_ATR_PCT_THRESHOLD = 0.04  # 4% ATR percentage threshold for filtering
@@ -497,16 +498,9 @@ def generate_candidates_system5(
                 if "Close" in df.columns and not df["Close"].empty:
                     last_price = df["Close"].iloc[-1]
                 # 翌営業日に補正
-                try:
-                    idx = pd.DatetimeIndex(pd.to_datetime(df.index, errors="coerce").normalize())
-                    pos = idx.searchsorted(ts, side="right")
-                    if pos >= len(idx):
-                        continue
-                    entry_date = pd.to_datetime(idx[pos]).tz_localize(None)
-                except Exception:
-                    entry_date = ts + pd.Timedelta(days=1)
-                    if entry_date not in df.index:
-                        continue
+                entry_date = resolve_signal_entry_date(ts)
+                if pd.isna(entry_date):
+                    continue
                 rec = {
                     "symbol": sym,
                     "entry_date": entry_date,

--- a/core/system6.py
+++ b/core/system6.py
@@ -9,7 +9,7 @@ from ta.volatility import AverageTrueRange
 
 from common.i18n import tr
 from common.utils import get_cached_data, resolve_batch_size, BatchSizeMonitor
-from common.utils_spy import get_next_nyse_trading_day
+from common.utils_spy import resolve_signal_entry_date
 
 
 SYSTEM6_BASE_COLUMNS = ["Open", "High", "Low", "Close", "Volume"]
@@ -419,19 +419,9 @@ def generate_candidates_system6(
             for date, row in setup_days.iterrows():
                 ts = pd.to_datetime(pd.Index([date]))[0]
                 # 翌営業日に補正
-                try:
-                    idx = pd.DatetimeIndex(pd.to_datetime(df.index, errors="coerce").normalize())
-                    pos = idx.searchsorted(ts, side="right")
-                    entry_val = idx[pos] if pos < len(idx) else None
-                    if entry_val is not None:
-                        entry_date = pd.to_datetime(entry_val).tz_localize(None)
-                    else:
-                        entry_date = get_next_nyse_trading_day(pd.Timestamp(ts))
-                except Exception:
-                    try:
-                        entry_date = get_next_nyse_trading_day(pd.Timestamp(ts))
-                    except Exception:
-                        continue
+                entry_date = resolve_signal_entry_date(ts)
+                if pd.isna(entry_date):
+                    continue
                 rec = {
                     "symbol": sym,
                     "entry_date": entry_date,

--- a/core/system7.py
+++ b/core/system7.py
@@ -5,10 +5,11 @@ run_backtest は strategy 側にカスタム実装が残る。
 """
 
 import os
-from typing import cast
 
 import pandas as pd
 from ta.volatility import AverageTrueRange
+
+from common.utils_spy import resolve_signal_entry_date
 
 
 def prepare_data_vectorized_system7(
@@ -133,10 +134,9 @@ def generate_candidates_system7(
     df = prepared_dict["SPY"]
     setup_days = df[df["setup"] == 1]
     for date, row in setup_days.iterrows():
-        entry_idx = cast(int, df.index.get_loc(date))
-        if entry_idx + 1 >= len(df):
+        entry_date = resolve_signal_entry_date(date)
+        if pd.isna(entry_date):
             continue
-        entry_date = df.index[entry_idx + 1]
         # last_price（直近終値）を取得
         last_price = None
         if "Close" in df.columns and not df["Close"].empty:


### PR DESCRIPTION
## Summary
- add a resolve_signal_entry_date helper that converts signal days to the next NYSE session without needing cached bars
- update Systems 1–7 candidate builders to call the helper so TRDlist entries are populated even when only the latest business day is cached
- drop the redundant next-day index searches and keep normalized tz-naive entry timestamps for downstream consumers

## Testing
- pytest --override-ini=addopts=
- flake8 --ignore=E501,F821,W503 common/utils_spy.py core/system1.py core/system2.py core/system3.py core/system4.py core/system5.py core/system6.py core/system7.py

------
https://chatgpt.com/codex/tasks/task_e_68cb41bf38f88332bae1f7f3828975d1