### PR TITLE
Add fallback to legacy today signal pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - シグナル通知に推奨銘柄の日足チャート画像を添付
 - `run_all_systems_today.py` の文字列連結を改善
 - Today Signals に保有ポジションと利益保護判定を追加
+- Today Signals の軽量化ロジックに prepare_data/generate_candidates のフォールバックを追加し既存処理を保持


### PR DESCRIPTION
## Summary
- add a guard that detects when the lightweight today signal path lacks the required data and fall back to strategy.prepare_data
- reuse generate_candidates as a secondary fallback when prepare_data was used but no candidates were produced while keeping the optimized path as default
- document the fallback behaviour in the changelog

## Testing
- python -m flake8 common/today_signals.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb41621d48833293b82cfbeb550a84