### PR TITLE
Optimize allocation and reuse Alpaca position data

### DIFF
--- a/scripts/run_all_systems_today.py
+++ b/scripts/run_all_systems_today.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 import json
@@ -962,20 +962,22 @@ def _subset_data(basic_data: dict[str, pd.DataFrame], keys: list[str]) -> dict[s
     return out
 
 
-def _load_active_positions_by_system() -> dict[str, int]:
-    """Return current active position counts grouped by system name.
+@dataclass(frozen=True)
+class _StrategyAllocationMeta:
+    calc_fn: Callable[..., Any] | None
+    risk_pct: float
+    max_pct: float
+    max_positions: int
 
-    Alpaca の保有ポジションと `data/symbol_system_map.json` を突き合わせ、
-    system1〜7 のどの戦略で保有しているかを推定する。
-    失敗した場合は空 dict を返す。
-    """
 
-    counts: dict[str, int] = {}
+def _fetch_positions_and_symbol_map() -> tuple[list[Any], dict[str, str]]:
+    """Fetch Alpaca positions and cached symbol-to-system mapping once."""
+
     try:
         client = ba.get_client(paper=True)
         positions = list(client.get_all_positions())
     except Exception:
-        return counts
+        positions = []
 
     try:
         mapping_path = Path("data/symbol_system_map.json")
@@ -984,6 +986,30 @@ def _load_active_positions_by_system() -> dict[str, int]:
         else:
             symbol_system_map = {}
     except Exception:
+        symbol_system_map = {}
+
+    return positions, symbol_system_map
+
+
+def _load_active_positions_by_system(
+    positions: Sequence[object] | None = None,
+    symbol_system_map: Mapping[str, str] | None = None,
+) -> dict[str, int]:
+    """Return current active position counts grouped by system name.
+
+    Alpaca の保有ポジションと `data/symbol_system_map.json` を突き合わせ、
+    system1〜7 のどの戦略で保有しているかを推定する。
+    失敗した場合は空 dict を返す。
+    """
+
+    counts: dict[str, int] = {}
+
+    if positions is None or symbol_system_map is None:
+        positions, symbol_system_map = _fetch_positions_and_symbol_map()
+
+    if positions is None:
+        positions = []
+    if symbol_system_map is None:
         symbol_system_map = {}
 
     for pos in positions:
@@ -1000,7 +1026,10 @@ def _load_active_positions_by_system() -> dict[str, int]:
         if qty <= 0:
             continue
         side = str(getattr(pos, "side", "")).lower()
-        system_name = str(symbol_system_map.get(sym, "")).lower()
+        mapped = symbol_system_map.get(sym)
+        if mapped is None and sym.lower() in symbol_system_map:
+            mapped = symbol_system_map.get(sym.lower())
+        system_name = str(mapped or "").lower()
         if not system_name:
             if sym == "SPY" and side == "short":
                 system_name = "system7"
@@ -1021,114 +1050,136 @@ def _amount_pick(
     """資金配分に基づいて候補を採用。
     shares と position_value を付与して返す。
     """
-    chosen = []
-    chosen_symbols = set()
+    chosen: list[dict[str, Any]] = []
+    chosen_symbols: set[str] = set()
 
     active_positions = active_positions or {}
 
     # システムごとの割当予算
     budgets = {
         name: float(total_budget) * float(weights.get(name, 0.0)) for name in weights
-    }  # noqa: E501
+    }
     remaining = budgets.copy()
 
     # システム名の順序を固定（system1..system7）
     sys_order = [f"system{i}" for i in range(1, 8)]
     ordered_names = [n for n in sys_order if n in weights]
-    # 各システムの最大ポジション上限（設定 max_positions、既定10）と採用カウンタ
-    max_pos_by_system: dict[str, int] = {}
-    for _n in ordered_names:
+
+    strategy_meta: dict[str, _StrategyAllocationMeta] = {}
+    candidates_by_system: dict[str, list[dict[str, Any]]] = {}
+    candidate_index: dict[str, int] = {}
+
+    for name in ordered_names:
+        stg = strategies.get(name)
+        config = getattr(stg, "config", {}) if stg is not None else {}
+        calc_fn = getattr(stg, "calculate_position_size", None)
+        if not callable(calc_fn):
+            calc_fn = None
         try:
-            _stg = strategies.get(_n)
-            _lim = int(getattr(_stg, "config", {}).get("max_positions", 10))
+            risk_pct = float(config.get("risk_pct", 0.02))
         except Exception:
-            _lim = 10
-        taken = int(active_positions.get(_n, 0))
-        max_pos_by_system[_n] = max(0, _lim - taken)
+            risk_pct = 0.02
+        try:
+            max_pct = float(config.get("max_pct", 0.10))
+        except Exception:
+            max_pct = 0.10
+        try:
+            max_positions = int(config.get("max_positions", 10))
+        except Exception:
+            max_positions = 10
+
+        strategy_meta[name] = _StrategyAllocationMeta(
+            calc_fn=calc_fn,
+            risk_pct=risk_pct,
+            max_pct=max_pct,
+            max_positions=max_positions,
+        )
+
+        df = per_system.get(name, pd.DataFrame())
+        if df is None or getattr(df, "empty", True):
+            candidates_by_system[name] = []
+        else:
+            candidates_by_system[name] = df.to_dict("records")
+        candidate_index[name] = 0
+
+    max_pos_by_system = {
+        name: max(0, strategy_meta[name].max_positions - int(active_positions.get(name, 0)))
+        for name in ordered_names
+    }
     count_by_system: dict[str, int] = {k: 0 for k in ordered_names}
+
+    def _normalize_shares(value: Any) -> int:
+        try:
+            return int(float(value))
+        except Exception:
+            return 0
+
     # システムごとにスコア順で採用。複数周回して1件ずつ拾う（偏りを軽減）
     still = True
     while still:
         still = False
         for name in ordered_names:
-            df = per_system.get(name, pd.DataFrame())
+            records = candidates_by_system.get(name, [])
             if (
-                df is None
-                or df.empty
+                not records
                 or remaining.get(name, 0.0) <= 0.0
                 or count_by_system.get(name, 0) >= max_pos_by_system.get(name, 0)
+                or candidate_index.get(name, 0) >= len(records)
             ):
                 continue
-            stg = strategies[name]
-            # 順に探索
-            for _, row in df.iterrows():
-                sym = row["symbol"]
-                if sym in chosen_symbols:
-                    continue
-                entry = (
-                    float(row["entry_price"])
-                    if not pd.isna(row.get("entry_price"))
-                    else None  # noqa: E501
-                )
-                stop = (
-                    float(row["stop_price"])
-                    if not pd.isna(row.get("stop_price"))
-                    else None  # noqa: E501
-                )
-                if not entry or not stop or entry <= 0:
+
+            meta = strategy_meta[name]
+            idx = candidate_index[name]
+
+            while idx < len(records):
+                row = records[idx]
+                idx += 1
+                candidate_index[name] = idx
+
+                sym = str(row.get("symbol", "")).upper()
+                if not sym or sym in chosen_symbols:
                     continue
 
-                # 望ましい枚数（全システム割当基準）
+                entry_raw = row.get("entry_price")
+                stop_raw = row.get("stop_price")
                 try:
-                    # stg may be typed as object; call via cast to avoid
-                    # static type errors. Call calculate_position_size if available.
-                    calc_fn = getattr(stg, "calculate_position_size", None)
-                    if callable(calc_fn):
-                        try:
-                            ds = calc_fn(
-                                budgets[name],
-                                entry,
-                                stop,
-                                risk_pct=float(
-                                    getattr(stg, "config", {}).get("risk_pct", 0.02)
-                                ),  # noqa: E501
-                                max_pct=float(
-                                    getattr(stg, "config", {}).get("max_pct", 0.10)
-                                ),  # noqa: E501
-                            )
-                            if ds is None:
-                                desired_shares = 0
-                            else:
-                                try:
-                                    if isinstance(ds, (int | float | str)):
-                                        try:
-                                            desired_shares = int(float(ds))
-                                        except Exception:
-                                            desired_shares = 0
-                                    else:
-                                        desired_shares = 0
-                                except Exception:
-                                    desired_shares = 0
-                        except Exception:
-                            desired_shares = 0
-                    else:
-                        desired_shares = 0
+                    entry = float(entry_raw)
                 except Exception:
-                    desired_shares = 0
+                    entry = None
+                try:
+                    stop = float(stop_raw)
+                except Exception:
+                    stop = None
+                if entry is None or stop is None or entry <= 0:
+                    continue
+
+                desired_shares = 0
+                if meta.calc_fn is not None:
+                    try:
+                        ds = meta.calc_fn(
+                            budgets[name],
+                            entry,
+                            stop,
+                            risk_pct=meta.risk_pct,
+                            max_pct=meta.max_pct,
+                        )
+                        desired_shares = _normalize_shares(ds)
+                    except Exception:
+                        desired_shares = 0
+
                 if desired_shares <= 0:
                     continue
 
-                # 予算内に収まるよう調整
-                max_by_cash = int(remaining[name] // abs(entry))
+                max_by_cash = int(remaining[name] // abs(entry)) if entry else 0
                 shares = min(desired_shares, max_by_cash)
                 if shares <= 0:
                     continue
+
                 position_value = shares * abs(entry)
                 if position_value <= 0:
                     continue
 
-                # 採用
-                rec = row.to_dict()
+                rec = dict(row)
                 rec["shares"] = int(shares)
                 rec["position_value"] = float(round(position_value, 2))
                 # 採用直前の残余を system_budget に表示（見た目が減っていく）
@@ -1139,7 +1190,7 @@ def _amount_pick(
                 remaining[name] -= position_value
                 count_by_system[name] = count_by_system.get(name, 0) + 1
                 still = True
-                break  # 1件ずつ拾って次のシステムへ
+                break
 
     if not chosen:
         return pd.DataFrame()
@@ -3576,6 +3627,9 @@ def compute_today_signals(
     except Exception:
         pass
 
+    positions_cache: list[Any] | None = None
+    symbol_system_map_cache: dict[str, str] | None = None
+
     # --- 日次メトリクス（事前フィルタ通過数・候補数）の保存 ---
     try:
         metrics_rows = []
@@ -3636,7 +3690,13 @@ def compute_today_signals(
                         pass
 
                 # Exit 件数を簡易推定（Alpaca の保有ポジションと各 Strategy の compute_exit を利用）
-                def _estimate_exit_counts_today() -> dict[str, int]:
+                if positions_cache is None or symbol_system_map_cache is None:
+                    positions_cache, symbol_system_map_cache = _fetch_positions_and_symbol_map()
+
+                def _estimate_exit_counts_today(
+                    positions0: Sequence[object],
+                    symbol_system_map0: Mapping[str, str],
+                ) -> dict[str, int]:
                     counts: dict[str, int] = {}
                     try:
                         # 価格ロード関数は共通ローダーを利用
@@ -3651,28 +3711,11 @@ def compute_today_signals(
                         except Exception:
                             latest_trading_day = None
 
-                        # Alpaca ポジション取得（失敗時は空）
-                        try:
-                            client0 = ba.get_client(paper=True)
-                            positions0 = list(client0.get_all_positions())
-                        except Exception:
-                            positions0 = []
-
                         # エントリー日のローカル記録と system 推定マップ
                         entry_map0 = load_entry_dates()
-                        sym_map_path0 = Path("data/symbol_system_map.json")
-                        try:
-                            import json as _json
+                        symbol_map_local = symbol_system_map0 or {}
 
-                            symbol_system_map0 = (
-                                _json.loads(sym_map_path0.read_text(encoding="utf-8"))
-                                if sym_map_path0.exists()
-                                else {}
-                            )
-                        except Exception:
-                            symbol_system_map0 = {}
-
-                        for pos in positions0:
+                        for pos in positions0 or []:
                             try:
                                 sym = str(getattr(pos, "symbol", "")).upper()
                                 if not sym:
@@ -3681,8 +3724,10 @@ def compute_today_signals(
                                 if qty <= 0:
                                     continue
                                 pos_side = str(getattr(pos, "side", "")).lower()
-                                # system の推定
-                                system0 = str(symbol_system_map0.get(sym, "")).lower()
+                                mapped = symbol_map_local.get(sym)
+                                if mapped is None and sym.lower() in symbol_map_local:
+                                    mapped = symbol_map_local.get(sym.lower())
+                                system0 = str(mapped or "").lower()
                                 if not system0:
                                     if sym == "SPY" and pos_side == "short":
                                         system0 = "system7"
@@ -3832,7 +3877,9 @@ def compute_today_signals(
                         return {}
                     return counts
 
-                exit_counts_map = _estimate_exit_counts_today() or {}
+                exit_counts_map = _estimate_exit_counts_today(
+                    positions_cache or [], symbol_system_map_cache or {}
+                ) or {}
                 # UI へも Exit 件数を送る（早期に可視化）
                 try:
                     cb_exit = globals().get("_PER_SYSTEM_EXIT")
@@ -3894,6 +3941,9 @@ def compute_today_signals(
     except Exception:
         _log("⚠️ メトリクス集計で例外が発生しました（処理続行）")
 
+    if positions_cache is None or symbol_system_map_cache is None:
+        positions_cache, symbol_system_map_cache = _fetch_positions_and_symbol_map()
+
     # 1) 枠配分（スロット）モード or 2) 金額配分モード
     def _normalize_alloc(d: dict[str, float], default_map: dict[str, float]) -> dict[str, float]:
         try:
@@ -3917,7 +3967,9 @@ def compute_today_signals(
     long_alloc = _normalize_alloc(settings_alloc_long, defaults_long)
     short_alloc = _normalize_alloc(settings_alloc_short, defaults_short)
 
-    active_positions_map = _load_active_positions_by_system()
+    active_positions_map = _load_active_positions_by_system(
+        positions_cache, symbol_system_map_cache
+    )
     max_positions_per_system: dict[str, int] = {}
     for name, stg in strategies.items():
         try:


### PR DESCRIPTION
## Summary
- Precompute strategy allocation metadata and iterate sequentially through candidate lists in `_amount_pick` to avoid repeatedly scanning the same DataFrames while sizing positions.
- Introduce `_fetch_positions_and_symbol_map` so Alpaca positions and symbol map data are fetched once and reused for both exit estimation and active slot counting.

## Testing
- pytest
- flake8 scripts/run_all_systems_today.py

------
https://chatgpt.com/codex/tasks/task_e_68cc142416ec8332a2423f7ccee37960