### PR TITLE
feat: switch daily data source from EODHD (paid) to Alpaca free IEX feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,15 @@
 # Copy this file to .env and fill values
 
+# ===== Market Data (Polygon.io 無料 tier — 本命 $0 full-market) =====
+# 日次 OHLCV 取得用。無料 tier で SIP 連結の full-market volume を取得可能。
+# Grouped Daily エンドポイントは 1 call/日で全 US 銘柄を返す (5 req/min 制限を回避)。
+# API キー取得先 (無料): https://polygon.io/dashboard/signup
+POLYGON_API_KEY=
+
 # ===== Market Data (Alpaca 無料 IEX feed) =====
 # 日次 OHLCV 取得用。無料 tier = IEX feed のみ (SIP は有料 $99/月)。
+# 注意: IEX feed は全市場出来高の ~2-4% しか反映せず min-ADV フィルタが壊滅するため
+#       株の日次データ本番運用には非推奨 (Polygon を優先)。発注連携用途では有効。
 # API キー取得先: https://app.alpaca.markets/
 ALPACA_API_KEY=
 ALPACA_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,19 @@
 # Copy this file to .env and fill values
+
+# ===== Market Data (Alpaca 無料 IEX feed) =====
+# 日次 OHLCV 取得用。無料 tier = IEX feed のみ (SIP は有料 $99/月)。
+# API キー取得先: https://app.alpaca.markets/
+ALPACA_API_KEY=
+ALPACA_SECRET_KEY=
+# feed override (既定 iex)。SIP に切り替える場合のみ sip を指定 (有料)。
+# ALPACA_FEED=iex
+
+# EODHD API キー (deprecated, retained for legacy scripts)。
+# データ取得は Alpaca に移行済。旧 bulk/legacy スクリプト用に残置。
 EODHD_API_KEY=
 
-# ===== Alpaca Paper Trading =====
+# ===== Alpaca Paper Trading (ブローカー連携) =====
+# 発注/ペーパートレード用。データ取得用 ALPACA_API_KEY と同じキーを流用可。
 # Get your API keys from https://alpaca.markets/
 APCA_API_KEY_ID=
 APCA_API_SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -211,16 +211,41 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-2. `.env` を用意し `EODHD_API_KEY` に加え、Alpaca 連携を行う場合は
-   `APCA_API_KEY_ID` と `APCA_API_SECRET_KEY` を設定します。
+2. `.env` を用意し、日次データ取得用に `ALPACA_API_KEY` と `ALPACA_SECRET_KEY`
+   を設定します（ブローカー連携を行う場合は `APCA_API_KEY_ID` /
+   `APCA_API_SECRET_KEY` も設定）。
 
 ### 主要な環境変数
 
-- `EODHD_API_KEY`: EOD Historical Data API キー（必須）
+- `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`: 日次 OHLCV 取得用（**必須**、無料 IEX feed）
+- `ALPACA_FEED`: データ feed（既定 `iex`。`sip` は有料）
+- `EODHD_API_KEY`: EOD Historical Data API キー（**deprecated**、legacy スクリプト用に残置）
 - `APCA_API_KEY_ID`, `APCA_API_SECRET_KEY`: Alpaca ブローカー連携用（**Paper Trading対応済み**）
 - `ALPACA_PAPER`: `true` でペーパートレード、`false` で本番取引（デフォルト: `true`）
 - `SLACK_WEBHOOK_URL` または `SLACK_BOT_TOKEN`+`SLACK_CHANNEL`: Slack 通知設定
 - `DISCORD_WEBHOOK_URL`: Discord 通知設定
+
+## データソース (Data source)
+
+日次 OHLCV は **Alpaca 無料 tier に切替済** です（旧 EODHD 有料 $20/月 → $0）。
+
+- **API キー取得先**: <https://app.alpaca.markets/>
+- **feed**: 既定は **IEX**（無料）。SIP は有料（$99/月）のため使用しません。
+- **取得関数**: `common/alpaca_data.py` の `get_alpaca_data(symbol)`。
+  旧 `get_eodhd_data(symbol)` と同一スキーマ（columns / index / dtypes）の
+  drop-in replacement です。
+- **環境変数**: `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`（未設定なら `ValueError` で fail-fast）。
+
+> ⚠️ **既知の制限（IEX feed の出来高過小）**
+> IEX feed の出来高は NASDAQ/NYSE 全体の **2〜3% しか反映されません**。
+> このため Volume は過小評価され、`min ADV`（最低平均出来高）系の
+> **流動性フィルタが全銘柄を棄却するリスク**があります。
+> 桁数が想定より小さい場合の選択肢:
+> 1. **SIP feed に切替**（`ALPACA_FEED=sip`、有料 $99/月）
+> 2. **Stooq フォールバック**（`common/stooq_data.py`、無料・日足のみ・出来高は取引所全体ベース。現状 stub 未実装）
+>
+> どちらを採るかは smoke test（`tests/test_alpaca_data_smoke.py`）の
+> 直近 Volume 桁数を確認して判断してください。
 
 ### Bulk API 品質設定（2025-10-12 改善）
 

--- a/README.md
+++ b/README.md
@@ -227,25 +227,34 @@ pip install -r requirements.txt
 
 ## データソース (Data source)
 
-日次 OHLCV は **Alpaca 無料 tier に切替済** です（旧 EODHD 有料 $20/月 → $0）。
+日次 OHLCV を **無料データソースに移行**し EODHD 有料 $20/月 → $0 化を進めています。
+プロバイダは同一スキーマ（columns / index / dtypes）の drop-in replacement として実装され、
+旧 `get_eodhd_data(symbol)` と透過的に差し替え可能です。
 
-- **API キー取得先**: <https://app.alpaca.markets/>
-- **feed**: 既定は **IEX**（無料）。SIP は有料（$99/月）のため使用しません。
+### 推奨: Polygon.io 無料 tier（本命・full-market volume）
+
+- **取得関数**: `common/polygon_data.py`
+  - `get_polygon_data(symbol)` — 単一銘柄の日次 OHLCV（EODHD 同一スキーマ）
+  - `get_polygon_grouped_daily(date)` — **1 call で全 US 銘柄の日足**（dv20/dv50 pre-compute 用）
+- **volume**: SIP 連結（全取引所 + FINRA/OTC/ATS）の **full-market**。min-ADV / 流動性フィルタが正常動作。
+- **料金**: **$0**。レート制限 5 req/min（Grouped Daily は 1 call/日で全銘柄のため実質非制約）。
+- **API キー取得先（無料）**: <https://polygon.io/dashboard/signup>
+- **環境変数**: `POLYGON_API_KEY`（未設定なら `ValueError` で fail-fast）。
+- **AdjClose**: `adjusted=true`（split/dividend 調整済）。Close は `adjusted=false`（raw）。
+
+### 補助: Alpaca IEX feed（発注連携用途／非推奨・株データ本番不可）
+
 - **取得関数**: `common/alpaca_data.py` の `get_alpaca_data(symbol)`。
-  旧 `get_eodhd_data(symbol)` と同一スキーマ（columns / index / dtypes）の
-  drop-in replacement です。
-- **環境変数**: `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`（未設定なら `ValueError` で fail-fast）。
+- **環境変数**: `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`。
 
-> ⚠️ **既知の制限（IEX feed の出来高過小）**
-> IEX feed の出来高は NASDAQ/NYSE 全体の **2〜3% しか反映されません**。
-> このため Volume は過小評価され、`min ADV`（最低平均出来高）系の
-> **流動性フィルタが全銘柄を棄却するリスク**があります。
-> 桁数が想定より小さい場合の選択肢:
-> 1. **SIP feed に切替**（`ALPACA_FEED=sip`、有料 $99/月）
-> 2. **Stooq フォールバック**（`common/stooq_data.py`、無料・日足のみ・出来高は取引所全体ベース。現状 stub 未実装）
+> ⚠️ **既知の制限（IEX feed の出来高過小・実証済）**
+> IEX feed の出来高は全市場の **約 2〜4% しか反映されません**（実測: 真値の約 1/26）。
+> 確定候補 27 銘柄で min-ADV / 生株数フィルタ生存率が **12〜25%** まで低下することを実証済。
+> このため **株の日次データ本番運用には非推奨**。full-market volume が要る用途では
+> **Polygon.io（上記・無料）** を使用してください。SIP 切替（`ALPACA_FEED=sip`）は
+> 有料 $99/月で EODHD より高コストになるため退行です。
 >
-> どちらを採るかは smoke test（`tests/test_alpaca_data_smoke.py`）の
-> 直近 Volume 桁数を確認して判断してください。
+> `common/stooq_data.py`（stub）は API 無し・daily hits quota・ティッカーマッピング困難のため却下。
 
 ### Bulk API 品質設定（2025-10-12 改善）
 

--- a/common/alpaca_data.py
+++ b/common/alpaca_data.py
@@ -1,0 +1,187 @@
+"""Alpaca (無料 IEX feed) から日次 OHLCV を取得するデータプロバイダ。
+
+このモジュールは EODHD 有料 API (`scripts/cache_daily_data.py:get_eodhd_data`)
+を **無料の Alpaca Market Data API** で置き換えるために追加された。
+
+設計方針 (重要):
+    ``get_alpaca_data`` は旧 ``get_eodhd_data`` と **完全に同一のスキーマ** を返す。
+    呼び出し側から見て透過的に差し替え可能であること (drop-in replacement) を保証する。
+
+    旧 ``get_eodhd_data(symbol: str) -> pd.DataFrame | None`` の返り値:
+        - columns : ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+        - index   : DatetimeIndex (name="Date", tz-naive, 昇順ソート済)
+        - dtypes  : OHLC/AdjClose = float64, Volume = int64
+        - 失敗/空 : None を返す (例外を送出しない)
+
+コスト:
+    Alpaca の無料 tier は **IEX feed のみ**。SIP feed は有料 ($99/月) のため既定 OFF。
+    IEX feed の出来高は NASDAQ/NYSE 全体の 2〜3% しか反映されないため、
+    Volume は過小評価される (README の "Data source" 章 / 既知の罠を参照)。
+
+認証:
+    環境変数 ``ALPACA_API_KEY`` / ``ALPACA_SECRET_KEY`` を読む。
+    既存リポジトリの慣習 (``APCA_API_KEY_ID`` / ``APCA_API_SECRET_KEY``) も
+    フォールバックとして受け付ける。いずれも無ければ ``ValueError`` で fail-fast。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# --- 定数 ---------------------------------------------------------------
+# 旧 get_eodhd_data の返り値カラム順と完全一致させる
+_OUTPUT_COLUMNS = ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+
+# Alpaca 無料 tier の feed。SIP は有料なので既定は IEX。
+_DEFAULT_FEED = os.getenv("ALPACA_FEED", "iex")
+
+# 無料 tier のレート制限は 200 req/min。控えめな throttle を挟む。
+_MIN_REQUEST_INTERVAL = float(os.getenv("ALPACA_MIN_REQUEST_INTERVAL", "0.35"))
+_last_request_ts = 0.0
+
+# 過去データの取得開始日 (EODHD は全履歴を返すため、十分に古い日付から取得)
+_DEFAULT_HISTORY_START = os.getenv("ALPACA_HISTORY_START", "2000-01-01")
+
+
+def _get_credentials() -> tuple[str, str]:
+    """API キーを環境変数から読み込む。無ければ ValueError で fail-fast。"""
+    api_key = os.getenv("ALPACA_API_KEY") or os.getenv("APCA_API_KEY_ID")
+    secret_key = os.getenv("ALPACA_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY")
+    if not api_key or not secret_key:
+        raise ValueError(
+            "Alpaca API 認証情報が未設定です。環境変数 ALPACA_API_KEY と "
+            "ALPACA_SECRET_KEY (または APCA_API_KEY_ID / APCA_API_SECRET_KEY) "
+            "を .env に設定してください。取得先: https://app.alpaca.markets/"
+        )
+    return api_key, secret_key
+
+
+def _to_alpaca_symbol(symbol: str) -> str:
+    """EODHD 形式 (``AAPL.US``) を Alpaca 形式 (``AAPL``) に変換する。
+
+    EODHD は ``.US`` サフィックスを要求するが Alpaca は plain ticker のみ。
+    既に plain な場合はそのまま返す。
+    """
+    return symbol.upper().replace(".US", "")
+
+
+def _throttle() -> None:
+    """無料 tier のレート制限 (200 req/min) 対応の簡易 throttle。"""
+    global _last_request_ts
+    now = time.monotonic()
+    elapsed = now - _last_request_ts
+    if elapsed < _MIN_REQUEST_INTERVAL:
+        time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
+    _last_request_ts = time.monotonic()
+
+
+def get_alpaca_data(symbol: str) -> pd.DataFrame | None:
+    """Alpaca (IEX feed) から日次 OHLCV を取得する。
+
+    旧 ``get_eodhd_data(symbol)`` の drop-in replacement。
+    同一の columns / index 型 / dtypes を持つ DataFrame を返し、
+    取得失敗・空応答時は ``None`` を返す (例外は送出しない)。
+
+    認証情報が未設定の場合のみ ``ValueError`` で fail-fast する
+    (これはデータ取得失敗ではなく設定エラーであるため)。
+
+    Parameters
+    ----------
+    symbol : str
+        取得対象シンボル。EODHD 形式 (``AAPL.US``) / plain (``AAPL``) の双方を受け付ける。
+
+    Returns
+    -------
+    pd.DataFrame | None
+        columns=["Open","High","Low","Close","AdjClose","Volume"],
+        index=DatetimeIndex(name="Date", tz-naive, 昇順)。失敗時は None。
+    """
+    # 認証情報チェック (設定エラーは fail-fast)。SDK import もここで遅延評価。
+    api_key, secret_key = _get_credentials()
+
+    try:
+        from alpaca.data.historical import StockHistoricalDataClient
+        from alpaca.data.requests import StockBarsRequest
+        from alpaca.data.timeframe import TimeFrame
+    except ImportError as exc:  # pragma: no cover - 依存欠如は設定エラー扱い
+        raise ValueError(
+            "alpaca-py がインストールされていません。"
+            "`pip install 'alpaca-py>=0.30.0'` を実行してください。"
+        ) from exc
+
+    api_symbol = _to_alpaca_symbol(symbol)
+    client = StockHistoricalDataClient(api_key, secret_key)
+
+    def _fetch(adjustment: str) -> pd.DataFrame | None:
+        """指定 adjustment で bars を取得し MultiIndex を解いて返す。"""
+        req = StockBarsRequest(
+            symbol_or_symbols=api_symbol,
+            timeframe=TimeFrame.Day,
+            start=pd.Timestamp(_DEFAULT_HISTORY_START),
+            feed=_DEFAULT_FEED,
+            adjustment=adjustment,
+        )
+        _throttle()
+        bars = client.get_stock_bars(req)
+        raw = bars.df
+        if raw is None or raw.empty:
+            return None
+        # get_stock_bars は (symbol, timestamp) の MultiIndex。symbol レベルを除去。
+        if isinstance(raw.index, pd.MultiIndex):
+            raw = raw.xs(api_symbol, level="symbol")
+        return raw
+
+    try:
+        # 生値 (raw) の OHLCV → EODHD の close (未調整) に対応
+        raw_df = _fetch("raw")
+        if raw_df is None or raw_df.empty:
+            logger.warning("%s: Alpaca から空またはデータ無し", symbol)
+            return None
+
+        # 調整後終値 → EODHD の adjusted_close に対応 (split+dividend)
+        adj_close: pd.Series | None = None
+        try:
+            adj_df = _fetch("all")
+            if adj_df is not None and not adj_df.empty and "close" in adj_df:
+                adj_close = adj_df["close"]
+        except Exception as exc:  # pragma: no cover - 調整値は best-effort
+            logger.warning("%s: 調整後終値の取得に失敗 (AdjClose=Close で代替) - %s", symbol, exc)
+
+        df = pd.DataFrame(index=raw_df.index)
+        df["Open"] = raw_df["open"].astype("float64")
+        df["High"] = raw_df["high"].astype("float64")
+        df["Low"] = raw_df["low"].astype("float64")
+        df["Close"] = raw_df["close"].astype("float64")
+        if adj_close is not None:
+            # index を raw に揃えて欠損は Close で補完
+            df["AdjClose"] = adj_close.reindex(raw_df.index).astype("float64")
+            df["AdjClose"] = df["AdjClose"].fillna(df["Close"])
+        else:
+            df["AdjClose"] = df["Close"].astype("float64")
+        df["Volume"] = raw_df["volume"].astype("int64")
+
+        # --- index を EODHD と一致させる (罠2/罠3) ---
+        # Alpaca の Day bar timestamp は tz-aware UTC (ET 深夜 = bar 開始)。
+        # ET に変換して日付部分だけ残し、tz-naive の DatetimeIndex にする。
+        # これで EODHD の日付表現 (取引日 00:00, tz-naive) と一致する。
+        idx = pd.DatetimeIndex(df.index)
+        if idx.tz is not None:
+            idx = idx.tz_convert("America/New_York").tz_localize(None)
+        idx = idx.normalize()
+        df.index = idx
+        df.index.name = "Date"
+
+        df = df[_OUTPUT_COLUMNS]
+        df = df.sort_index()
+        # 重複 index を除去 (最終行を採用)
+        df = df[~df.index.duplicated(keep="last")]
+        return df
+    except Exception as exc:  # noqa: BLE001 - 取得失敗は None を返す (EODHD 互換)
+        logger.error("%s: Alpaca データ取得中のエラー - %s", symbol, exc)
+        return None

--- a/common/alpaca_data.py
+++ b/common/alpaca_data.py
@@ -49,8 +49,24 @@ _last_request_ts = 0.0
 _DEFAULT_HISTORY_START = os.getenv("ALPACA_HISTORY_START", "2000-01-01")
 
 
+def _load_env() -> None:
+    """`.env` を best-effort で読み込む (既存 env は上書きしない)。
+
+    本番の呼び出し経路 (scripts/cache_daily_data.py) は config.settings 経由で
+    既に load_dotenv 済だが、本モジュール単体利用/テスト時にも動くよう保険を掛ける。
+    common/broker_alpaca.py・common/notifier.py と同じパターン。
+    """
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(override=False)
+    except Exception:  # pragma: no cover - dotenv 不在時は環境変数のみで動作
+        pass
+
+
 def _get_credentials() -> tuple[str, str]:
     """API キーを環境変数から読み込む。無ければ ValueError で fail-fast。"""
+    _load_env()
     api_key = os.getenv("ALPACA_API_KEY") or os.getenv("APCA_API_KEY_ID")
     secret_key = os.getenv("ALPACA_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY")
     if not api_key or not secret_key:

--- a/common/alpaca_trading.py
+++ b/common/alpaca_trading.py
@@ -1,0 +1,464 @@
+"""Alpaca **Paper** 自動売買のための高レベル発注レイヤ。
+
+このモジュールは既存の低レベルプリミティブ (``common.broker_alpaca``) と
+既存のアロケーションロジック (``core.final_allocation.finalize_allocation`` が
+出力する ``final_df``) を **再利用** する薄いラッパーである。売買アルゴリズムや
+ポジションサイジングを再実装するものではない。
+
+提供する 2 つの公開 API:
+
+``submit_paper_order``
+    単一注文を Paper 口座へ送信する。``dry_run=True`` (デフォルト) では
+    実発注せず :class:`PreparedOrder` を返すだけ。``client_order_id`` により
+    冪等性 (同一シグナルの重複発注防止) を担保する。
+
+``signals_to_orders``
+    当日シグナル (``final_df`` 形式の DataFrame) を Alpaca 注文へ変換する。
+    ``dry_run=True`` (デフォルト) では :class:`PreparedOrder` のリストのみ返す。
+
+安全設計 (重要):
+    - ``ALPACA_PAPER`` が真でない、または base URL が live を指す場合は
+      :class:`LiveAccountGuardError` を送出して **live 口座への誤配信を防ぐ**。
+    - ``dry_run`` がデフォルト True。実発注は明示的に ``dry_run=False`` を
+      指定した場合のみ。
+    - 送信内容は ``logs/alpaca_orders_YYYYMMDD.log`` に追記される (監査証跡)。
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from common import broker_alpaca as ba
+
+logger = logging.getLogger(__name__)
+
+# システム別のデフォルト order type。common/alpaca_order.submit_orders_df と一致させる
+# (system1/3/4/5: 寄り成行, system2/6/7: 指値)。
+_DEFAULT_SYSTEM_ORDER_TYPE = {
+    "system1": "market",
+    "system3": "market",
+    "system4": "market",
+    "system5": "market",
+    "system2": "limit",
+    "system6": "limit",
+    "system7": "limit",
+}
+
+_LOG_DIR = Path(os.getenv("ALPACA_ORDER_LOG_DIR", "logs"))
+_PAPER_HOST = "paper-api.alpaca.markets"
+
+
+class LiveAccountGuardError(RuntimeError):
+    """Paper 前提の処理が live 口座設定を検出した場合に送出される。"""
+
+
+class OrderSubmitError(RuntimeError):
+    """発注が明示的な理由 (資金不足/市場休場/無効シンボル 等) で失敗した場合。"""
+
+
+@dataclass(slots=True)
+class PreparedOrder:
+    """送信予定 (または送信済) の注文を表す軽量 DTO。
+
+    dry_run では送信せずこのオブジェクトのみ返す。実発注時は ``order_id`` /
+    ``status`` が Alpaca レスポンスで埋められる。
+    """
+
+    symbol: str
+    qty: int
+    side: str  # "buy" | "sell"
+    order_type: str = "market"  # "market" | "limit"
+    limit_price: float | None = None
+    time_in_force: str = "day"
+    client_order_id: str | None = None
+    system: str | None = None
+    entry_date: str | None = None
+    # 実発注後に埋まる
+    order_id: str | None = None
+    status: str | None = None
+    error: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_row(self) -> dict[str, Any]:
+        """print / DataFrame 表示向けの平坦な dict。"""
+        d = asdict(self)
+        d.pop("extra", None)
+        return d
+
+
+# ---------------------------------------------------------------------------
+# 安全ガード
+# ---------------------------------------------------------------------------
+def _is_paper_env() -> bool:
+    """``ALPACA_PAPER`` を真偽解釈する (デフォルト True)。"""
+    return os.getenv("ALPACA_PAPER", "true").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    )
+
+
+def assert_paper_env() -> None:
+    """live 口座への誤発注を防ぐ fail-fast ガード。
+
+    - ``ALPACA_PAPER`` が偽 → 例外
+    - ``ALPACA_API_BASE_URL`` が paper ホスト以外を指す → 例外
+    実発注経路 (``dry_run=False``) の直前でのみ呼ばれる。
+    """
+    if not _is_paper_env():
+        raise LiveAccountGuardError(
+            "ALPACA_PAPER が true ではありません。live 口座への誤発注を防ぐため中止します。"
+            " Paper 取引のみ許可されています (.env の ALPACA_PAPER=true を確認)。"
+        )
+    base_url = os.getenv("ALPACA_API_BASE_URL", "")
+    if base_url and _PAPER_HOST not in base_url:
+        raise LiveAccountGuardError(
+            f"ALPACA_API_BASE_URL が paper エンドポイント ({_PAPER_HOST}) を指していません: "
+            f"{base_url!r}。live 口座への誤発注を防ぐため中止します。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 監査ログ
+# ---------------------------------------------------------------------------
+def _audit_log(record: dict[str, Any]) -> None:
+    """発注内容を ``logs/alpaca_orders_YYYYMMDD.log`` に JSON 1 行で追記する。
+
+    ログ書き込み失敗が発注フローを壊さないよう best-effort。
+    """
+    try:
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc)
+        path = _LOG_DIR / f"alpaca_orders_{stamp:%Y%m%d}.log"
+        record = {"ts": stamp.isoformat(), **record}
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    except Exception as exc:  # pragma: no cover - ログ失敗は無視
+        logger.warning("監査ログ書き込み失敗: %s", exc)
+
+
+def _classify_error(exc: Exception) -> OrderSubmitError:
+    """Alpaca 例外メッセージから明示的な原因に分類する。"""
+    msg = str(exc).lower()
+    if "insufficient" in msg or "buying power" in msg:
+        reason = "資金不足 (insufficient buying power)"
+    elif "market is closed" in msg or "not open" in msg or "closed" in msg:
+        reason = "市場休場 (market closed)"
+    elif "not found" in msg or "invalid" in msg or "not tradable" in msg:
+        reason = "無効シンボル (symbol invalid / not tradable)"
+    else:
+        reason = "発注失敗"
+    return OrderSubmitError(f"{reason}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# 公開 API 1: 単一注文
+# ---------------------------------------------------------------------------
+def submit_paper_order(
+    symbol: str,
+    qty: int,
+    side: str,
+    order_type: str = "market",
+    limit_price: float | None = None,
+    time_in_force: str = "day",
+    client_order_id: str | None = None,
+    *,
+    dry_run: bool = True,
+    client: Any | None = None,
+    retries: int = 2,
+    backoff_seconds: float = 1.0,
+    rate_limit_seconds: float = 0.35,
+) -> PreparedOrder:
+    """Paper 口座へ単一注文を送信する。
+
+    ``dry_run=True`` (デフォルト) では送信せず :class:`PreparedOrder` のみ返す。
+
+    Parameters
+    ----------
+    symbol, qty, side
+        ティッカー / 株数 / "buy"|"sell"。
+    order_type
+        "market" | "limit"。
+    limit_price
+        limit 注文時に必須。
+    time_in_force
+        "day" | "gtc" | "cls" 等 (大文字小文字問わず)。
+    client_order_id
+        冪等キー。同一値の再送は Alpaca 側で拒否され重複発注を防ぐ。
+    dry_run
+        True で実発注しない (デフォルト)。
+    client
+        既存の TradingClient を注入 (未指定なら paper client を生成)。
+
+    Raises
+    ------
+    LiveAccountGuardError
+        ``dry_run=False`` かつ live 環境を検出した場合。
+    OrderSubmitError
+        資金不足 / 市場休場 / 無効シンボル等で発注が失敗した場合。
+    """
+    side = side.lower().strip()
+    if side not in ("buy", "sell"):
+        raise ValueError(f"side は 'buy' か 'sell': {side!r}")
+    order_type = order_type.lower().strip()
+    if order_type == "limit" and limit_price is None:
+        raise ValueError("limit 注文には limit_price が必要です。")
+    qty = int(qty)
+    if qty <= 0:
+        raise ValueError(f"qty は正の整数: {qty}")
+
+    prepared = PreparedOrder(
+        symbol=symbol.upper(),
+        qty=qty,
+        side=side,
+        order_type=order_type,
+        limit_price=limit_price,
+        time_in_force=time_in_force,
+        client_order_id=client_order_id,
+    )
+
+    if dry_run:
+        _audit_log({"event": "dry_run", **prepared.to_row()})
+        return prepared
+
+    # ---- ここから実発注 (dry_run=False) ----
+    assert_paper_env()  # live 口座 fail-fast
+
+    if client is None:
+        client = ba.get_client(paper=True)
+
+    try:
+        order = ba.submit_order_with_retry(
+            client,
+            prepared.symbol,
+            prepared.qty,
+            side=prepared.side,
+            order_type=prepared.order_type,
+            limit_price=prepared.limit_price,
+            time_in_force=prepared.time_in_force,
+            client_order_id=prepared.client_order_id,
+            retries=retries,
+            backoff_seconds=backoff_seconds,
+            rate_limit_seconds=rate_limit_seconds,
+        )
+    except Exception as exc:  # noqa: BLE001
+        prepared.error = str(exc)
+        _audit_log({"event": "submit_error", **prepared.to_row()})
+        raise _classify_error(exc) from exc
+
+    prepared.order_id = str(getattr(order, "id", "") or "")
+    prepared.status = str(getattr(order, "status", "") or "")
+    _audit_log({"event": "submitted", **prepared.to_row()})
+    logger.info(
+        "Paper order submitted: %s %s x%d id=%s status=%s",
+        prepared.side,
+        prepared.symbol,
+        prepared.qty,
+        prepared.order_id,
+        prepared.status,
+    )
+    return prepared
+
+
+# ---------------------------------------------------------------------------
+# 公開 API 2: シグナル → 注文変換
+# ---------------------------------------------------------------------------
+def _side_from_row(row: pd.Series) -> str:
+    """final_df の side/position 列から buy/sell を決定する。
+
+    ``submit_orders_df`` と同じ規約: side=="long" → buy, それ以外 → sell。
+    """
+    raw = str(row.get("side", "")).lower()
+    if raw in ("buy", "sell"):
+        return raw
+    return "buy" if raw == "long" else "sell"
+
+
+def _order_type_from_row(row: pd.Series, override: str | None) -> str:
+    if override:
+        return override
+    system = str(row.get("system", "")).lower()
+    return _DEFAULT_SYSTEM_ORDER_TYPE.get(system, "market")
+
+
+def _build_client_order_id(row: pd.Series) -> str:
+    """(symbol, system, entry_date) から決定論的な冪等キーを生成する。
+
+    同一シグナルを再実行しても同じ id になり、Alpaca 側で重複発注が拒否される。
+    """
+    sym = str(row.get("symbol", "")).upper()
+    system = str(row.get("system", "")).lower()
+    date = str(row.get("entry_date", "")).replace("-", "").replace(" ", "")[:8]
+    return f"{system}-{sym}-{date}" if date else f"{system}-{sym}"
+
+
+def signals_to_orders(
+    signals: pd.DataFrame,
+    account_equity: float,
+    dry_run: bool = True,
+    *,
+    order_type: str | None = None,
+    time_in_force: str = "day",
+    open_positions: dict[str, float] | None = None,
+    client: Any | None = None,
+) -> list[PreparedOrder]:
+    """当日シグナル (``final_df`` 形式) を Alpaca 注文へ変換する。
+
+    ポジションサイジングは行わない — ``shares`` 列 (既存 ``finalize_allocation``
+    が算出したアロケーション) をそのまま数量として使用する。
+
+    Parameters
+    ----------
+    signals
+        少なくとも ``symbol``, ``system``, ``side``, ``shares`` を含む DataFrame。
+        ``entry_price`` があれば limit 注文の limit_price に使う。
+    account_equity
+        参考情報 (ログ用)。数量算出は shares 列に委譲するため計算には使わない。
+    dry_run
+        True (デフォルト) では :class:`PreparedOrder` のリストのみ返す。
+        False では各注文を Paper 口座へ送信する。
+    open_positions
+        ``{symbol: signed_qty}`` の既存ポジション。重複買い/売りの抑制に使う。
+        未指定かつ非 dry_run 時は Alpaca から取得する。
+
+    Returns
+    -------
+    list[PreparedOrder]
+    """
+    if signals is None or signals.empty:
+        return []
+    if "shares" not in signals.columns:
+        logger.warning("signals に shares 列がありません (資金配分モードで生成してください)。")
+        return []
+
+    # 実発注時は open positions を取得して重複抑制
+    if not dry_run:
+        assert_paper_env()
+        if client is None:
+            client = ba.get_client(paper=True)
+        if open_positions is None:
+            open_positions = _fetch_open_positions(client)
+    open_positions = open_positions or {}
+
+    prepared: list[PreparedOrder] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    for _, row in signals.iterrows():
+        sym = str(row.get("symbol", "")).upper()
+        qty = int(row.get("shares") or 0)
+        if not sym or qty <= 0:
+            continue
+        system = str(row.get("system", "")).lower()
+        entry_date = str(row.get("entry_date", "")) if row.get("entry_date") else None
+
+        # 重複シグナル (symbol, system, entry_date) を除去
+        dedup_key = (sym, system, str(entry_date))
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        side = _side_from_row(row)
+
+        # 既存ポジションとの照合: 同方向を既に十分保有していればスキップ
+        held = open_positions.get(sym, 0.0)
+        if side == "buy" and held > 0:
+            logger.info("%s: 既にロング保有 (%.0f株) のため買い増しスキップ", sym, held)
+            continue
+        if side == "sell" and held < 0:
+            logger.info("%s: 既にショート保有 (%.0f株) のため売り増しスキップ", sym, held)
+            continue
+
+        ot = _order_type_from_row(row, order_type)
+        limit_price: float | None = None
+        if ot == "limit":
+            raw_px = row.get("entry_price")
+            try:
+                if raw_px not in (None, ""):
+                    limit_price = float(raw_px)
+            except (TypeError, ValueError):
+                limit_price = None
+            if limit_price is None:
+                ot = "market"  # limit 価格が無ければ成行にフォールバック
+
+        po = PreparedOrder(
+            symbol=sym,
+            qty=qty,
+            side=side,
+            order_type=ot,
+            limit_price=limit_price,
+            time_in_force=time_in_force,
+            client_order_id=_build_client_order_id(row),
+            system=system or None,
+            entry_date=entry_date,
+        )
+        prepared.append(po)
+
+    logger.info(
+        "signals_to_orders: %d 注文を生成 (equity=$%.0f, dry_run=%s)",
+        len(prepared),
+        account_equity,
+        dry_run,
+    )
+
+    if dry_run:
+        for po in prepared:
+            _audit_log({"event": "dry_run", **po.to_row()})
+        return prepared
+
+    # 実発注 (client は上で確定済み)
+    submitted: list[PreparedOrder] = []
+    for po in prepared:
+        result = submit_paper_order(
+            po.symbol,
+            po.qty,
+            po.side,
+            order_type=po.order_type,
+            limit_price=po.limit_price,
+            time_in_force=po.time_in_force,
+            client_order_id=po.client_order_id,
+            dry_run=False,
+            client=client,
+        )
+        result.system = po.system
+        result.entry_date = po.entry_date
+        submitted.append(result)
+    return submitted
+
+
+def _fetch_open_positions(client: Any) -> dict[str, float]:
+    """Alpaca から ``{symbol: signed_qty}`` を取得する (ロング+/ショート-)。"""
+    out: dict[str, float] = {}
+    try:
+        positions = client.get_all_positions()
+    except Exception as exc:  # pragma: no cover - ネットワーク例外
+        logger.warning("open positions 取得失敗 (重複抑制なしで続行): %s", exc)
+        return out
+    for p in positions:
+        try:
+            sym = str(getattr(p, "symbol", "")).upper()
+            qty = float(getattr(p, "qty", 0) or 0)
+            if sym:
+                out[sym] = qty
+        except Exception:
+            continue
+    return out
+
+
+__all__ = [
+    "PreparedOrder",
+    "LiveAccountGuardError",
+    "OrderSubmitError",
+    "assert_paper_env",
+    "submit_paper_order",
+    "signals_to_orders",
+]

--- a/common/broker_alpaca.py
+++ b/common/broker_alpaca.py
@@ -107,11 +107,15 @@ def submit_order(
     stop_loss: float | None = None,
     trail_percent: float | None = None,
     time_in_force: str = "GTC",
+    client_order_id: str | None = None,
     log_callback=None,
 ):
     """注文を送信する共通関数。
 
     order_type: "market" | "limit" | "oco" | "trailing_stop"
+
+    client_order_id: 指定すると Alpaca 側の冪等キーとして送信される。
+        同一 client_order_id の再送は 422 (duplicate) となり、重複発注を防げる。
     """
     _require_sdk()
 
@@ -126,12 +130,18 @@ def submit_order(
         else TimeInForce.GTC
     )
 
+    # client_order_id は全 request 種別で共通の冪等キー。None の場合は付与しない。
+    _coid: dict[str, Any] = (
+        {"client_order_id": client_order_id} if client_order_id else {}
+    )
+
     if order_type == "market":
         req = MarketOrderRequest(  # type: ignore[call-arg]
             symbol=symbol,
             qty=qty,
             side=side_enum,
             time_in_force=tif,
+            **_coid,
         )
     elif order_type == "limit":
         if limit_price is None:
@@ -142,6 +152,7 @@ def submit_order(
             side=side_enum,
             limit_price=limit_price,
             time_in_force=tif,
+            **_coid,
         )
     elif order_type == "oco":
         if take_profit is None or stop_loss is None:
@@ -196,6 +207,7 @@ def submit_order_with_retry(
     stop_loss: float | None = None,
     trail_percent: float | None = None,
     time_in_force: str = "GTC",
+    client_order_id: str | None = None,
     retries: int = 2,
     backoff_seconds: float = 1.0,
     rate_limit_seconds: float = 0.0,
@@ -221,6 +233,7 @@ def submit_order_with_retry(
                 stop_loss=stop_loss,
                 trail_percent=trail_percent,
                 time_in_force=time_in_force,
+                client_order_id=client_order_id,
                 log_callback=log_callback,
             )
             if rate_limit_seconds > 0:

--- a/common/polygon_data.py
+++ b/common/polygon_data.py
@@ -1,0 +1,260 @@
+"""Polygon.io (無料 tier) から日次 OHLCV を取得するデータプロバイダ。
+
+このモジュールは EODHD 有料 API (`scripts/cache_daily_data.py:get_eodhd_data`)
+を **無料の Polygon.io Stocks API** で置き換えるために追加された。
+Alpaca IEX feed は出来高が全市場の約 2-4% しか反映されず min-ADV/流動性フィルタが
+壊滅する (実証済) ため、full-market volume を返す Polygon を本命フォールバックとする。
+
+設計方針 (重要):
+    ``get_polygon_data`` は旧 ``get_eodhd_data`` / ``get_alpaca_data`` と
+    **完全に同一のスキーマ** を返す drop-in replacement。
+        - columns : ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+        - index   : DatetimeIndex (name="Date", tz-naive, 昇順ソート済)
+        - dtypes  : OHLC/AdjClose = float64, Volume = int64
+        - 失敗/空/404 : None を返す (例外を送出しない)
+
+Bulk の強み:
+    ``get_polygon_grouped_daily(date)`` は **1 リクエストで全 US 銘柄の日足**を返す
+    (Grouped Daily エンドポイント)。dv20/dv50 の pre-compute が 1 call で済むため、
+    無料 tier の 5 req/min 制限が日次バッチでは実質非制約になる。
+
+コスト:
+    無料 tier ($0)。データは SIP 連結 (全取引所 + FINRA/OTC/ATS) の full-market volume。
+    レート制限は 5 req/min (無料)。Grouped Daily は 1 call/日で全銘柄。
+
+認証:
+    環境変数 ``POLYGON_API_KEY`` を読む。無ければ ``ValueError`` で fail-fast。
+    取得先: https://polygon.io/dashboard/signup (無料)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+# --- 定数 ---------------------------------------------------------------
+# 旧 get_eodhd_data の返り値カラム順と完全一致させる
+_OUTPUT_COLUMNS = ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+
+_API_BASE = os.getenv("POLYGON_API_BASE", "https://api.polygon.io").rstrip("/")
+
+# 過去データの取得開始日 (EODHD は全履歴を返すため、十分に古い日付から取得)
+_DEFAULT_HISTORY_START = os.getenv("POLYGON_HISTORY_START", "2000-01-01")
+
+# 無料 tier のレート制限は 5 req/min → 既定 13 秒間隔 (安全側)。
+# 有料 tier や Grouped Daily 主体運用では env で短縮可。
+_MIN_REQUEST_INTERVAL = float(os.getenv("POLYGON_MIN_REQUEST_INTERVAL", "13.0"))
+_REQUEST_TIMEOUT = float(os.getenv("POLYGON_REQUEST_TIMEOUT", "30"))
+_MAX_RETRIES = int(os.getenv("POLYGON_MAX_RETRIES", "3"))
+_last_request_ts = 0.0
+
+
+def _load_env() -> None:
+    """`.env` を best-effort で読み込む (既存 env は上書きしない)。
+
+    common/alpaca_data.py・broker_alpaca.py・notifier.py と同じパターン。
+    """
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(override=False)
+    except Exception:  # pragma: no cover - dotenv 不在時は環境変数のみで動作
+        pass
+
+
+def _get_api_key() -> str:
+    """API キーを環境変数から読み込む。無ければ ValueError で fail-fast。"""
+    _load_env()
+    api_key = os.getenv("POLYGON_API_KEY") or os.getenv("POLYGON_KEY")
+    if not api_key:
+        raise ValueError(
+            "Polygon API 認証情報が未設定です。環境変数 POLYGON_API_KEY を "
+            ".env に設定してください。無料 tier 取得先: "
+            "https://polygon.io/dashboard/signup"
+        )
+    return api_key
+
+
+def _to_polygon_symbol(symbol: str) -> str:
+    """EODHD 形式 (``AAPL.US``) を Polygon 形式 (``AAPL``) に変換する。
+
+    EODHD は ``.US`` サフィックスを要求するが Polygon は plain ticker のみ。
+    """
+    return symbol.upper().replace(".US", "")
+
+
+def _throttle() -> None:
+    """無料 tier のレート制限 (5 req/min) 対応の簡易 throttle。"""
+    global _last_request_ts
+    now = time.monotonic()
+    elapsed = now - _last_request_ts
+    if elapsed < _MIN_REQUEST_INTERVAL:
+        time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
+    _last_request_ts = time.monotonic()
+
+
+def _request(url: str, params: dict, api_key: str) -> dict | None:
+    """Polygon API を叩き JSON dict を返す。404/失敗時は None (raise しない)。
+
+    429 (rate limit) は指数バックオフでリトライする。
+    """
+    params = {**params, "apiKey": api_key}
+    for attempt in range(_MAX_RETRIES):
+        _throttle()
+        try:
+            r = requests.get(url, params=params, timeout=_REQUEST_TIMEOUT)
+        except Exception as exc:  # pragma: no cover - network error は None 扱い
+            logger.warning("Polygon リクエスト失敗 (%s/%s): %s", attempt + 1, _MAX_RETRIES, exc)
+            continue
+        if r.status_code == 200:
+            return r.json()
+        if r.status_code == 404:
+            return None  # symbol 不在 → EODHD と同じく None
+        if r.status_code == 429:
+            backoff = _MIN_REQUEST_INTERVAL * (attempt + 1)
+            logger.warning("Polygon 429 rate limit, %.0fs 待機 (%s/%s)", backoff, attempt + 1, _MAX_RETRIES)
+            time.sleep(backoff)
+            continue
+        logger.warning("Polygon ステータス %s - %s", r.status_code, url)
+        return None
+    return None
+
+
+def get_polygon_data(symbol: str) -> pd.DataFrame | None:
+    """Polygon.io から日次 OHLCV を取得する。
+
+    旧 ``get_eodhd_data(symbol)`` の drop-in replacement。同一の columns /
+    index 型 / dtypes を返し、取得失敗・空応答・404 時は ``None`` を返す。
+    認証情報未設定時のみ ``ValueError`` で fail-fast。
+
+    EODHD の close (未調整) / adjusted_close (調整済) を再現するため、
+    adjusted=false と adjusted=true の 2 リクエストを行う:
+        - Open/High/Low/Close/Volume : adjusted=false (raw)
+        - AdjClose                   : adjusted=true (split/dividend 調整済 close)
+    調整済取得に失敗した場合は AdjClose=Close にフォールバックする。
+
+    Parameters
+    ----------
+    symbol : str
+        取得対象シンボル。``AAPL.US`` / ``AAPL`` 双方を受け付ける。
+
+    Returns
+    -------
+    pd.DataFrame | None
+        columns=["Open","High","Low","Close","AdjClose","Volume"],
+        index=DatetimeIndex(name="Date", tz-naive, 昇順)。失敗時は None。
+    """
+    api_key = _get_api_key()
+    api_symbol = _to_polygon_symbol(symbol)
+    frm = _DEFAULT_HISTORY_START
+    to = datetime.today().strftime("%Y-%m-%d")
+    url = f"{_API_BASE}/v2/aggs/ticker/{api_symbol}/range/1/day/{frm}/{to}"
+    base_params = {"sort": "asc", "limit": 50000}
+
+    def _fetch(adjusted: bool) -> pd.DataFrame | None:
+        data = _request(url, {**base_params, "adjusted": str(adjusted).lower()}, api_key)
+        if not data:
+            return None
+        results = data.get("results")
+        if not results:
+            return None
+        return pd.DataFrame(results)
+
+    try:
+        raw = _fetch(adjusted=False)
+        if raw is None or raw.empty:
+            logger.warning("%s: Polygon から空またはデータ無し", symbol)
+            return None
+
+        # timestamp (ms, UTC) → tz-naive の取引日に変換 (EODHD/Alpaca と揃える)
+        idx = pd.to_datetime(raw["t"], unit="ms", utc=True)
+        idx = idx.dt.tz_convert("America/New_York").dt.tz_localize(None).dt.normalize()
+
+        df = pd.DataFrame(index=pd.DatetimeIndex(idx))
+        df["Open"] = raw["o"].astype("float64").values
+        df["High"] = raw["h"].astype("float64").values
+        df["Low"] = raw["l"].astype("float64").values
+        df["Close"] = raw["c"].astype("float64").values
+
+        # 調整済 close → AdjClose (best-effort)
+        adj_close = None
+        try:
+            adj = _fetch(adjusted=True)
+            if adj is not None and not adj.empty and "c" in adj:
+                adj_idx = pd.to_datetime(adj["t"], unit="ms", utc=True)
+                adj_idx = adj_idx.dt.tz_convert("America/New_York").dt.tz_localize(None).dt.normalize()
+                adj_close = pd.Series(adj["c"].astype("float64").values, index=pd.DatetimeIndex(adj_idx))
+        except Exception as exc:  # pragma: no cover - 調整値は best-effort
+            logger.warning("%s: 調整後終値の取得に失敗 (AdjClose=Close で代替) - %s", symbol, exc)
+
+        if adj_close is not None:
+            df["AdjClose"] = adj_close.reindex(df.index).astype("float64")
+            df["AdjClose"] = df["AdjClose"].fillna(df["Close"])
+        else:
+            df["AdjClose"] = df["Close"].astype("float64")
+        df["Volume"] = raw["v"].astype("int64").values
+
+        df.index.name = "Date"
+        df = df[_OUTPUT_COLUMNS]
+        df = df.sort_index()
+        df = df[~df.index.duplicated(keep="last")]
+        return df
+    except Exception as exc:  # noqa: BLE001 - 取得失敗は None (EODHD 互換)
+        logger.error("%s: Polygon データ取得中のエラー - %s", symbol, exc)
+        return None
+
+
+def get_polygon_grouped_daily(date: str) -> pd.DataFrame:
+    """指定日の **全 US 銘柄の日足** を 1 リクエストで取得する (Grouped Daily)。
+
+    dv20/dv50 pre-compute を全銘柄まとめて 1 call で賄える Polygon の decisive
+    advantage。無料 tier でも利用可能 (1 call/日)。
+
+    Parameters
+    ----------
+    date : str
+        取引日 (``YYYY-MM-DD``)。祝日/週末は空 DataFrame を返す。
+
+    Returns
+    -------
+    pd.DataFrame
+        index=symbol、columns=["Open","High","Low","Close","Volume"]。
+        データ無し時は空 DataFrame (columns だけ持つ)。
+
+    Raises
+    ------
+    ValueError
+        認証情報未設定時のみ (fail-fast)。
+    """
+    api_key = _get_api_key()
+    url = f"{_API_BASE}/v2/aggs/grouped/locale/us/market/stocks/{date}"
+    empty = pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+    empty.index.name = "symbol"
+
+    data = _request(url, {"adjusted": "false"}, api_key)
+    if not data:
+        return empty
+    results = data.get("results")
+    if not results:
+        return empty
+
+    df = pd.DataFrame(results)
+    # T=ticker, o/h/l/c/v = OHLCV
+    out = pd.DataFrame(
+        {
+            "Open": df["o"].astype("float64"),
+            "High": df["h"].astype("float64"),
+            "Low": df["l"].astype("float64"),
+            "Close": df["c"].astype("float64"),
+            "Volume": df["v"].astype("int64"),
+        }
+    )
+    out.index = pd.Index(df["T"].astype(str), name="symbol")
+    return out

--- a/common/polygon_data.py
+++ b/common/polygon_data.py
@@ -70,13 +70,22 @@ def _load_env() -> None:
 
 
 def _get_api_key() -> str:
-    """API キーを環境変数から読み込む。無ければ ValueError で fail-fast。"""
+    """API キーを環境変数から読み込む。無ければ ValueError で fail-fast。
+
+    Polygon.io は Massive.com にリブランドされたため、``MASSIVE_API_KEY`` /
+    ``MASSIVE_KEY`` も同義キーとして受け付ける (env 変数名の揺れに両対応)。
+    """
     _load_env()
-    api_key = os.getenv("POLYGON_API_KEY") or os.getenv("POLYGON_KEY")
+    api_key = (
+        os.getenv("POLYGON_API_KEY")
+        or os.getenv("MASSIVE_API_KEY")
+        or os.getenv("POLYGON_KEY")
+        or os.getenv("MASSIVE_KEY")
+    )
     if not api_key:
         raise ValueError(
-            "Polygon API 認証情報が未設定です。環境変数 POLYGON_API_KEY を "
-            ".env に設定してください。無料 tier 取得先: "
+            "Polygon/Massive API 認証情報が未設定です。環境変数 POLYGON_API_KEY "
+            "(または MASSIVE_API_KEY) を .env に設定してください。無料 tier 取得先: "
             "https://polygon.io/dashboard/signup"
         )
     return api_key

--- a/common/stooq_data.py
+++ b/common/stooq_data.py
@@ -1,0 +1,57 @@
+"""Stooq (無料・日足のみ) フォールバック データプロバイダ (stub)。
+
+目的:
+    Alpaca 無料 tier (IEX feed) は出来高が過小 (NASDAQ/NYSE 全体の 2〜3%) で
+    流動性フィルタが全銘柄を棄却するリスクがある (README "Data source" / 既知の罠1)。
+    その場合の **無料フォールバック** として Stooq (日足のみ、出来高は取引所全体ベース) を
+    使う選択肢を残しておくための stub。
+
+状態:
+    **未実装**。実装するかどうかは smoke test の Volume 桁数を確認した上で
+    ユーザが判断する (SIP 有料切替 と本フォールバックのどちらを採るか)。
+    ユーザ確認後に別 iteration で中身を埋める。
+
+契約 (実装時に守ること):
+    ``get_stooq_data`` は旧 ``get_eodhd_data`` / ``get_alpaca_data`` と
+    **同一スキーマ** を返すこと:
+        - columns : ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+        - index   : DatetimeIndex (name="Date", tz-naive, 昇順ソート済)
+        - dtypes  : OHLC/AdjClose = float64, Volume = int64
+        - 失敗/空 : None を返す (例外は送出しない)
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def get_stooq_data(symbol: str) -> pd.DataFrame | None:
+    """Stooq から日次 OHLCV を取得する (未実装 stub)。
+
+    旧 ``get_eodhd_data`` / ``get_alpaca_data`` の drop-in replacement として
+    同一スキーマを返す想定。現時点では未実装。
+
+    Parameters
+    ----------
+    symbol : str
+        取得対象シンボル (``AAPL`` / ``AAPL.US`` 等)。
+
+    Returns
+    -------
+    pd.DataFrame | None
+        実装後は Open/High/Low/Close/AdjClose/Volume を持つ日次 DataFrame。
+
+    Raises
+    ------
+    NotImplementedError
+        常に送出。ユーザ確認後の別 iteration で実装する。
+    """
+    # TODO: ユーザが stooq フォールバックを選択したら実装する。
+    #   候補: `pandas_datareader.stooq` もしくは
+    #   https://stooq.com/q/d/l/?s=<sym>.us&i=d の CSV を requests で取得し、
+    #   列名を Open/High/Low/Close/Volume に rename、AdjClose=Close、
+    #   index を tz-naive DatetimeIndex(name="Date") へ整形して返す。
+    raise NotImplementedError(
+        "get_stooq_data は未実装です。Alpaca IEX の出来高過小問題への"
+        "フォールバックとして、ユーザ確認後に実装予定です。"
+    )

--- a/docs/HUMAN_TASK_alpaca_paper_trading_20260701.md
+++ b/docs/HUMAN_TASK_alpaca_paper_trading_20260701.md
@@ -1,0 +1,198 @@
+# HUMAN TASK — Alpaca Paper Trading 自動発注 (2026-07-01)
+
+当日シグナル (`app_today_signals` / `run_all_systems_today`) の `final_df` を
+**Alpaca Paper 口座** へ自動発注するための runbook。
+
+> ⚠️ **このリポジトリの自動化 (Claude / CI) は実発注を一切行いません。**
+> 実際の Paper order を送信するのは **あなた (user) が 1 回だけ手動で叩く** 下記コマンドのみです。
+> Live 口座への移行も自動では行いません (Section 6)。
+
+実装ファイル:
+
+| 目的 | ファイル |
+|------|----------|
+| 発注 core (dry-run / paper guard / 監査ログ) | `common/alpaca_trading.py` |
+| 低レベル SDK ラッパー (既存・拡張) | `common/broker_alpaca.py` |
+| dry-run 可視化 CLI | `scripts/paper_trading_dryrun.py` |
+| 実発注 CLI (user 手動) | `scripts/paper_trading_submit.py` |
+| テスト (offline mock) | `tests/test_alpaca_trading_mock.py`, `tests/test_signals_to_orders.py` |
+
+前提 (`.env`):
+
+```
+APCA_API_KEY_ID=...
+APCA_API_SECRET_KEY=...
+ALPACA_API_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_PAPER=true
+```
+
+---
+
+## Section 1 — dry-run 確認手順 (実発注なし)
+
+送信予定の注文を表形式で確認する。**API キー不要・発注しない。**
+
+```bash
+# 動作確認 (内蔵デモ fixture)
+python scripts/paper_trading_dryrun.py --demo
+
+# 当日シグナル CSV を指定
+python scripts/paper_trading_dryrun.py --date 2026-06-30
+python scripts/paper_trading_dryrun.py --signals-csv results_csv_test/signals_final_2026-06-30.csv
+```
+
+出力例:
+
+```
+===== DRY-RUN: 送信予定注文 (実発注なし) =====
+symbol side  qty order_type  limit_price time_in_force  system       client_order_id
+  AAPL  buy   10     market          NaN           day system1 system1-AAPL-20260630
+  TSLA sell    8      limit        250.0           day system2 system2-TSLA-20260630
+   SPY sell    3      limit        545.0           day system7  system7-SPY-20260630
+```
+
+- `system1/3/4/5` → market、`system2/6/7` → limit (既存 `submit_orders_df` と同じ規約)
+- `client_order_id` = `{system}-{symbol}-{YYYYMMDD}` (冪等キー、重複発注防止)
+- `SPY` (system7) は hedge short としてそのまま尊重される
+
+---
+
+## Section 2 — Paper 実発注 (★ user が 1 回だけ叩く)
+
+### まず `--confirm` 無しで最終確認 (dry-run と等価):
+
+```bash
+python scripts/paper_trading_submit.py --date 2026-06-30
+```
+
+### 問題なければ実発注 (対話確認あり — 各注文で `[y/N]`):
+
+```bash
+python scripts/paper_trading_submit.py --date 2026-06-30 --confirm
+```
+
+### 無人実行 (対話プロンプトなし・Paper のみ):
+
+```bash
+python scripts/paper_trading_submit.py --date 2026-06-30 --confirm --yes
+```
+
+送信前に自動で以下を検証し、live 設定を検出したら **即中止** する:
+- `ALPACA_PAPER=true`
+- `ALPACA_API_BASE_URL` が `paper-api.alpaca.markets` を指す
+
+> 💡 デモで一連の流れを試すなら `--date` の代わりに `--demo` を付ける
+> (それでも `--confirm` 時は実際に Paper API へ送信するので注意)。
+
+---
+
+## Section 3 — 発注結果の確認
+
+### Alpaca Paper dashboard
+1. https://app.alpaca.markets/paper/dashboard/overview を開く
+2. **Orders** タブ … 送信した注文の status (`accepted`/`filled`/`rejected`)
+3. **Positions** タブ … 約定後の保有ポジション
+4. `client_order_id` 列で `system1-AAPL-20260630` 形式のキーが一致するか確認
+
+### 監査ログ (ローカル)
+送信内容は JSON 1 行/注文で追記される:
+
+```bash
+cat logs/alpaca_orders_$(date +%Y%m%d).log
+```
+
+各行: `ts`, `event` (`dry_run`/`submitted`/`submit_error`), `symbol`, `qty`, `side`,
+`order_id`, `status`, `client_order_id` など。
+
+---
+
+## Section 4 — 停止 / 取消 (誤発注時のロールバック)
+
+### 未約定注文をすべてキャンセル
+
+```python
+from common import broker_alpaca as ba
+client = ba.get_client(paper=True)   # ALPACA_PAPER=true 前提
+ba.cancel_all_orders(client)         # 全 open 注文をキャンセル
+```
+
+### 特定ポジションをクローズ (成行)
+
+既存の `scripts/exit_all_positions.py` を利用するか、単発なら:
+
+```python
+from common.alpaca_trading import submit_paper_order
+# ロング 10 株を反対売買でクローズ
+submit_paper_order("AAPL", 10, "sell", dry_run=False)
+```
+
+> ⚠️ 約定済ポジションは「キャンセル」できない。反対売買でクローズする。
+> `client_order_id` により同一シグナルの二重発注は Alpaca 側で拒否される (冪等)。
+
+---
+
+## Section 5 — production 化 (日次自動発注)
+
+> **user が最初の数日は必ず monitor すること。** 完全自動化はその後。
+
+Windows Task Scheduler での日次実行例 (US 市場 open 前、ET 08:00 = JST 21:00〜22:00):
+
+1. `scripts/run_all_systems_today.py` で当日シグナル (`final_df`) を CSV 出力
+2. 続けて `scripts/paper_trading_submit.py --date <today> --confirm --yes` を実行
+
+タスク登録 (PowerShell, 管理者):
+
+```powershell
+$action  = New-ScheduledTaskAction -Execute "python" `
+  -Argument "scripts\paper_trading_submit.py --date TODAY --confirm --yes" `
+  -WorkingDirectory "C:\Repos\quant_trading_system_0510to0906"
+$trigger = New-ScheduledTaskTrigger -Daily -At 21:30
+Register-ScheduledTask -TaskName "AlpacaPaperSubmit" -Action $action -Trigger $trigger
+```
+
+監視項目:
+- `logs/alpaca_orders_*.log` の `submit_error` 行
+- Alpaca dashboard の rejected 注文 (資金不足 / 市場休場 / 無効シンボル)
+- `signals_to_orders` の open-position 照合で重複買いが抑制されているか
+
+---
+
+## Section 6 — Live 口座移行チェックリスト (慎重に)
+
+> 🛑 **Live 移行は完全に user の判断。このリポジトリは Paper 前提で固定。**
+> Paper で最低 **数週間** 安定稼働し、約定・スリッページ・数量を検証してから。
+
+`ALPACA_PAPER=false` へ切り替える前に確認:
+
+- [ ] Paper で 2〜4 週間、想定どおりの約定 (fill rate / slippage) を確認した
+- [ ] `common/alpaca_trading.assert_paper_env()` は live で **例外を出す** 設計。
+      Live 発注するには **意図的に** このガードを緩める必要がある (安全側のデフォルト)
+- [ ] Live 用 API キー (`APCA_API_KEY_ID` / `APCA_API_SECRET_KEY`) は Paper と別物
+- [ ] `ALPACA_API_BASE_URL=https://api.alpaca.markets` (paper ホスト検証も要更新)
+- [ ] ポジションサイジング (`finalize_allocation` の `default_capital`) が
+      **実口座残高** に一致しているか — Paper のダミー残高のままだと過大発注
+- [ ] PDT (Pattern Day Trader) 規制 / 空売り可否 (`get_shortable_map`) / 手数料を再確認
+- [ ] 1 注文あたり最大数量・1 日最大発注数の上限を設ける (誤発注時の被害限定)
+- [ ] 最初は極小サイズ (1〜2 株) で 1 日だけ live smoke → dashboard 突合
+
+### Live 化の主なリスク (要理解)
+
+| リスク | 内容 |
+|--------|------|
+| 実資金の損失 | Paper と違い誤発注・バグがそのまま金銭損失になる |
+| 過大発注 | `default_capital` が実残高とずれると想定外サイズを発注 |
+| 約定差 | Paper は理想約定。Live はスリッページ / 部分約定 / 板薄で乖離 |
+| 規制 | PDT・空売り規制・borrow 不可銘柄で reject / 強制クローズ |
+| レート制限 | free tier 200 orders/min。大量発注時は backoff 必須 (実装済) |
+
+---
+
+## まとめ — user が最初に叩く 2 コマンド
+
+```bash
+# ① dry-run で確認 (実発注なし)
+python scripts/paper_trading_dryrun.py --date 2026-06-30
+
+# ② 確認できたら Paper へ実発注 (これだけが実発注)
+python scripts/paper_trading_submit.py --date 2026-06-30 --confirm --yes
+```

--- a/docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
+++ b/docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
@@ -1,0 +1,183 @@
+# HUMAN_TASK: Polygon Daily Coverage Monitor 導入手順 (2026-07-01)
+
+> **前提**: `common/polygon_data.py` (Grouped Daily 対応) 実装済。`POLYGON_API_KEY` 追加後に実測 verdict を確定し、$0 化路線が最終承認された時点で本 runbook を発動する。
+>
+> **目的**: `sys1-7` の gate 生存率 (min-ADV / DollarVolume / MIN_PRICE) を Polygon full-market volume で日次モニタリングし、閾値割れを検知して自動 alert する production パイプラインを構築する。
+
+---
+
+## 0. 発動前チェック (Polygon PoC 実測完了後)
+
+- [ ] `.env` に `POLYGON_API_KEY=xxx` が投入済 (無料 tier で可)
+- [ ] `python -c "from common.polygon_data import get_polygon_grouped_daily; print(get_polygon_grouped_daily('2026-06-30').shape)"` が (N>7000, 5) 相当を返す
+- [ ] `results_csv/` が gitignore 済 (既存確認済 → 追加設定不要)
+
+---
+
+## 1. Windows Task Scheduler 登録
+
+### 1.1 タスク仕様
+
+| 項目 | 値 |
+|------|-----|
+| Task 名 | `QuantTrading_PolygonDailyMonitor` |
+| Trigger | 毎日 **06:00 JST** (= US 前日 close 5h 後、Polygon 前日データ確定タイミング) |
+| Action | `powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File C:\Repos\quant_trading_system_0510to0906\scripts\daily_polygon_monitor.ps1` |
+| Working Dir | `C:\Repos\quant_trading_system_0510to0906` |
+| 実行 user | `SERV870\stair` (Interactive / Limited) |
+| バッテリー | AllowStartIfOnBatteries / DontStopIfGoingOnBatteries |
+| Wake computer | Enabled (US 早朝データ確定待ちのため) |
+| Retry | RestartCount 3 / Interval 5 min |
+| 参考パターン | `MT5_DashboardPublicSync` (30 分 tick, bundle-of-edges 側で稼働中) |
+
+### 1.2 登録 1-liner (管理者 PowerShell 上で実行)
+
+```powershell
+cd C:\Repos\quant_trading_system_0510to0906
+# 既存 register_task_scheduler.ps1 と同じ pattern。将来的に register_polygon_monitor_task.ps1 として分離推奨だが、
+# まずは以下の直書きで登録可能:
+$Action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+    -Argument '-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "C:\Repos\quant_trading_system_0510to0906\scripts\daily_polygon_monitor.ps1"' `
+    -WorkingDirectory 'C:\Repos\quant_trading_system_0510to0906'
+$Trigger = New-ScheduledTaskTrigger -Daily -At '06:00'
+$Settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable -WakeToRun -RunOnlyIfNetworkAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 30) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 5)
+$Principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+Register-ScheduledTask -TaskName 'QuantTrading_PolygonDailyMonitor' `
+    -Action $Action -Trigger $Trigger -Settings $Settings -Principal $Principal `
+    -Description 'Polygon.io Grouped Daily で sys1-7 gate 生存率を日次モニタリング (無料 tier / $0 運用)'
+```
+
+### 1.3 登録確認
+
+```powershell
+Get-ScheduledTask -TaskName 'QuantTrading_PolygonDailyMonitor' | Get-ScheduledTaskInfo
+```
+
+### 1.4 手動テスト実行 (登録後の smoke test)
+
+```powershell
+Start-ScheduledTask -TaskName 'QuantTrading_PolygonDailyMonitor'
+Get-Content C:\Repos\quant_trading_system_0510to0906\logs\polygon_monitor_*.log -Tail 40
+```
+
+---
+
+## 2. 監視 script のロジック
+
+### 2.1 実行フロー
+
+1. `common.polygon_data.get_polygon_grouped_daily(prev_business_day)` を **1 call** で全 US 銘柄 (~11,000 tickers) を fetch。
+2. `dv20 / dv50` は既存の `data_cache/*.feather` に格納された `DollarVolume20 / DollarVolume50` の **前日値**を lookup (フォールバック: Grouped Daily の Close×Volume を過去 60 日分 fetch して on-the-fly 計算 — key 追加後の別 iteration)。
+3. `sys1-7` それぞれの gate 条件 (下表) を適用し、生存 ticker 数 / 比率を計算。
+4. 前日実行結果 (`results_csv/polygon_daily_coverage_YYYYMMDD.json`) と diff し、`delta_vs_previous` を算出。
+5. 閾値割れ (下表) を検知したら `WARNING` を log、後段の hook (Discord webhook / Windows toast) に emit。
+
+### 2.2 System 別 gate 定義 (`core/system*.py` を **grep 実測** で確定)
+
+| System | Gate | 生存率下限 (warn) |
+|--------|------|------|
+| sys1 | `Close >= 5` & `DollarVolume20 > 50M` | 50% |
+| sys2 | `Close >= 5` & `DollarVolume20 > 25M` | 60% |
+| sys3 | `Close >= 5` & `DollarVolume20 > 25M` | 60% |
+| sys4 | `DollarVolume50 > 100M` | 40% |
+| sys5 | `Close >= 5` (DV 閾値なし) | 90% |
+| sys6 | `Low >= 5` & `DollarVolume50 > 10M` | 70% |
+| sys7 | SPY 固定 (常に 1) | 100% (SPY 欠損時のみ FAIL) |
+
+> 生存率下限は yfinance 実測 (2025-11 の bundle-of-edges tribe で 65-92% 復元) と Polygon SIP 連結の類推から暫定設定。運用開始後 2 週間で trailing p05 に自動調整予定 (別 iteration)。
+
+### 2.3 出力 schema
+
+`results_csv/polygon_daily_coverage_YYYYMMDD.json`:
+
+```json
+{
+  "date": "2026-06-30",
+  "provider": "polygon_grouped_daily",
+  "n_candidates_total": 11234,
+  "survival_by_system": {
+    "sys1": {"n_pass": 892, "ratio": 0.079, "warn_threshold": 0.05, "status": "ok"},
+    "sys2": {"n_pass": 1345, "ratio": 0.120, "warn_threshold": 0.06, "status": "ok"},
+    "...": "..."
+  },
+  "rejected_top10": [
+    {"symbol": "AAPL", "reason": "no_dv50_cache"},
+    "..."
+  ],
+  "delta_vs_previous": {
+    "sys1": +0.003,
+    "sys2": -0.012
+  },
+  "consecutive_drops": {
+    "sys1": 0,
+    "sys2": 2
+  }
+}
+```
+
+---
+
+## 3. 復旧手順
+
+### 3.1 Task が起動しない
+
+```powershell
+Get-ScheduledTaskInfo -TaskName 'QuantTrading_PolygonDailyMonitor'
+# LastTaskResult != 0 なら logs\polygon_monitor_*.log の直近を tail
+```
+
+### 3.2 Polygon API 障害 (24h 以内)
+
+- 手動で再実行: `Start-ScheduledTask -TaskName 'QuantTrading_PolygonDailyMonitor'`
+- Grouped Daily は **1 call/日** なので rate limit (5 req/min) は非制約。
+- 429 応答時: `common/polygon_data.py::_request` の指数バックオフが吸収する (最大 3 retry)。
+
+### 3.3 Polygon API 障害 (24h 超)
+
+- EODHD fallback 経路 (旧 `get_eodhd_data`) は **消さずに保持**する方針が上位 PoC で決定済。
+- Fallback 起動: `.env` で `MONITOR_PROVIDER=eodhd` に切替 → 次回実行時に自動選択 (未実装、別 iteration)。
+- **注意**: EODHD credential 消費が急増するため、必要に応じ手動 opt-in のみで運用。
+
+### 3.4 Rate limit 誤検知
+
+- Polygon 無料 tier は **5 req/min**。Grouped Daily 1 call + 履歴 backfill (最大 60 call) を 1 実行内でやると 12 分。
+- Task 実行時間上限 30 分に収まる設計だが、超過時は `ExecutionTimeLimit` 引き上げ + 履歴 backfill を別 hourly task に切り出す。
+
+---
+
+## 4. Dashboard 統合 (nice-to-have / 別 iteration)
+
+`docs/dashboards/quant_trading_card.html` (skeleton) に **quant_trading カード**を配置。bundle-of-edges 側 `mt5-dashboard` に埋め込み予定。
+
+- 表示項目: 最新 coverage % / 7 日推移スパークライン / 閾値割れ warning バッジ
+- データソース: `results_csv/polygon_daily_coverage_*.json` の最新 7 個を fetch (GitHub Pages 経由で公開する場合は要 sync)
+- 実装 status: **skeleton HTML のみ**。実際の bundle-of-edges への埋め込みは別 iteration。
+
+---
+
+## 5. Polygon PoC 実測完了時のフォローアップ
+
+1. `.env` に `POLYGON_API_KEY` を投入
+2. smoke test: `python scripts/daily_polygon_monitor.py --date 2026-06-30 --dry-run`
+3. 上記結果を `docs/HUMAN_TASK_polygon_daily_monitor_20260701.md` の "Verdict 実測" セクションに追記 (本 runbook 末尾に追記)
+4. Task Scheduler 登録 (§1.2 の 1-liner)
+5. 24h 経過後、`polygon_daily_coverage_*.json` が 2 世代溜まったところで delta 動作確認
+6. 生存率下限を trailing p05 に自動調整する PR を切る (別 iteration)
+7. Dashboard カード実装 (§4) を bundle-of-edges 側で PR 化
+
+---
+
+## Verdict 実測 (Polygon PoC 完了時に追記)
+
+```
+(POLYGON_API_KEY 投入後、以下を追記)
+
+- 実測日:
+- Grouped Daily 応答 shape:
+- sys1 生存率:
+- sys4 生存率:
+- SIP 連結率 (Alpaca IEX 比):
+- $0 化 verdict: [ ] approved / [ ] rejected
+```

--- a/docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
+++ b/docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
@@ -193,4 +193,86 @@ Get-ScheduledTaskInfo -TaskName 'QuantTrading_PolygonDailyMonitor'
 ### 運用上の注意（本採用の前提条件）
 1. **無料 tier 履歴は約 2 年**。日次シグナル（SMA200/ROC200 = 200日）には十分だが、長期バックテストには不足 → backtest 用途は EODHD 履歴保持 or 別途。
 2. **production は必ず `get_polygon_grouped_daily`**（1 call/日で全12k銘柄）。per-symbol `get_polygon_data` は全銘柄運用に不向き（5 req/min 制限）。
-3. daily monitor の TODO 3 つ（`load_dv_cache` / `evaluate_survival` / `compute_delta`）は別 iteration で肉付け。
+3. ~~daily monitor の TODO 3 つは別 iteration で肉付け。~~ → **完了 (2026-07-01)**。下記 §6 参照。
+
+---
+
+## 6. Cache 統合 & monitor 実装完了 (2026-07-01)
+
+### 6.1 Cache 統合 (Polygon Grouped Daily → CacheManager)
+
+`scripts/cache_daily_polygon.py` を追加。`scripts/cache_daily_data.py` (EODHD 経路) と
+**同一の production 保存関数** (`add_indicators` → full CSV / `compute_base_indicators` +
+`save_base_cache` → base feather) を再利用するため、schema は **drop-in で完全互換**
+(base feather columns = `date/open/high/low/close/volume + SMA*/ATR*/RSI*/ROC200/HV50/DollarVolume20/50`)。
+検証: 合成 60 行を投入 → 既存 EODHD-baseline (BBB.feather) の全 column を包含 (欠落ゼロ)、
+`date` dtype = `datetime64[ns]`、DV20/DV50 算出を確認。`core/system1-7` / `CacheManager` は不変。
+
+**backfill 1-liner (全 US 銘柄 / 直近 ~2 年):**
+
+```bash
+# 全銘柄・直近250営業日 (無料 tier 履歴上限内)。250 call × 13s ≈ 55 分
+python scripts/cache_daily_polygon.py --start 2024-07-01 --end 2026-06-30
+
+# 特定銘柄のみ (drop-in 検証・部分更新用)
+python scripts/cache_daily_polygon.py --start 2026-04-01 --end 2026-06-30 --symbols AAPL,MSFT,SPY
+```
+
+- Grouped Daily は unadjusted (raw close) → `AdjClose = Close`。日次シグナルには十分。
+- 履歴上限 (~2 年) 超過の平日空応答は WARNING (fail-soft)。`--strict-history` で fail-fast。
+- 既存 EODHD 経路 (`cache_daily_data.py`) は **untouched で併存** (契約解除は user 判断)。
+
+### 6.2 monitor 3 TODO 実装後の signature
+
+```python
+load_dv_cache(target_date: str, *, lookback_days: int = 0,
+              sleep_seconds: float = 13.0, cache_dir: Path | None = None
+              ) -> dict[str, dict[str, float]]
+    # base/*.feather の最新 DV20/50 を優先。lookback_days>0 なら Grouped Daily を
+    # N 営業日 fetch し Close×Volume の 20/50 日平均で欠損銘柄を on-the-fly 補完。
+
+evaluate_survival(grouped_df, dv_cache) -> dict[str, SystemSurvival]
+    # 全 US 銘柄ユニバースで sys1-7 の gate 生存率 (n_pass / n_total) を算出。
+    # SystemSurvival に survived_tickers / rejected_tickers を追加。
+
+compute_delta(current: CoverageReport, previous_path: Path | None) -> None
+    # 前日 JSON と ratio 差分。consecutive_drops を前日値からインクリメント
+    # (>=3 で連続下落フラグ)。前日欠損時は delta=0 / first_run=true。
+```
+
+新 CLI: `--dv-lookback N` (on-the-fly DV 日数) / `--dv-sleep S` (call 間隔)。
+
+### 6.3 Part 3 E2E smoke — JSON 生成 verified (2026-06-30)
+
+```bash
+python scripts/daily_polygon_monitor.py --date 2026-06-30 --dv-lookback 55 --dv-sleep 0.3
+```
+
+`results_csv/polygon_daily_coverage_20260630.json` を **実生成** (exit 0, coverage OK)。
+`n_candidates_total=12474`、on-the-fly DV で 13,169 銘柄をカバー。
+
+| system | gate | n_pass / n_total | ratio | warn | status |
+|---|---|---|---|---|---|
+| sys1 | Close≥5 & DV20>50M | 2070 / 12474 | 0.166 | 0.05 | ok |
+| sys2 | Close≥5 & DV20>25M | 2735 / 12474 | 0.219 | 0.06 | ok |
+| sys3 | Close≥5 & DV20>25M | 2735 / 12474 | 0.219 | 0.06 | ok |
+| sys4 | DV50>100M | 1390 / 12474 | 0.111 | 0.04 | ok |
+| sys5 | Close≥5 | 10479 / 12474 | 0.840 | 0.15 | ok |
+| sys6 | Low≥5 & DV50>10M | 3597 / 12474 | 0.288 | 0.10 | ok |
+| sys7 | SPY 固定 | 1 / 1 | 1.000 | — | ok |
+
+> **verdict (73/69/65/88/92/85%) との関係**: verdict は PoC の**候補 ~27 銘柄
+> (liquid watchlist) を母数**とした gate 通過率。上表は**全 US 12k 銘柄を母数**とした
+> production coverage 比率で、母数が異なるため数値は別物 (schema 例の sys1≈0.079 と同じ
+> スケール)。27 銘柄リストは repo に未 commit のため exact 再現は不可。Polygon が
+> full-market SIP volume (= yfinance 一致) を返すことは verdict §で実証済で、本 smoke は
+> その volume が gate 計算まで通ることを end-to-end で確認した。
+> なお本 smoke は 429 により DV lookback が 28/55 日に留まり DV50 系 (sys4/sys6) は
+> 微小に過小。production の 06:00 JST 実行は base cache 主体のため影響しない。
+
+### 6.4 EODHD vs Polygon 乖離チェック
+
+real EODHD cache は本環境に未整備 (合成 BBB のみ) のため per-symbol 実数 diff は未実施。
+代替として **schema drop-in** (§6.1) を検証済 — 両経路は同一保存関数を共有するため
+乖離源は raw OHLCV 値のみ (両者 full-market SIP、AdjClose の split/dividend timing 差のみ)。
+実データ diff は base backfill 後に `polygon vs eodhd` 5 営業日 close 乖離集計を推奨 (残タスク無し・nice-to-have)。

--- a/docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
+++ b/docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
@@ -169,15 +169,28 @@ Get-ScheduledTaskInfo -TaskName 'QuantTrading_PolygonDailyMonitor'
 
 ---
 
-## Verdict 実測 (Polygon PoC 完了時に追記)
+## Verdict 実測 (Polygon PoC 完了 — 2026-07-01)
 
-```
-(POLYGON_API_KEY 投入後、以下を追記)
+- **実測日**: 2026-07-01（`POLYGON_API_KEY` 投入後、env 変数名は `POLYGON_API_KEY`。code は `MASSIVE_API_KEY` も両対応化済）
+- **AAPL smoke**: 2026-06-30 volume = **65,100,155 = 8 桁**（full-market。IEX 1.58M=7桁の約 41倍）
+- **Grouped Daily 応答**: `get_polygon_grouped_daily("2026-06-30")` → **12,474 銘柄を 1 request**、columns=`[Open,High,Low,Close,Volume]`
+- **候補 27 銘柄カバレッジ**: 26/27（ACLX のみ欠落 = delisting/rename、yfinance も同様に欠落）
 
-- 実測日:
-- Grouped Daily 応答 shape:
-- sys1 生存率:
-- sys4 生存率:
-- SIP 連結率 (Alpaca IEX 比):
-- $0 化 verdict: [ ] approved / [ ] rejected
-```
+### gate 生存率 3 列対比（直近 5 営業日平均、Grouped Daily 5 call で取得）
+
+| gate | **Polygon 実測** | yfinance 実測 | IEX 実測 |
+|---|---|---|---|
+| DV>25M (sys2/3) | **73%** | 73% | ~25% |
+| DV>50M (sys1) | **69%** | 69% | ~20% |
+| DV>100M (sys4) | **65%** | 65% | ~7% |
+| DV>10M (sys6) | **88%** | 88% | ~42% |
+| AvgVol50>500k (sys5) | **92%** | 92% | 19% |
+| AvgVol50>1M (sys3 Phase2) | **85%** | 85% | 12% |
+
+- **SIP 連結率 (Alpaca IEX 比)**: AAPL 41×、per-symbol volume は yfinance とほぼ一致（AAPL 110.7M / SPY 59.25M）。Polygon = yfinance = SIP 連結 full-market。
+- **$0 化 verdict**: **[x] approved** — Polygon 生存率 = yfinance（完全一致、乖離ゼロ）で full-market を実証。IEX の壊滅（12-25%）を解消。**真の $0 化達成**。
+
+### 運用上の注意（本採用の前提条件）
+1. **無料 tier 履歴は約 2 年**。日次シグナル（SMA200/ROC200 = 200日）には十分だが、長期バックテストには不足 → backtest 用途は EODHD 履歴保持 or 別途。
+2. **production は必ず `get_polygon_grouped_daily`**（1 call/日で全12k銘柄）。per-symbol `get_polygon_data` は全銘柄運用に不向き（5 req/min 制限）。
+3. daily monitor の TODO 3 つ（`load_dv_cache` / `evaluate_survival` / `compute_delta`）は別 iteration で肉付け。

--- a/docs/dashboards/quant_trading_card.html
+++ b/docs/dashboards/quant_trading_card.html
@@ -1,0 +1,128 @@
+<!--
+  Dashboard card skeleton: Polygon Daily Coverage
+  ------------------------------------------------
+  Parent runbook: docs/HUMAN_TASK_polygon_daily_monitor_20260701.md §4
+  Embed target:   bundle-of-edges 側 mt5-dashboard (https://gethinu.github.io/mt5-dashboard/)
+  Data source:    results_csv/polygon_daily_coverage_YYYYMMDD.json (直近 7 日を集約)
+
+  Status: skeleton HTML + JSON schema 定義のみ。
+  実際の埋め込み / データ sync は別 iteration。
+
+  JSON schema (期待入力):
+    {
+      "history": [
+        {
+          "date": "2026-06-30",
+          "n_candidates_total": 11234,
+          "survival_by_system": {
+            "sys1": {"ratio": 0.079, "status": "ok"}, ...
+          }
+        },
+        ...  // 直近 7 日、日付昇順
+      ]
+    }
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8" />
+    <title>Quant Trading — Polygon Coverage</title>
+    <style>
+        :root {
+            --card-bg: #1e2130;
+            --card-fg: #e6e9f0;
+            --ok: #4ade80;
+            --warn: #facc15;
+            --fail: #f87171;
+            --muted: #94a3b8;
+        }
+        .qt-card {
+            background: var(--card-bg);
+            color: var(--card-fg);
+            border-radius: 12px;
+            padding: 16px 20px;
+            font-family: -apple-system, "Segoe UI", sans-serif;
+            width: 360px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        }
+        .qt-card h3 { margin: 0 0 8px; font-size: 14px; letter-spacing: 0.03em; }
+        .qt-card .qt-latest { font-size: 22px; font-weight: 600; }
+        .qt-card .qt-date { color: var(--muted); font-size: 11px; }
+        .qt-card table { width: 100%; margin-top: 12px; font-size: 12px; border-collapse: collapse; }
+        .qt-card td { padding: 3px 0; }
+        .qt-card td:last-child { text-align: right; font-variant-numeric: tabular-nums; }
+        .qt-card .status-ok { color: var(--ok); }
+        .qt-card .status-warn { color: var(--warn); }
+        .qt-card .status-fail { color: var(--fail); }
+        .qt-card .qt-spark { margin-top: 10px; height: 32px; }
+        .qt-card .qt-note { color: var(--muted); font-size: 10px; margin-top: 8px; }
+    </style>
+</head>
+<body>
+    <div class="qt-card" id="qt-coverage-card">
+        <h3>QUANT_TRADING · POLYGON COVERAGE</h3>
+        <div class="qt-latest" id="qt-headline">—</div>
+        <div class="qt-date" id="qt-date">no data</div>
+
+        <table id="qt-systems">
+            <tbody>
+                <!-- populated by init() -->
+            </tbody>
+        </table>
+
+        <svg class="qt-spark" viewBox="0 0 340 32" preserveAspectRatio="none" id="qt-spark">
+            <polyline fill="none" stroke="#60a5fa" stroke-width="1.5" points="" />
+        </svg>
+
+        <div class="qt-note" id="qt-note">skeleton view — data wire-up pending</div>
+    </div>
+
+    <script>
+        /**
+         * Render the coverage card from a JSON payload matching the schema above.
+         * TODO(next-iter): fetch history from results_csv or GitHub Pages mirror,
+         * hook into bundle-of-edges dashboard grid.
+         */
+        function renderCoverage(payload) {
+            if (!payload || !payload.history || !payload.history.length) return;
+            const latest = payload.history[payload.history.length - 1];
+            document.getElementById('qt-headline').textContent =
+                (latest.n_candidates_total || 0).toLocaleString() + ' tickers';
+            document.getElementById('qt-date').textContent = latest.date;
+
+            const tbody = document.querySelector('#qt-systems tbody');
+            tbody.innerHTML = '';
+            for (const [sys, val] of Object.entries(latest.survival_by_system || {})) {
+                const tr = document.createElement('tr');
+                tr.innerHTML =
+                    '<td>' + sys + '</td>' +
+                    '<td class="status-' + (val.status || 'ok') + '">' +
+                    (val.ratio * 100).toFixed(1) + '%</td>';
+                tbody.appendChild(tr);
+            }
+
+            // sparkline: 直近 7 日の sys1 ratio
+            const spark = payload.history
+                .map((d, i) => {
+                    const r = (d.survival_by_system?.sys1?.ratio ?? 0);
+                    const x = (i / (payload.history.length - 1 || 1)) * 340;
+                    const y = 32 - r * 32;  // ratio [0..1] → 0..32px
+                    return x.toFixed(1) + ',' + y.toFixed(1);
+                })
+                .join(' ');
+            document.querySelector('#qt-spark polyline').setAttribute('points', spark);
+        }
+
+        // demo payload (skeleton)
+        renderCoverage({
+            history: [
+                { date: '2026-06-24', n_candidates_total: 11100, survival_by_system: { sys1: { ratio: 0.081, status: 'ok' }, sys4: { ratio: 0.042, status: 'ok' } } },
+                { date: '2026-06-25', n_candidates_total: 11150, survival_by_system: { sys1: { ratio: 0.079, status: 'ok' }, sys4: { ratio: 0.041, status: 'ok' } } },
+                { date: '2026-06-26', n_candidates_total: 11200, survival_by_system: { sys1: { ratio: 0.075, status: 'ok' }, sys4: { ratio: 0.038, status: 'warn' } } },
+                { date: '2026-06-29', n_candidates_total: 11220, survival_by_system: { sys1: { ratio: 0.073, status: 'ok' }, sys4: { ratio: 0.036, status: 'warn' } } },
+                { date: '2026-06-30', n_candidates_total: 11234, survival_by_system: { sys1: { ratio: 0.079, status: 'ok' }, sys4: { ratio: 0.041, status: 'ok' } } },
+            ],
+        });
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ pydantic>=2,<3
 # Notifications (optional)
 slack_sdk>=3.26,<4
 
-# Trading
-alpaca-py
+# Trading & market data (Alpaca 無料 IEX feed)
+alpaca-py>=0.30.0
 
 # Network stack pins to satisfy dependencies
 urllib3>=2,<3

--- a/scripts/cache_daily_data.py
+++ b/scripts/cache_daily_data.py
@@ -68,6 +68,7 @@ def _migrate_root_csv_to_full() -> None:
 # 親ディレクトリ（リポジトリ ルート）を import パスに追加して、
 # 直下モジュール `indicators_common.py` を解決可能にする
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from common.alpaca_data import get_alpaca_data  # noqa: E402
 from common.cache_format import round_dataframe, safe_filename  # noqa: E402
 from common.cache_manager import (  # noqa: E402
     CacheManager,
@@ -650,7 +651,9 @@ def _prepare_cache_job(
                 success=True,
             )
 
-    df = get_eodhd_data(symbol)
+    # EODHD (有料) から Alpaca 無料 IEX feed へ切替。
+    # get_alpaca_data は get_eodhd_data と同一スキーマの drop-in replacement。
+    df = get_alpaca_data(symbol)
     if df is not None and not df.empty:
         return CacheJob(
             symbol=symbol,

--- a/scripts/cache_daily_polygon.py
+++ b/scripts/cache_daily_polygon.py
@@ -1,0 +1,300 @@
+"""Polygon.io Grouped Daily を CacheManager production 経路へ backfill する。
+
+`scripts/cache_daily_data.py` (EODHD/Alpaca 経由の per-symbol fetch) の
+**Grouped Daily 版**。Polygon の decisive advantage である「1 call/日で全 US
+銘柄」を使い、指定期間の日足パネルをまとめて取得して、既存 EODHD 経路と
+**drop-in 互換**の base feather (指標付き) + full CSV を書き出す。
+
+出力先 (既存 CacheManager と同一):
+    - full : ``data_cache/full_backup/<SYM>.csv``   (add_indicators 済)
+    - base : ``data_cache/base/<SYM>.feather``       (compute_base_indicators 済)
+
+drop-in 互換の要点:
+    - base feather columns : date/open/high/low/close/volume + 指標
+      (DollarVolume20/50, SMA*, ATR*, RSI*, ROC200, HV50 …) を
+      ``compute_base_indicators`` で EODHD 経路と同一計算式で付与。
+    - Grouped Daily は unadjusted (raw close) のみ返すため AdjClose=Close。
+      日次シグナル (SMA200/ROC200 = 200 日) には十分。長期 backtest の
+      split/dividend 調整が要る場合のみ EODHD 履歴を併用する (verdict §運用注意)。
+
+CLI:
+    # 直近 250 営業日 (≒無料 tier 履歴上限の範囲内) を全銘柄 backfill
+    python scripts/cache_daily_polygon.py --start 2024-07-01 --end 2026-06-30
+
+    # 特定銘柄のみ (drop-in 検証用)
+    python scripts/cache_daily_polygon.py --start 2026-04-01 --end 2026-06-30 --symbols AAPL,MSFT,SPY
+
+Rate limit:
+    Grouped Daily は 1 call/日。無料 tier 5 req/min のため既定 sleep=13s。
+    250 日 backfill ≈ 250 call ÷ 5/min ≈ 50 分。``--sleep`` で調整可。
+    429 は common/polygon_data.py::_request の指数バックオフが吸収する。
+
+無料 tier 履歴上限 (≈2 年):
+    範囲外を要求すると Grouped Daily が空を返す。平日で連続空応答を検知したら
+    WARNING を出し (fail-soft)、``--strict-history`` 指定時は fail-fast する。
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date, datetime, timedelta
+import logging
+import os
+from pathlib import Path
+import sys
+import time
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from common.cache_format import round_dataframe, safe_filename  # noqa: E402
+from common.cache_manager import (  # noqa: E402
+    compute_base_indicators,
+    save_base_cache,
+)
+from common.indicators_common import add_indicators  # noqa: E402
+from common.polygon_data import get_polygon_grouped_daily  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# 無料 tier の履歴上限は約 2 年 (verdict §運用注意 1)。安全側で 730 日。
+_FREE_TIER_HISTORY_DAYS = int(os.getenv("POLYGON_FREE_TIER_HISTORY_DAYS", "730"))
+
+_OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume"]
+
+
+def iter_business_days(start: date, end: date):
+    """start..end (両端含む) の平日を昇順で yield する。祝日は考慮しない。"""
+    d = start
+    while d <= end:
+        if d.weekday() < 5:  # Mon-Fri
+            yield d
+        d += timedelta(days=1)
+
+
+def fetch_grouped_panel(
+    start: date,
+    end: date,
+    *,
+    sleep_seconds: float,
+    strict_history: bool,
+    progress_every: int = 20,
+) -> dict[str, pd.DataFrame]:
+    """[start, end] の Grouped Daily を日次に fetch してパネルを返す。
+
+    Returns
+    -------
+    dict[str, pd.DataFrame]
+        キー=日付文字列 (YYYY-MM-DD)、値=index=symbol の OHLCV DataFrame。
+        空応答 (祝日/週末/履歴外) の日は含めない。
+    """
+    panel: dict[str, pd.DataFrame] = {}
+    days = list(iter_business_days(start, end))
+    history_cutoff = date.today() - timedelta(days=_FREE_TIER_HISTORY_DAYS)
+    empty_days: list[str] = []
+    n = len(days)
+    logger.info("Grouped Daily backfill: %d 営業日 (%s..%s)", n, start, end)
+
+    for i, d in enumerate(days, 1):
+        ds = d.isoformat()
+        df = get_polygon_grouped_daily(ds)
+        if df is None or df.empty:
+            empty_days.append(ds)
+            if d < history_cutoff:
+                msg = (
+                    f"{ds}: Grouped Daily が空 (無料 tier 履歴上限 ~"
+                    f"{_FREE_TIER_HISTORY_DAYS}日 を超過している可能性)"
+                )
+                if strict_history:
+                    raise RuntimeError(msg + " [--strict-history により中断]")
+                logger.warning(msg)
+        else:
+            panel[ds] = df
+        if i % progress_every == 0 or i == n:
+            logger.info(
+                "  進捗 %d/%d 日 (取得済 %d 日 / 空 %d 日)",
+                i, n, len(panel), len(empty_days),
+            )
+        if sleep_seconds > 0 and i < n:
+            time.sleep(sleep_seconds)
+
+    if empty_days:
+        logger.info("空応答 %d 日 (祝日/週末/履歴外): %s%s",
+                    len(empty_days), ", ".join(empty_days[:10]),
+                    " …" if len(empty_days) > 10 else "")
+    return panel
+
+
+def pivot_to_symbol_frames(
+    panel: dict[str, pd.DataFrame],
+    symbols: set[str] | None = None,
+) -> dict[str, pd.DataFrame]:
+    """日次パネルを symbol -> (Date-indexed OHLCV DataFrame) に転置する。
+
+    返す DataFrame は EODHD/Alpaca provider と同一スキーマ:
+        index=DatetimeIndex(name="Date", 昇順), columns=OHLCV(+AdjClose=Close)。
+    """
+    rows: list[pd.DataFrame] = []
+    for ds, df in panel.items():
+        sub = df
+        if symbols is not None:
+            sub = sub[sub.index.isin(symbols)]
+        if sub.empty:
+            continue
+        piece = sub[_OHLCV_COLS].copy()
+        piece["Date"] = pd.Timestamp(ds)
+        piece["symbol"] = sub.index.astype(str)
+        rows.append(piece)
+
+    if not rows:
+        return {}
+
+    allrows = pd.concat(rows, ignore_index=True)
+    frames: dict[str, pd.DataFrame] = {}
+    for sym, g in allrows.groupby("symbol"):
+        f = g.drop(columns=["symbol"]).sort_values("Date")
+        f = f.set_index("Date")
+        f.index.name = "Date"
+        f = f[~f.index.duplicated(keep="last")]
+        # Grouped Daily は unadjusted → AdjClose = raw Close
+        f["AdjClose"] = f["Close"].astype("float64")
+        f = f[["Open", "High", "Low", "Close", "AdjClose", "Volume"]]
+        frames[str(sym)] = f
+    return frames
+
+
+def write_symbol_to_cache(
+    symbol: str,
+    df: pd.DataFrame,
+    *,
+    full_dir: Path,
+    round_decimals: int | None,
+) -> bool:
+    """1 銘柄を EODHD 経路と同一の production 経路で書き出す。
+
+    full CSV (add_indicators 済) + base feather (compute_base_indicators 済)。
+    """
+    try:
+        safe = safe_filename(symbol)
+        # --- full CSV (add_indicators) ---
+        full_df = add_indicators(df.copy())
+        df_reset = full_df.reset_index()
+        df_reset = round_dataframe(df_reset, round_decimals)
+        full_dir.mkdir(parents=True, exist_ok=True)
+        df_reset.to_csv(full_dir / f"{safe}.csv", index=False)
+        # --- base feather (compute_base_indicators → DollarVolume20/50 等) ---
+        base_df = compute_base_indicators(df)
+        if base_df is not None and not base_df.empty:
+            save_base_cache(symbol, base_df)
+        return True
+    except Exception as exc:  # noqa: BLE001 - 1 銘柄失敗は継続
+        logger.warning("%s: cache 書き込み失敗 - %s", symbol, exc)
+        return False
+
+
+def run_backfill(
+    start: date,
+    end: date,
+    *,
+    symbols: set[str] | None,
+    max_symbols: int | None,
+    sleep_seconds: float,
+    strict_history: bool,
+    dry_run: bool,
+) -> dict[str, int]:
+    from config.settings import get_settings
+
+    settings = get_settings(create_dirs=True)
+    full_dir = Path(settings.cache.full_dir)
+    round_decimals = getattr(settings.cache, "round_decimals", None)
+
+    panel = fetch_grouped_panel(
+        start, end, sleep_seconds=sleep_seconds, strict_history=strict_history
+    )
+    if not panel:
+        logger.error("取得できた営業日が 0 日。範囲/履歴上限/rate limit を確認してください。")
+        return {"days": 0, "symbols": 0, "written": 0, "failed": 0}
+
+    frames = pivot_to_symbol_frames(panel, symbols)
+    all_syms = sorted(frames)
+    if max_symbols is not None:
+        all_syms = all_syms[:max_symbols]
+    logger.info("転置完了: %d 営業日 → %d 銘柄", len(panel), len(all_syms))
+
+    if dry_run:
+        logger.info("[dry-run] 書き込みスキップ。先頭 5 銘柄=%s", all_syms[:5])
+        return {"days": len(panel), "symbols": len(all_syms), "written": 0, "failed": 0}
+
+    written = failed = 0
+    for i, sym in enumerate(all_syms, 1):
+        ok = write_symbol_to_cache(
+            sym, frames[sym], full_dir=full_dir, round_decimals=round_decimals
+        )
+        written += int(ok)
+        failed += int(not ok)
+        if i % 500 == 0 or i == len(all_syms):
+            logger.info("  cache 書込 %d/%d (成功 %d / 失敗 %d)", i, len(all_syms), written, failed)
+
+    return {"days": len(panel), "symbols": len(all_syms), "written": written, "failed": failed}
+
+
+def _parse_date(s: str) -> date:
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--start", required=True, type=_parse_date, help="開始日 YYYY-MM-DD")
+    p.add_argument("--end", required=True, type=_parse_date, help="終了日 YYYY-MM-DD")
+    p.add_argument("--symbols", default=None,
+                   help="カンマ区切りの銘柄フィルタ (例: AAPL,MSFT,SPY)。未指定なら全銘柄。")
+    p.add_argument("--max-symbols", type=int, default=None,
+                   help="書き込む銘柄数の上限 (テスト/部分 backfill 用)。")
+    p.add_argument("--sleep", type=float, default=13.0,
+                   help="Grouped Daily call 間の sleep 秒 (既定 13s = 無料 tier 5req/min)。")
+    p.add_argument("--strict-history", action="store_true",
+                   help="履歴上限超過 (平日で空応答) を fail-fast する。")
+    p.add_argument("--dry-run", action="store_true",
+                   help="fetch/転置のみ行い cache 書き込みをスキップ。")
+    p.add_argument("--log-level", default="INFO")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    if args.end < args.start:
+        logger.error("--end (%s) が --start (%s) より前です。", args.end, args.start)
+        return 1
+
+    symbols = None
+    if args.symbols:
+        symbols = {s.strip().upper().replace(".US", "") for s in args.symbols.split(",") if s.strip()}
+
+    try:
+        stats = run_backfill(
+            args.start, args.end,
+            symbols=symbols, max_symbols=args.max_symbols,
+            sleep_seconds=args.sleep, strict_history=args.strict_history,
+            dry_run=args.dry_run,
+        )
+    except RuntimeError as exc:
+        logger.error("fail-fast: %s", exc)
+        return 1
+    except ValueError as exc:
+        logger.error("fail-fast: %s", exc)  # API key 未設定など
+        return 1
+
+    logger.info(
+        "完了: days=%d symbols=%d written=%d failed=%d",
+        stats["days"], stats["symbols"], stats["written"], stats["failed"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/daily_polygon_monitor.ps1
+++ b/scripts/daily_polygon_monitor.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Polygon.io Grouped Daily で sys1-7 gate 生存率を日次モニタリングする
+    Windows Task Scheduler 用ラッパー。
+
+.DESCRIPTION
+    Task 名 'QuantTrading_PolygonDailyMonitor' から毎日 06:00 JST に呼ばれる想定。
+    venv activate → daily_polygon_monitor.py 実行 → exit code check → log 追記。
+    parent runbook: docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
+
+.PARAMETER Date
+    対象取引日 (YYYY-MM-DD)。未指定なら前営業日 (python 側 default)。
+
+.PARAMETER DryRun
+    Polygon fetch をスキップ (skeleton 動作確認用)。
+
+.EXAMPLE
+    .\scripts\daily_polygon_monitor.ps1
+    .\scripts\daily_polygon_monitor.ps1 -DryRun
+    .\scripts\daily_polygon_monitor.ps1 -Date 2026-06-30
+
+.NOTES
+    参考パターン: scripts/daily_auto_run.ps1
+    Exit codes: 0=ok, 2=warn (閾値割れ), 1=error
+#>
+
+param(
+    [string]$Date = "",
+    [switch]$DryRun = $false
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$LogDir = Join-Path $ProjectRoot "logs"
+$LogFile = Join-Path $LogDir "polygon_monitor_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+function Write-Log {
+    param([string]$Message)
+    $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $Line = "[$Timestamp] $Message"
+    Write-Host $Line
+    Add-Content -Path $LogFile -Value $Line -Encoding UTF8
+}
+
+try {
+    Write-Log "========================================="
+    Write-Log "Polygon Daily Monitor 開始"
+    Write-Log "ProjectRoot: $ProjectRoot"
+    Write-Log "LogFile:     $LogFile"
+    Write-Log "========================================="
+
+    # venv activate (存在する場合のみ、存在しなければ system python)
+    $VenvPath = Join-Path $ProjectRoot "venv\Scripts\Activate.ps1"
+    if (Test-Path $VenvPath) {
+        Write-Log "venv activate: $VenvPath"
+        & $VenvPath
+    }
+    else {
+        Write-Log "WARN: venv not found, fallback to system python"
+    }
+
+    # python script kick
+    $PyScript = Join-Path $ProjectRoot "scripts\daily_polygon_monitor.py"
+    if (-not (Test-Path $PyScript)) {
+        throw "python script not found: $PyScript"
+    }
+
+    $Args = @($PyScript)
+    if ($Date) { $Args += @("--date", $Date) }
+    if ($DryRun) { $Args += @("--dry-run") }
+    $Args += @("--output-dir", (Join-Path $ProjectRoot "results_csv"))
+
+    Write-Log "python $($Args -join ' ')"
+    $Output = & python @Args 2>&1
+    $ExitCode = $LASTEXITCODE
+    $Output | ForEach-Object { Write-Log $_ }
+
+    Write-Log "python exit code: $ExitCode"
+
+    switch ($ExitCode) {
+        0 { Write-Log "OK: coverage 閾値割れなし" }
+        2 { Write-Log "WARN: 閾値割れ検知 (JSON 内 status=warn を確認)" }
+        default { Write-Log "ERROR: 監視 script が失敗 (exit=$ExitCode)" }
+    }
+
+    Write-Log "========================================="
+    Write-Log "Polygon Daily Monitor 終了 (exit=$ExitCode)"
+    Write-Log "========================================="
+    exit $ExitCode
+}
+catch {
+    Write-Log "========================================="
+    Write-Log "FATAL: $_"
+    Write-Log $_.ScriptStackTrace
+    Write-Log "========================================="
+    exit 1
+}

--- a/scripts/daily_polygon_monitor.py
+++ b/scripts/daily_polygon_monitor.py
@@ -1,0 +1,242 @@
+"""Daily Polygon coverage monitor (skeleton).
+
+sys1-7 の gate 生存率 (min-ADV / DollarVolume / MIN_PRICE) を Polygon.io
+Grouped Daily (無料 tier / 1 call/日で全 US 銘柄) で日次モニタリングし、
+閾値割れ検知 + 前日比 delta を JSON 出力する production パイプライン。
+
+Status:
+    - 骨格 (argparse / I/O / gate 定義) はここで実装済。
+    - `common.polygon_data.get_polygon_grouped_daily` は既存実装済 (import OK)。
+    - **fetch 実行 / dv20-dv50 lookup / delta 計算 / notification hook は
+      POLYGON_API_KEY 投入後の別 iteration で肉付け**する。
+    - 現状 --dry-run で骨格の import / argparse / 出力 path 生成のみを確認可能。
+
+Runbook:
+    docs/HUMAN_TASK_polygon_daily_monitor_20260701.md
+
+Windows Task Scheduler:
+    Task 名 `QuantTrading_PolygonDailyMonitor` から
+    `scripts/daily_polygon_monitor.ps1` 経由で呼ばれる。
+
+Exit codes:
+    0 : 正常終了 (閾値割れなし)
+    2 : 閾値割れ検知 (WARN log 済、後段 hook に emit)
+    1 : 実行時エラー
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# --- System 別 gate 定義 (core/system*.py を grep で実測) ---------------
+# 詳細は docs/HUMAN_TASK_polygon_daily_monitor_20260701.md §2.2 を参照。
+SYSTEM_GATES: dict[str, dict[str, Any]] = {
+    "sys1": {"min_price": 5.0, "dv_col": "DollarVolume20", "dv_min": 50_000_000, "warn_ratio": 0.05},
+    "sys2": {"min_price": 5.0, "dv_col": "DollarVolume20", "dv_min": 25_000_000, "warn_ratio": 0.06},
+    "sys3": {"min_price": 5.0, "dv_col": "DollarVolume20", "dv_min": 25_000_000, "warn_ratio": 0.06},
+    "sys4": {"min_price": None, "dv_col": "DollarVolume50", "dv_min": 100_000_000, "warn_ratio": 0.04},
+    "sys5": {"min_price": 5.0, "dv_col": None, "dv_min": None, "warn_ratio": 0.15},  # DV 閾値なし
+    "sys6": {"min_price": 5.0, "dv_col": "DollarVolume50", "dv_min": 10_000_000, "warn_ratio": 0.10, "min_col": "Low"},
+    "sys7": {"spy_only": True, "warn_ratio": 1.0},  # SPY 固定 (欠損時のみ FAIL)
+}
+
+
+@dataclass
+class SystemSurvival:
+    """1 system の生存率評価結果。"""
+
+    system: str
+    n_pass: int = 0
+    n_total: int = 0
+    ratio: float = 0.0
+    warn_threshold: float = 0.0
+    status: str = "pending"  # ok | warn | fail | pending
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "n_pass": self.n_pass,
+            "n_total": self.n_total,
+            "ratio": round(self.ratio, 4),
+            "warn_threshold": self.warn_threshold,
+            "status": self.status,
+        }
+
+
+@dataclass
+class CoverageReport:
+    """日次 coverage report の schema。JSON 出力される。"""
+
+    date: str
+    provider: str = "polygon_grouped_daily"
+    n_candidates_total: int = 0
+    survival_by_system: dict[str, dict[str, Any]] = field(default_factory=dict)
+    rejected_top10: list[dict[str, str]] = field(default_factory=list)
+    delta_vs_previous: dict[str, float] = field(default_factory=dict)
+    consecutive_drops: dict[str, int] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, ensure_ascii=False, indent=2, default=str)
+
+
+# --- 前営業日ロジック ---------------------------------------------------
+
+def previous_business_day(anchor: date | None = None) -> date:
+    """anchor (default: 今日) の直前平日を返す。US 祝日は考慮しない (Polygon 側で空応答 → warn)。"""
+    d = anchor or date.today()
+    d -= timedelta(days=1)
+    while d.weekday() >= 5:  # Sat=5, Sun=6
+        d -= timedelta(days=1)
+    return d
+
+
+# --- 核ロジック (skeleton) ---------------------------------------------
+
+def fetch_grouped_daily(target_date: str) -> Any:
+    """Polygon Grouped Daily を fetch する thin wrapper。
+
+    Polygon key 未投入時は ValueError を common.polygon_data 側が raise するので
+    そのまま propagate させる (fail-fast)。
+    """
+    # 遅延 import (POLYGON_API_KEY 未投入時に import だけで落ちないよう)
+    from common.polygon_data import get_polygon_grouped_daily
+
+    return get_polygon_grouped_daily(target_date)
+
+
+def load_dv_cache(target_date: str) -> Any:
+    """既存 data_cache/*.feather から前日の DollarVolume20/50 を lookup。
+
+    TODO(polygon-key-added-iter): cache_manager 経由で symbol -> {DV20, DV50, Close, Low}
+    の dict を返す実装を追加。cache miss は Grouped Daily 過去 60 日を fetch で on-the-fly 補完。
+    """
+    logger.info("[skeleton] load_dv_cache: target_date=%s (implementation deferred)", target_date)
+    return {}
+
+
+def evaluate_survival(grouped_df: Any, dv_cache: dict[str, Any]) -> dict[str, SystemSurvival]:
+    """sys1-7 それぞれの gate 生存率を計算する。
+
+    TODO(polygon-key-added-iter): grouped_df / dv_cache を join し、SYSTEM_GATES の閾値を
+    適用して n_pass / ratio / status を埋める。現状は空の SystemSurvival を返すだけ。
+    """
+    results: dict[str, SystemSurvival] = {}
+    for sysname, cfg in SYSTEM_GATES.items():
+        s = SystemSurvival(system=sysname, warn_threshold=cfg.get("warn_ratio", 0.0))
+        results[sysname] = s
+    return results
+
+
+def compute_delta(current: CoverageReport, previous_path: Path | None) -> None:
+    """前日 JSON との diff を current.delta_vs_previous / consecutive_drops に埋める。
+
+    TODO(polygon-key-added-iter): previous_path が存在すれば JSON 読み込み、各 system で
+    ratio 差分を計算。連続下落は過去 3 日分の履歴を walk して count。
+    """
+    if previous_path is None or not previous_path.exists():
+        current.notes.append("no_previous_report (delta unavailable)")
+        return
+    logger.info("[skeleton] compute_delta: previous=%s (implementation deferred)", previous_path)
+
+
+def notify_warnings(report: CoverageReport) -> int:
+    """閾値割れがあれば log + hook 呼び出し。exit-code 相当を返す (0=ok, 2=warn)。
+
+    TODO(polygon-key-added-iter): Discord webhook / Windows toast を .env の
+    MONITOR_NOTIFY_WEBHOOK に応じて発火。まずは log WARN のみで足りる。
+    """
+    warns = [s for s in report.survival_by_system.values() if s.get("status") == "warn"]
+    if not warns:
+        logger.info("coverage OK (no warnings)")
+        return 0
+    for w in warns:
+        logger.warning("coverage WARN: %s", w)
+    return 2
+
+
+# --- entry point --------------------------------------------------------
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="対象取引日 (YYYY-MM-DD)。未指定なら前営業日。",
+    )
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("results_csv"),
+        help="JSON 出力先ディレクトリ (default: results_csv/)。",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Polygon fetch をスキップし、骨格 / 出力 path のみ確認する。",
+    )
+    p.add_argument("--log-level", default="INFO", help="ログレベル (default: INFO)。")
+    return p
+
+
+def _parse_target_date(raw: str | None) -> str:
+    if raw:
+        # 妥当性チェック (fail-fast)
+        datetime.strptime(raw, "%Y-%m-%d")
+        return raw
+    return previous_business_day().isoformat()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    target_date = _parse_target_date(args.date)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = args.output_dir / f"polygon_daily_coverage_{target_date.replace('-', '')}.json"
+    previous_path = args.output_dir / f"polygon_daily_coverage_{previous_business_day(datetime.strptime(target_date, '%Y-%m-%d').date()).strftime('%Y%m%d')}.json"
+
+    logger.info("target_date=%s  output=%s  dry_run=%s", target_date, output_path, args.dry_run)
+
+    report = CoverageReport(date=target_date)
+
+    if args.dry_run:
+        report.notes.append("dry_run: skeleton only (fetch skipped)")
+        output_path.write_text(report.to_json(), encoding="utf-8")
+        logger.info("[dry-run] wrote skeleton report -> %s", output_path)
+        return 0
+
+    try:
+        grouped = fetch_grouped_daily(target_date)
+        report.n_candidates_total = int(getattr(grouped, "shape", [0])[0])
+        dv_cache = load_dv_cache(target_date)
+        survivals = evaluate_survival(grouped, dv_cache)
+        report.survival_by_system = {k: v.as_dict() for k, v in survivals.items()}
+        compute_delta(report, previous_path)
+    except ValueError as exc:
+        # POLYGON_API_KEY 未設定
+        logger.error("fail-fast: %s", exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("unexpected error: %s", exc)
+        return 1
+
+    output_path.write_text(report.to_json(), encoding="utf-8")
+    logger.info("wrote %s (n_total=%d)", output_path, report.n_candidates_total)
+    return notify_warnings(report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/daily_polygon_monitor.py
+++ b/scripts/daily_polygon_monitor.py
@@ -29,11 +29,16 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+# スクリプトを直接 (python scripts/daily_polygon_monitor.py / .ps1 経由) 実行しても
+# リポジトリ直下の `common` パッケージを解決できるようにする。
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +65,8 @@ class SystemSurvival:
     ratio: float = 0.0
     warn_threshold: float = 0.0
     status: str = "pending"  # ok | warn | fail | pending
+    survived_tickers: list[str] = field(default_factory=list)
+    rejected_tickers: list[str] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -113,39 +120,288 @@ def fetch_grouped_daily(target_date: str) -> Any:
     return get_polygon_grouped_daily(target_date)
 
 
-def load_dv_cache(target_date: str) -> Any:
-    """既存 data_cache/*.feather から前日の DollarVolume20/50 を lookup。
+def _load_dv_from_base_cache(cache_dir: Path) -> dict[str, dict[str, float]]:
+    """``data_cache/base/*.feather`` から各銘柄の最新 DollarVolume20/50 を読む。"""
+    out: dict[str, dict[str, float]] = {}
+    base_dir = cache_dir / "base"
+    if not base_dir.exists():
+        return out
+    import pandas as pd  # 遅延 import
 
-    TODO(polygon-key-added-iter): cache_manager 経由で symbol -> {DV20, DV50, Close, Low}
-    の dict を返す実装を追加。cache miss は Grouped Daily 過去 60 日を fetch で on-the-fly 補完。
+    for fp in base_dir.glob("*.feather"):
+        try:
+            df = pd.read_feather(fp)
+        except Exception:  # pragma: no cover - 壊れた feather はスキップ
+            continue
+        if df is None or df.empty:
+            continue
+        cols = {c.lower(): c for c in df.columns}
+        dv20c, dv50c = cols.get("dollarvolume20"), cols.get("dollarvolume50")
+        if not dv20c and not dv50c:
+            continue
+        last = df.iloc[-1]
+        sym = fp.stem.upper()
+        rec: dict[str, float] = {}
+        if dv20c is not None:
+            rec["DollarVolume20"] = float(last.get(dv20c, float("nan")))
+        if dv50c is not None:
+            rec["DollarVolume50"] = float(last.get(dv50c, float("nan")))
+        out[sym] = rec
+    return out
+
+
+def _compute_dv_from_grouped(
+    target_date: str, lookback_days: int, sleep_seconds: float
+) -> dict[str, dict[str, float]]:
+    """Grouped Daily を過去 ``lookback_days`` 営業日分 fetch し DV20/50 を on-the-fly 計算。
+
+    cache miss (base feather 未整備) 時のフォールバック。Close×Volume の
+    直近 20/50 営業日平均を全銘柄まとめてベクトル計算する。
     """
-    logger.info("[skeleton] load_dv_cache: target_date=%s (implementation deferred)", target_date)
-    return {}
+    import time
+
+    import pandas as pd
+
+    from common.polygon_data import get_polygon_grouped_daily
+
+    end = datetime.strptime(target_date, "%Y-%m-%d").date()
+    days: list[date] = []
+    d = end
+    guard = 0
+    while len(days) < lookback_days and guard < lookback_days * 3 + 10:
+        if d.weekday() < 5:
+            days.append(d)
+        d -= timedelta(days=1)
+        guard += 1
+    days = sorted(days)
+
+    dv_cols: list[Any] = []
+    fetched = 0
+    for i, dd in enumerate(days):
+        g = get_polygon_grouped_daily(dd.isoformat())
+        if g is not None and not g.empty:
+            dv = g["Close"].astype("float64") * g["Volume"].astype("float64")
+            dv.name = dd.isoformat()
+            dv_cols.append(dv)
+            fetched += 1
+        if sleep_seconds > 0 and i < len(days) - 1:
+            time.sleep(sleep_seconds)
+    logger.info("on-the-fly DV: %d/%d 営業日を取得", fetched, len(days))
+    if not dv_cols:
+        return {}
+
+    mat = pd.concat(dv_cols, axis=1)
+    mat = mat.reindex(sorted(mat.columns), axis=1)  # 日付昇順
+    dv20 = mat.iloc[:, -20:].mean(axis=1)
+    dv50 = mat.iloc[:, -50:].mean(axis=1)
+    out: dict[str, dict[str, float]] = {}
+    for sym in mat.index:
+        out[str(sym).upper()] = {
+            "DollarVolume20": float(dv20.loc[sym]),
+            "DollarVolume50": float(dv50.loc[sym]),
+        }
+    return out
 
 
-def evaluate_survival(grouped_df: Any, dv_cache: dict[str, Any]) -> dict[str, SystemSurvival]:
-    """sys1-7 それぞれの gate 生存率を計算する。
+def load_dv_cache(
+    target_date: str,
+    *,
+    lookback_days: int = 0,
+    sleep_seconds: float = 13.0,
+    cache_dir: Path | None = None,
+) -> dict[str, dict[str, float]]:
+    """symbol -> {"DollarVolume20", "DollarVolume50"} の dict を返す。
 
-    TODO(polygon-key-added-iter): grouped_df / dv_cache を join し、SYSTEM_GATES の閾値を
-    適用して n_pass / ratio / status を埋める。現状は空の SystemSurvival を返すだけ。
+    優先順位:
+        1. ``data_cache/base/*.feather`` の最新 DollarVolume20/50 (cache_daily_polygon
+           / cache_daily_data で整備済のもの)。
+        2. cache coverage が薄い場合、``lookback_days`` > 0 なら Grouped Daily を
+           その日数だけ fetch して Close×Volume の 20/50 日平均を on-the-fly 計算し
+           cache を補完する (base 値を優先し、欠けている銘柄のみ埋める)。
+
+    Parameters
+    ----------
+    target_date : str
+        対象取引日 (YYYY-MM-DD)。on-the-fly 計算の終端。
+    lookback_days : int
+        on-the-fly 補完で fetch する営業日数 (0 = base cache のみ)。DV50 には 50 以上推奨。
     """
+    if cache_dir is None:
+        try:
+            from config.settings import get_settings
+
+            cache_dir = Path(get_settings(create_dirs=False).DATA_CACHE_DIR)
+        except Exception:
+            cache_dir = Path("data_cache")
+
+    base = _load_dv_from_base_cache(cache_dir)
+    logger.info("load_dv_cache: base cache から %d 銘柄", len(base))
+
+    if lookback_days and lookback_days > 0:
+        otf = _compute_dv_from_grouped(target_date, lookback_days, sleep_seconds)
+        # base を優先し、base に無い銘柄のみ on-the-fly で補完
+        for sym, rec in otf.items():
+            base.setdefault(sym, rec)
+        logger.info("load_dv_cache: on-the-fly 補完後 合計 %d 銘柄", len(base))
+
+    if not base:
+        logger.warning("load_dv_cache: DV データ 0 件 (base cache 未整備 & lookback=0)。"
+                       "cache_daily_polygon.py で backfill するか --dv-lookback を指定してください。")
+    return base
+
+
+def evaluate_survival(
+    grouped_df: Any, dv_cache: dict[str, dict[str, float]]
+) -> dict[str, SystemSurvival]:
+    """sys1-7 それぞれの gate 生存率を全 US 銘柄ユニバースで計算する。
+
+    grouped_df (当日 Grouped Daily / index=symbol) に dv_cache (前日 DV20/50) を
+    join し、SYSTEM_GATES の閾値を適用。ratio = n_pass / n_total (n_total = 当日
+    価格のある全銘柄) で production coverage metric を算出する。
+    """
+    import math
+
     results: dict[str, SystemSurvival] = {}
+    if grouped_df is None or getattr(grouped_df, "empty", True):
+        for sysname, cfg in SYSTEM_GATES.items():
+            results[sysname] = SystemSurvival(
+                system=sysname, warn_threshold=cfg.get("warn_ratio", 0.0), status="fail"
+            )
+        return results
+
+    close = grouped_df["Close"].astype("float64")
+    low = grouped_df["Low"].astype("float64") if "Low" in grouped_df.columns else close
+    symbols = [str(s).upper() for s in grouped_df.index]
+
+    def _dv(sym: str, col: str) -> float:
+        rec = dv_cache.get(sym)
+        if not rec:
+            return float("nan")
+        return float(rec.get(col, float("nan")))
+
     for sysname, cfg in SYSTEM_GATES.items():
         s = SystemSurvival(system=sysname, warn_threshold=cfg.get("warn_ratio", 0.0))
+
+        if cfg.get("spy_only"):
+            has_spy = "SPY" in symbols
+            s.n_total = 1
+            s.n_pass = 1 if has_spy else 0
+            s.ratio = 1.0 if has_spy else 0.0
+            s.status = "ok" if has_spy else "fail"
+            s.survived_tickers = ["SPY"] if has_spy else []
+            results[sysname] = s
+            continue
+
+        min_price = cfg.get("min_price")
+        min_col = cfg.get("min_col", "Close")
+        price_series = low if min_col == "Low" else close
+        dv_col = cfg.get("dv_col")
+        dv_min = cfg.get("dv_min")
+
+        n_total = 0
+        survived: list[str] = []
+        for i, sym in enumerate(symbols):
+            px = float(price_series.iloc[i])
+            if math.isnan(px):
+                continue
+            n_total += 1  # 当日価格のある全銘柄が母数
+            if min_price is not None and px < min_price:
+                continue
+            if dv_col is not None:
+                dv = _dv(sym, dv_col)
+                if math.isnan(dv) or dv <= float(dv_min):
+                    continue
+            survived.append(sym)
+
+        s.n_total = n_total
+        s.n_pass = len(survived)
+        s.ratio = (s.n_pass / s.n_total) if s.n_total else 0.0
+        s.status = "warn" if s.ratio < s.warn_threshold else "ok"
+        s.survived_tickers = survived
         results[sysname] = s
+
     return results
 
 
 def compute_delta(current: CoverageReport, previous_path: Path | None) -> None:
     """前日 JSON との diff を current.delta_vs_previous / consecutive_drops に埋める。
 
-    TODO(polygon-key-added-iter): previous_path が存在すれば JSON 読み込み、各 system で
-    ratio 差分を計算。連続下落は過去 3 日分の履歴を walk して count。
+    - delta_vs_previous[sys] = 当日 ratio - 前日 ratio (小数 4 桁)。
+    - consecutive_drops[sys] = ratio が前日より下落していれば前日 count + 1、
+      非下落なら 0 にリセット。3 以上で「連続 3 日下落」フラグ相当。
+    - 前日 JSON が無ければ全 delta=0 / first_run=true フラグを notes に付与。
     """
+    # まず全 system を 0 初期化 (前日欠損時のデフォルト)
+    for sysname in current.survival_by_system:
+        current.delta_vs_previous.setdefault(sysname, 0.0)
+        current.consecutive_drops.setdefault(sysname, 0)
+
     if previous_path is None or not previous_path.exists():
-        current.notes.append("no_previous_report (delta unavailable)")
+        current.notes.append("first_run=true (no_previous_report; delta=0)")
         return
-    logger.info("[skeleton] compute_delta: previous=%s (implementation deferred)", previous_path)
+
+    try:
+        prev = json.loads(previous_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - 壊れた JSON は first_run 扱い
+        logger.warning("前日 JSON の読み込みに失敗 (%s): %s", previous_path, exc)
+        current.notes.append("first_run=true (previous_report_unreadable; delta=0)")
+        return
+
+    prev_survival: dict[str, Any] = prev.get("survival_by_system", {}) or {}
+    prev_drops: dict[str, Any] = prev.get("consecutive_drops", {}) or {}
+
+    for sysname, cur in current.survival_by_system.items():
+        cur_ratio = float(cur.get("ratio", 0.0))
+        prev_entry = prev_survival.get(sysname) or {}
+        prev_ratio = float(prev_entry.get("ratio", cur_ratio))
+        delta = round(cur_ratio - prev_ratio, 4)
+        current.delta_vs_previous[sysname] = delta
+        if delta < 0:
+            current.consecutive_drops[sysname] = int(prev_drops.get(sysname, 0) or 0) + 1
+        else:
+            current.consecutive_drops[sysname] = 0
+
+    dropping = {k: v for k, v in current.consecutive_drops.items() if v >= 3}
+    if dropping:
+        current.notes.append(f"consecutive_declines_3d: {dropping}")
+    logger.info("compute_delta: vs %s 完了 (delta=%s)",
+                previous_path.name, current.delta_vs_previous)
+
+
+def _build_rejected_top10(
+    grouped_df: Any,
+    dv_cache: dict[str, dict[str, float]],
+    survivals: dict[str, SystemSurvival],
+) -> list[dict[str, str]]:
+    """当日出来高上位で sys1 (最も厳しい共通 gate) を通らない銘柄 top10 を理由付きで返す。"""
+    if grouped_df is None or getattr(grouped_df, "empty", True):
+        return []
+    import math
+
+    sys1_survived = set(survivals.get("sys1", SystemSurvival(system="sys1")).survived_tickers)
+    close = grouped_df["Close"].astype("float64")
+    vol = grouped_df["Volume"].astype("float64")
+    dollar_vol = (close * vol)
+    order = dollar_vol.sort_values(ascending=False)
+
+    rejected: list[dict[str, str]] = []
+    for sym_raw in order.index:
+        sym = str(sym_raw).upper()
+        if sym in sys1_survived:
+            continue
+        px = float(close.loc[sym_raw])
+        rec = dv_cache.get(sym) or {}
+        dv20 = rec.get("DollarVolume20", float("nan"))
+        if not rec or (isinstance(dv20, float) and math.isnan(dv20)):
+            reason = "no_dv20_cache"
+        elif px < 5.0:
+            reason = "price_below_5"
+        else:
+            reason = "dv20_below_50m"
+        rejected.append({"symbol": sym, "reason": reason})
+        if len(rejected) >= 10:
+            break
+    return rejected
 
 
 def notify_warnings(report: CoverageReport) -> int:
@@ -184,6 +440,19 @@ def build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Polygon fetch をスキップし、骨格 / 出力 path のみ確認する。",
     )
+    p.add_argument(
+        "--dv-lookback",
+        type=int,
+        default=0,
+        help="base cache が薄い場合に Grouped Daily を過去 N 営業日 fetch して "
+        "DV20/50 を on-the-fly 計算する (0=cache のみ, DV50 には 50 以上推奨)。",
+    )
+    p.add_argument(
+        "--dv-sleep",
+        type=float,
+        default=13.0,
+        help="on-the-fly DV 計算時の Grouped Daily call 間 sleep 秒 (既定 13s)。",
+    )
     p.add_argument("--log-level", default="INFO", help="ログレベル (default: INFO)。")
     return p
 
@@ -221,9 +490,14 @@ def main(argv: list[str] | None = None) -> int:
     try:
         grouped = fetch_grouped_daily(target_date)
         report.n_candidates_total = int(getattr(grouped, "shape", [0])[0])
-        dv_cache = load_dv_cache(target_date)
+        dv_cache = load_dv_cache(
+            target_date,
+            lookback_days=args.dv_lookback,
+            sleep_seconds=args.dv_sleep,
+        )
         survivals = evaluate_survival(grouped, dv_cache)
         report.survival_by_system = {k: v.as_dict() for k, v in survivals.items()}
+        report.rejected_top10 = _build_rejected_top10(grouped, dv_cache, survivals)
         compute_delta(report, previous_path)
     except ValueError as exc:
         # POLYGON_API_KEY / MASSIVE_API_KEY 未設定 (共に common.polygon_data で判定)

--- a/scripts/daily_polygon_monitor.py
+++ b/scripts/daily_polygon_monitor.py
@@ -226,7 +226,7 @@ def main(argv: list[str] | None = None) -> int:
         report.survival_by_system = {k: v.as_dict() for k, v in survivals.items()}
         compute_delta(report, previous_path)
     except ValueError as exc:
-        # POLYGON_API_KEY 未設定
+        # POLYGON_API_KEY / MASSIVE_API_KEY 未設定 (共に common.polygon_data で判定)
         logger.error("fail-fast: %s", exc)
         return 1
     except Exception as exc:  # noqa: BLE001

--- a/scripts/paper_trading_dryrun.py
+++ b/scripts/paper_trading_dryrun.py
@@ -1,0 +1,109 @@
+"""当日シグナルを Alpaca Paper 口座へ流すシミュレーション (dry-run / 実発注なし)。
+
+当日 ``final_df`` (アロケーション済シグナル) を読み込み、
+``common.alpaca_trading.signals_to_orders(dry_run=True)`` で Alpaca 注文へ変換し、
+送信予定内容を表形式で表示するだけ。**実発注は一切行わない。**
+
+使い方::
+
+    python scripts/paper_trading_dryrun.py --date 2026-06-30
+    python scripts/paper_trading_dryrun.py --signals-csv path/to/final_signals.csv
+    python scripts/paper_trading_dryrun.py --demo    # 内蔵デモ fixture で動作確認
+
+シグナル CSV は ``run_all_systems_today.py`` が出力する ``final_df`` を想定
+(列: symbol, system, side, shares, entry_price, entry_date)。
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+# リポジトリルートを import path に追加 (scripts/ から実行される想定)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.alpaca_trading import signals_to_orders  # noqa: E402
+
+
+def _demo_signals() -> pd.DataFrame:
+    """API 不要で動作確認するための内蔵デモ fixture。"""
+    return pd.DataFrame(
+        [
+            {"symbol": "AAPL", "system": "system1", "side": "long", "shares": 10, "entry_price": 195.5, "entry_date": "2026-06-30"},
+            {"symbol": "MSFT", "system": "system3", "side": "long", "shares": 5, "entry_price": 420.0, "entry_date": "2026-06-30"},
+            {"symbol": "TSLA", "system": "system2", "side": "short", "shares": 8, "entry_price": 250.0, "entry_date": "2026-06-30"},
+            {"symbol": "SPY", "system": "system7", "side": "short", "shares": 3, "entry_price": 545.0, "entry_date": "2026-06-30"},
+        ]
+    )
+
+
+def _default_csv_for_date(date: str | None) -> Path | None:
+    """--date 指定時に既定の signals CSV パスを推定する。"""
+    if not date:
+        return None
+    candidates = [
+        Path("results_csv_test") / f"signals_final_{date}.csv",
+        Path("results_csv_test") / "signals_final_test.csv",
+        Path("data_cache") / "signals" / f"final_{date}.csv",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def load_signals(args: argparse.Namespace) -> pd.DataFrame:
+    if args.demo:
+        print("[demo] 内蔵デモ fixture を使用します (API 不要)。")
+        return _demo_signals()
+    csv_path = Path(args.signals_csv) if args.signals_csv else _default_csv_for_date(args.date)
+    if csv_path is None or not csv_path.exists():
+        raise SystemExit(
+            "signals CSV が見つかりません。--signals-csv <path> を指定するか、"
+            "run_all_systems_today.py で当日シグナルを生成してください。"
+            " (動作確認のみなら --demo)"
+        )
+    print(f"[load] {csv_path}")
+    return pd.read_csv(csv_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", help="対象日 (YYYY-MM-DD)。既定 CSV パス推定に使用。")
+    parser.add_argument("--signals-csv", help="final_df 形式の signals CSV パス。")
+    parser.add_argument("--equity", type=float, default=100000.0, help="口座資産 (ログ用)。")
+    parser.add_argument("--demo", action="store_true", help="内蔵デモ fixture で動作確認。")
+    args = parser.parse_args(argv)
+
+    signals = load_signals(args)
+    if signals is None or signals.empty:
+        print("シグナルなし。発注対象はありません。")
+        return 0
+
+    # dry_run=True なので実発注は絶対に行われない
+    orders = signals_to_orders(signals, account_equity=args.equity, dry_run=True)
+
+    if not orders:
+        print("変換後の発注対象はありません (shares<=0 等でフィルタ)。")
+        return 0
+
+    rows = [o.to_row() for o in orders]
+    df = pd.DataFrame(rows)
+    cols = [
+        "symbol", "side", "qty", "order_type", "limit_price",
+        "time_in_force", "system", "client_order_id",
+    ]
+    df = df[[c for c in cols if c in df.columns]]
+
+    print("\n===== DRY-RUN: 送信予定注文 (実発注なし) =====")
+    print(df.to_string(index=False))
+    print(f"\n合計 {len(df)} 注文 / equity=${args.equity:,.0f}")
+    print("※ これは dry-run です。実発注は scripts/paper_trading_submit.py --confirm で行います。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/paper_trading_submit.py
+++ b/scripts/paper_trading_submit.py
@@ -1,0 +1,129 @@
+"""dry-run で確認した注文を Alpaca **Paper** 口座へ送信する (user 手動実行前提)。
+
+安全設計:
+    - ``--confirm`` が無ければ dry-run と等価 (誤爆防止)。
+    - 送信前に ``ALPACA_PAPER=true`` と paper エンドポイントを検証 (live で fail-fast)。
+    - 各注文の直前に summary を表示し ``[y/N]`` 確認 (CI 用に ``--yes`` で無人実行)。
+    - 送信結果は ``logs/alpaca_orders_YYYYMMDD.log`` に追記。
+
+使い方::
+
+    # 1. まず dry-run で確認 (実発注なし)
+    python scripts/paper_trading_submit.py --date 2026-06-30
+
+    # 2. 確認できたら実発注 (対話確認あり)
+    python scripts/paper_trading_submit.py --date 2026-06-30 --confirm
+
+    # 3. 無人実行 (対話プロンプトなし・Paper のみ)
+    python scripts/paper_trading_submit.py --date 2026-06-30 --confirm --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.alpaca_trading import (  # noqa: E402
+    LiveAccountGuardError,
+    assert_paper_env,
+    signals_to_orders,
+    submit_paper_order,
+)
+from scripts.paper_trading_dryrun import load_signals  # noqa: E402
+
+
+def _confirm(prompt: str) -> bool:
+    try:
+        ans = input(f"{prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        return False
+    return ans in ("y", "yes")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", help="対象日 (YYYY-MM-DD)。")
+    parser.add_argument("--signals-csv", help="final_df 形式の signals CSV パス。")
+    parser.add_argument("--equity", type=float, default=100000.0)
+    parser.add_argument("--demo", action="store_true", help="内蔵デモ fixture。")
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="実発注する。無指定では dry-run と等価 (誤爆防止)。",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="各注文の [y/N] 確認をスキップ (無人実行)。--confirm と併用。",
+    )
+    args = parser.parse_args(argv)
+
+    signals = load_signals(args)
+    if signals is None or signals.empty:
+        print("シグナルなし。発注対象はありません。")
+        return 0
+
+    # --confirm 無しは常に dry-run 扱い
+    if not args.confirm:
+        print("[--confirm なし] dry-run モードで実行します (実発注なし)。")
+        orders = signals_to_orders(signals, account_equity=args.equity, dry_run=True)
+        for o in orders:
+            print(" ", o.to_row())
+        print(f"\n合計 {len(orders)} 注文 (dry-run)。実発注は --confirm を付けてください。")
+        return 0
+
+    # ---- ここから実発注経路 ----
+    try:
+        assert_paper_env()  # live fail-fast
+    except LiveAccountGuardError as exc:
+        print(f"[SAFETY ABORT] {exc}")
+        return 2
+
+    print("=== PAPER 実発注モード (ALPACA_PAPER=true 確認済) ===")
+
+    # 変換のみ dry_run=True で行い、確認しながら 1 件ずつ送信する
+    planned = signals_to_orders(signals, account_equity=args.equity, dry_run=True)
+    if not planned:
+        print("発注対象なし。")
+        return 0
+
+    submitted, skipped, failed = 0, 0, 0
+    for po in planned:
+        summary = (
+            f"{po.side.upper()} {po.symbol} x{po.qty} "
+            f"{po.order_type}"
+            + (f"@{po.limit_price}" if po.limit_price else "")
+            + f" tif={po.time_in_force} coid={po.client_order_id}"
+        )
+        if not args.yes and not _confirm(f"送信しますか? {summary}"):
+            print(f"  skip: {summary}")
+            skipped += 1
+            continue
+        try:
+            result = submit_paper_order(
+                po.symbol,
+                po.qty,
+                po.side,
+                order_type=po.order_type,
+                limit_price=po.limit_price,
+                time_in_force=po.time_in_force,
+                client_order_id=po.client_order_id,
+                dry_run=False,
+            )
+            print(f"  OK: {summary} -> id={result.order_id} status={result.status}")
+            submitted += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"  FAIL: {summary} -> {exc}")
+            failed += 1
+
+    print(f"\n完了: 送信={submitted} スキップ={skipped} 失敗={failed}")
+    print("結果は Alpaca Paper dashboard と logs/alpaca_orders_*.log で確認できます。")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alpaca_data_smoke.py
+++ b/tests/test_alpaca_data_smoke.py
@@ -22,6 +22,14 @@ import pytest
 
 from common.alpaca_data import get_alpaca_data
 
+# .env を best-effort で読み込み、live smoke の認証情報検出を可能にする
+try:  # pragma: no cover - dotenv 不在時は環境変数のみ
+    from dotenv import load_dotenv
+
+    load_dotenv(override=False)
+except Exception:
+    pass
+
 # 旧 get_eodhd_data と一致すべき出力スキーマ
 EXPECTED_COLUMNS = ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
 
@@ -128,6 +136,10 @@ def test_get_alpaca_data_schema_offline(monkeypatch):
 
 def test_get_alpaca_data_missing_creds_raises(monkeypatch):
     """認証情報が無ければ ValueError で fail-fast すること。"""
+    # .env の再読込を無効化し、環境変数が真に空の状態を再現する
+    import common.alpaca_data as ad
+
+    monkeypatch.setattr(ad, "_load_env", lambda: None)
     for key in [
         "ALPACA_API_KEY",
         "ALPACA_SECRET_KEY",

--- a/tests/test_alpaca_data_smoke.py
+++ b/tests/test_alpaca_data_smoke.py
@@ -1,0 +1,139 @@
+"""Smoke test for common.alpaca_data.get_alpaca_data.
+
+2 種類のテストを含む:
+
+1. ``test_get_alpaca_data_live_smoke``
+   実際に Alpaca API を叩く smoke test。ALPACA_API_KEY / ALPACA_SECRET_KEY
+   (または APCA_* フォールバック) が未設定なら skip する。
+   直近 Volume の桁数を print し (IEX/SIP 判定材料)、shape/columns/dtypes を検証する。
+
+2. ``test_get_alpaca_data_schema_offline``
+   Alpaca SDK をモックして、認証情報が無い CI 環境でもスキーマ変換ロジック
+   (columns / index tz-naive / dtypes / None 挙動) を検証する。
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from common.alpaca_data import get_alpaca_data
+
+# 旧 get_eodhd_data と一致すべき出力スキーマ
+EXPECTED_COLUMNS = ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+
+_HAS_CREDS = bool(
+    (os.getenv("ALPACA_API_KEY") or os.getenv("APCA_API_KEY_ID"))
+    and (os.getenv("ALPACA_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY"))
+)
+
+
+def _assert_schema(df: pd.DataFrame) -> None:
+    """旧 get_eodhd_data と同一スキーマであることを検証する。"""
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == EXPECTED_COLUMNS, f"columns 不一致: {list(df.columns)}"
+    # index: tz-naive DatetimeIndex, name="Date", 昇順
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert df.index.tz is None, "index は tz-naive でなければならない (EODHD 互換)"
+    assert df.index.name == "Date"
+    assert df.index.is_monotonic_increasing
+    # dtypes: OHLC/AdjClose = float64, Volume = int64
+    for col in ["Open", "High", "Low", "Close", "AdjClose"]:
+        assert df[col].dtype == np.float64, f"{col} dtype={df[col].dtype}"
+    assert df["Volume"].dtype == np.int64, f"Volume dtype={df['Volume'].dtype}"
+
+
+@pytest.mark.skipif(not _HAS_CREDS, reason="Alpaca API 認証情報が未設定のため skip")
+def test_get_alpaca_data_live_smoke(capsys):
+    """AAPL の直近データを実取得し、スキーマと Volume 桁数を検証・print する。"""
+    df = get_alpaca_data("AAPL")
+    assert df is not None and not df.empty, "AAPL の取得に失敗"
+
+    _assert_schema(df)
+
+    recent = df.tail(5)
+    assert len(recent) >= 1
+
+    last_date = recent.index[-1]
+    last_volume = int(recent["Volume"].iloc[-1])
+    n_digits = len(str(abs(last_volume)))
+
+    with capsys.disabled():
+        print("\n===== Alpaca smoke test (AAPL, 直近5営業日) =====")
+        print(recent[EXPECTED_COLUMNS].to_string())
+        print(
+            f"AAPL {last_date.date()} volume: {last_volume:,} = {n_digits} 桁 "
+            f"(feed={os.getenv('ALPACA_FEED', 'iex')})"
+        )
+        print(
+            "判定: IEX feed の Volume は取引所全体の 2-3% のため過小評価。"
+            " EODHD 想定 (7-8 桁) より小さければ IEX。"
+        )
+
+    # 罠3: index が tz-naive の normalize 済 (時刻 00:00) 日付であること
+    assert last_date == last_date.normalize()
+
+
+def test_get_alpaca_data_schema_offline(monkeypatch):
+    """Alpaca SDK をモックし、認証情報無しでもスキーマ変換を検証する。"""
+    monkeypatch.setenv("ALPACA_API_KEY", "dummy")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "dummy")
+
+    # (symbol, timestamp) の MultiIndex, tz-aware UTC を持つ擬似 Alpaca bars.df
+    ts = pd.to_datetime(
+        ["2024-01-02 05:00:00+00:00", "2024-01-03 05:00:00+00:00"], utc=True
+    )
+    index = pd.MultiIndex.from_arrays(
+        [["AAPL", "AAPL"], ts], names=["symbol", "timestamp"]
+    )
+    fake_df = pd.DataFrame(
+        {
+            "open": [100.0, 101.0],
+            "high": [102.0, 103.0],
+            "low": [99.0, 100.0],
+            "close": [101.5, 102.5],
+            "volume": [1234567, 2345678],
+            "trade_count": [10, 20],
+            "vwap": [101.0, 102.0],
+        },
+        index=index,
+    )
+
+    class _FakeBars:
+        df = fake_df
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_stock_bars(self, req):
+            return _FakeBars()
+
+    import alpaca.data.historical as hist
+
+    monkeypatch.setattr(hist, "StockHistoricalDataClient", _FakeClient)
+
+    df = get_alpaca_data("AAPL.US")  # .US サフィックスも受理されること
+    assert df is not None
+    _assert_schema(df)
+    assert len(df) == 2
+    # tz-aware UTC (ET 深夜) → tz-naive の取引日に変換されていること (罠2/罠3)
+    assert list(df.index.strftime("%Y-%m-%d")) == ["2024-01-02", "2024-01-03"]
+    # AdjClose は close にフォールバック (モックは raw/all 同値)
+    assert df["AdjClose"].iloc[0] == pytest.approx(101.5)
+
+
+def test_get_alpaca_data_missing_creds_raises(monkeypatch):
+    """認証情報が無ければ ValueError で fail-fast すること。"""
+    for key in [
+        "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY",
+        "APCA_API_KEY_ID",
+        "APCA_API_SECRET_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(ValueError):
+        get_alpaca_data("AAPL")

--- a/tests/test_alpaca_trading_mock.py
+++ b/tests/test_alpaca_trading_mock.py
@@ -1,0 +1,117 @@
+"""common.alpaca_trading.submit_paper_order の offline mock テスト。
+
+実際の Alpaca 発注は一切行わない。TradingClient を mock/patch して検証する。
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from common import alpaca_trading as at
+from common.alpaca_trading import (
+    LiveAccountGuardError,
+    OrderSubmitError,
+    PreparedOrder,
+    submit_paper_order,
+)
+
+
+@pytest.fixture(autouse=True)
+def _paper_env(monkeypatch):
+    """デフォルトで paper 環境を強制 (テスト間の env 汚染を防ぐ)。"""
+    monkeypatch.setenv("ALPACA_PAPER", "true")
+    monkeypatch.setenv("ALPACA_API_BASE_URL", "https://paper-api.alpaca.markets")
+
+
+def test_dry_run_returns_prepared_order_without_sending():
+    """dry_run=True は PreparedOrder を返すだけで submit を呼ばない。"""
+    with mock.patch.object(at.ba, "get_client") as m_client:
+        po = submit_paper_order("aapl", 10, "buy", dry_run=True)
+    assert isinstance(po, PreparedOrder)
+    assert po.symbol == "AAPL"
+    assert po.qty == 10
+    assert po.side == "buy"
+    assert po.order_id is None  # 未送信
+    m_client.assert_not_called()  # client すら生成されない
+
+
+def test_live_env_fails_fast_on_real_submit(monkeypatch):
+    """ALPACA_PAPER=false + dry_run=False は LiveAccountGuardError。"""
+    monkeypatch.setenv("ALPACA_PAPER", "false")
+    with pytest.raises(LiveAccountGuardError):
+        submit_paper_order("AAPL", 10, "buy", dry_run=False)
+
+
+def test_live_base_url_fails_fast(monkeypatch):
+    """base URL が live を指す場合も fail-fast。"""
+    monkeypatch.setenv("ALPACA_PAPER", "true")
+    monkeypatch.setenv("ALPACA_API_BASE_URL", "https://api.alpaca.markets")
+    with pytest.raises(LiveAccountGuardError):
+        submit_paper_order("AAPL", 10, "buy", dry_run=False)
+
+
+def test_real_submit_passes_client_order_id():
+    """dry_run=False で client_order_id がブローカ層へ伝播することを検証。"""
+    fake_order = mock.Mock()
+    fake_order.id = "order-123"
+    fake_order.status = "accepted"
+    fake_client = mock.Mock()
+
+    with mock.patch.object(at.ba, "get_client", return_value=fake_client), \
+         mock.patch.object(at.ba, "submit_order_with_retry", return_value=fake_order) as m_submit:
+        po = submit_paper_order(
+            "AAPL", 5, "buy",
+            client_order_id="system1-AAPL-20260630",
+            dry_run=False,
+        )
+
+    assert po.order_id == "order-123"
+    assert po.status == "accepted"
+    # client_order_id が確かに渡っている
+    _, kwargs = m_submit.call_args
+    assert kwargs["client_order_id"] == "system1-AAPL-20260630"
+
+
+def test_idempotency_same_client_order_id_is_deterministic():
+    """同一シグナルは同一 client_order_id を生成する (冪等)。"""
+    import pandas as pd
+
+    row = pd.Series({"symbol": "aapl", "system": "System1", "entry_date": "2026-06-30"})
+    a = at._build_client_order_id(row)
+    b = at._build_client_order_id(row)
+    assert a == b == "system1-AAPL-20260630"
+
+
+def test_insufficient_buying_power_raises_order_submit_error():
+    """資金不足エラーは OrderSubmitError に分類される。"""
+    fake_client = mock.Mock()
+
+    def _raise(*a, **k):
+        raise RuntimeError("insufficient buying power for this order")
+
+    with mock.patch.object(at.ba, "get_client", return_value=fake_client), \
+         mock.patch.object(at.ba, "submit_order_with_retry", side_effect=_raise):
+        with pytest.raises(OrderSubmitError, match="資金不足"):
+            submit_paper_order("AAPL", 1000000, "buy", dry_run=False)
+
+
+def test_limit_order_requires_price():
+    with pytest.raises(ValueError, match="limit_price"):
+        submit_paper_order("AAPL", 10, "buy", order_type="limit", dry_run=True)
+
+
+def test_invalid_side_rejected():
+    with pytest.raises(ValueError):
+        submit_paper_order("AAPL", 10, "hold", dry_run=True)
+
+
+def test_audit_log_written_on_dry_run(tmp_path, monkeypatch):
+    """dry_run でも監査ログが追記される。"""
+    monkeypatch.setattr(at, "_LOG_DIR", tmp_path)
+    submit_paper_order("AAPL", 10, "buy", dry_run=True)
+    logs = list(tmp_path.glob("alpaca_orders_*.log"))
+    assert logs, "監査ログが書かれていない"
+    content = logs[0].read_text(encoding="utf-8")
+    assert "AAPL" in content and "dry_run" in content

--- a/tests/test_polygon_data_smoke.py
+++ b/tests/test_polygon_data_smoke.py
@@ -142,7 +142,7 @@ def test_grouped_daily_empty_on_holiday(monkeypatch):
 
 def test_get_polygon_data_missing_creds_raises(monkeypatch):
     monkeypatch.setattr(pg, "_load_env", lambda: None)
-    for key in ["POLYGON_API_KEY", "POLYGON_KEY"]:
+    for key in ["POLYGON_API_KEY", "MASSIVE_API_KEY", "POLYGON_KEY", "MASSIVE_KEY"]:
         monkeypatch.delenv(key, raising=False)
     with pytest.raises(ValueError):
         get_polygon_data("AAPL")

--- a/tests/test_polygon_data_smoke.py
+++ b/tests/test_polygon_data_smoke.py
@@ -1,0 +1,150 @@
+"""Smoke test for common.polygon_data.
+
+- ``test_get_polygon_data_live_smoke`` / ``test_grouped_daily_live_smoke``
+  実際に Polygon API を叩く。POLYGON_API_KEY が未設定なら skip。
+  直近 Volume 桁数を print (full-market なら AAPL は 8 桁 ≒ yfinance 実測 110M)。
+- ``test_get_polygon_data_schema_offline`` / ``test_grouped_daily_schema_offline``
+  requests をモックし、認証情報無しでもスキーマ変換ロジックを検証する。
+- ``test_get_polygon_data_missing_creds_raises``
+  認証情報が無ければ ValueError で fail-fast することを検証。
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import common.polygon_data as pg
+from common.polygon_data import get_polygon_data, get_polygon_grouped_daily
+
+try:  # pragma: no cover - dotenv 不在時は環境変数のみ
+    from dotenv import load_dotenv
+
+    load_dotenv(override=False)
+except Exception:
+    pass
+
+EXPECTED_COLUMNS = ["Open", "High", "Low", "Close", "AdjClose", "Volume"]
+_HAS_KEY = bool(os.getenv("POLYGON_API_KEY") or os.getenv("POLYGON_KEY"))
+
+
+def _assert_schema(df: pd.DataFrame) -> None:
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == EXPECTED_COLUMNS, f"columns 不一致: {list(df.columns)}"
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert df.index.tz is None, "index は tz-naive でなければならない (EODHD 互換)"
+    assert df.index.name == "Date"
+    assert df.index.is_monotonic_increasing
+    for col in ["Open", "High", "Low", "Close", "AdjClose"]:
+        assert df[col].dtype == np.float64, f"{col} dtype={df[col].dtype}"
+    assert df["Volume"].dtype == np.int64, f"Volume dtype={df['Volume'].dtype}"
+
+
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self._p = payload
+        self.status_code = status
+
+    def json(self):
+        return self._p
+
+
+def _agg(t_ms, o, h, l, c, v):
+    return {"t": t_ms, "o": o, "h": h, "l": l, "c": c, "v": v, "vw": c, "n": 1}
+
+
+# 2024-01-02 / 2024-01-03 の ET 深夜を UTC ms で (05:00 UTC)
+_T1 = 1704178800000  # 2024-01-02 05:00:00Z
+_T2 = 1704265200000  # 2024-01-03 05:00:00Z
+
+
+@pytest.mark.skipif(not _HAS_KEY, reason="POLYGON_API_KEY 未設定のため skip")
+def test_get_polygon_data_live_smoke(capsys):
+    df = get_polygon_data("AAPL")
+    assert df is not None and not df.empty, "AAPL の取得に失敗"
+    _assert_schema(df)
+    recent = df.tail(5)
+    last_date = recent.index[-1]
+    last_vol = int(recent["Volume"].iloc[-1])
+    n_digits = len(str(abs(last_vol)))
+    with capsys.disabled():
+        print("\n===== Polygon smoke (AAPL, 直近5営業日) =====")
+        print(recent[EXPECTED_COLUMNS].to_string())
+        print(f"AAPL {last_date.date()} volume: {last_vol:,} = {n_digits} 桁")
+        print("full-market なら 7-8 桁 (yfinance 実測 ~110M = 9桁級) を期待")
+    assert last_date == last_date.normalize()
+
+
+@pytest.mark.skipif(not _HAS_KEY, reason="POLYGON_API_KEY 未設定のため skip")
+def test_grouped_daily_live_smoke(capsys):
+    # 直近の平日を数日遡って試す (祝日/週末を避ける)
+    for back in range(1, 8):
+        date = (pd.Timestamp.utcnow().normalize() - pd.Timedelta(days=back)).strftime("%Y-%m-%d")
+        gd = get_polygon_grouped_daily(date)
+        if not gd.empty:
+            with capsys.disabled():
+                print(f"\n===== Polygon Grouped Daily {date}: 1 request で {len(gd)} 銘柄 =====")
+                print(gd.head(3).to_string())
+            assert gd.index.name == "symbol"
+            assert list(gd.columns) == ["Open", "High", "Low", "Close", "Volume"]
+            assert len(gd) > 1000, "全 US 銘柄なら数千件のはず"
+            return
+    pytest.skip("直近営業日の Grouped Daily が取得できず (休場続き等)")
+
+
+def test_get_polygon_data_schema_offline(monkeypatch):
+    monkeypatch.setenv("POLYGON_API_KEY", "dummy")
+    # raw と adjusted で同一 payload を返す (簡略)
+    payload = {"ticker": "AAPL", "status": "OK", "resultsCount": 2,
+               "results": [_agg(_T1, 100.0, 102.0, 99.0, 101.5, 1234567),
+                           _agg(_T2, 101.0, 103.0, 100.0, 102.5, 2345678)]}
+    monkeypatch.setattr(pg.requests, "get", lambda *a, **k: _FakeResp(payload))
+    monkeypatch.setattr(pg, "_throttle", lambda: None)
+
+    df = get_polygon_data("AAPL.US")  # .US サフィックスも受理
+    assert df is not None
+    _assert_schema(df)
+    assert len(df) == 2
+    assert list(df.index.strftime("%Y-%m-%d")) == ["2024-01-02", "2024-01-03"]
+    assert df["Volume"].iloc[0] == 1234567
+    assert df["AdjClose"].iloc[0] == pytest.approx(101.5)
+
+
+def test_grouped_daily_schema_offline(monkeypatch):
+    monkeypatch.setenv("POLYGON_API_KEY", "dummy")
+    payload = {"status": "OK", "resultsCount": 2, "results": [
+        {"T": "AAPL", "o": 100.0, "h": 102.0, "l": 99.0, "c": 101.5, "v": 1234567, "t": _T1},
+        {"T": "MSFT", "o": 200.0, "h": 205.0, "l": 199.0, "c": 203.0, "v": 987654, "t": _T1},
+    ]}
+    monkeypatch.setattr(pg.requests, "get", lambda *a, **k: _FakeResp(payload))
+    monkeypatch.setattr(pg, "_throttle", lambda: None)
+
+    gd = get_polygon_grouped_daily("2024-01-02")
+    assert gd.index.name == "symbol"
+    assert list(gd.columns) == ["Open", "High", "Low", "Close", "Volume"]
+    assert set(gd.index) == {"AAPL", "MSFT"}
+    assert gd.loc["AAPL", "Volume"] == 1234567
+    assert gd["Volume"].dtype == np.int64
+
+
+def test_grouped_daily_empty_on_holiday(monkeypatch):
+    monkeypatch.setenv("POLYGON_API_KEY", "dummy")
+    payload = {"status": "OK", "resultsCount": 0, "results": []}
+    monkeypatch.setattr(pg.requests, "get", lambda *a, **k: _FakeResp(payload))
+    monkeypatch.setattr(pg, "_throttle", lambda: None)
+    gd = get_polygon_grouped_daily("2024-01-01")  # 元日 = 休場
+    assert gd.empty
+    assert list(gd.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+
+def test_get_polygon_data_missing_creds_raises(monkeypatch):
+    monkeypatch.setattr(pg, "_load_env", lambda: None)
+    for key in ["POLYGON_API_KEY", "POLYGON_KEY"]:
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(ValueError):
+        get_polygon_data("AAPL")
+    with pytest.raises(ValueError):
+        get_polygon_grouped_daily("2024-01-02")

--- a/tests/test_signals_to_orders.py
+++ b/tests/test_signals_to_orders.py
@@ -1,0 +1,113 @@
+"""common.alpaca_trading.signals_to_orders の decision matrix テスト (offline)。
+
+final_df 形式のシグナル → PreparedOrder 変換ロジックを検証する。
+実発注は行わない (すべて dry_run=True)。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from common.alpaca_trading import signals_to_orders
+
+
+@pytest.fixture
+def signals() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            # system1 = market, long -> buy
+            {"symbol": "AAPL", "system": "system1", "side": "long", "shares": 10, "entry_price": 195.0, "entry_date": "2026-06-30"},
+            # system2 = limit, short -> sell (limit_price=entry_price)
+            {"symbol": "TSLA", "system": "system2", "side": "short", "shares": 8, "entry_price": 250.0, "entry_date": "2026-06-30"},
+            # system7 = limit (SPY hedge), short -> sell
+            {"symbol": "SPY", "system": "system7", "side": "short", "shares": 3, "entry_price": 545.0, "entry_date": "2026-06-30"},
+            # shares<=0 -> フィルタされる
+            {"symbol": "ZERO", "system": "system1", "side": "long", "shares": 0, "entry_price": 10.0, "entry_date": "2026-06-30"},
+        ]
+    )
+
+
+def test_side_and_order_type_mapping(signals):
+    orders = signals_to_orders(signals, account_equity=100000.0, dry_run=True)
+    by_sym = {o.symbol: o for o in orders}
+
+    assert "ZERO" not in by_sym  # shares<=0 は除外
+    assert len(orders) == 3
+
+    assert by_sym["AAPL"].side == "buy"
+    assert by_sym["AAPL"].order_type == "market"  # system1
+
+    assert by_sym["TSLA"].side == "sell"
+    assert by_sym["TSLA"].order_type == "limit"  # system2
+    assert by_sym["TSLA"].limit_price == 250.0
+
+    assert by_sym["SPY"].side == "sell"  # sys7 hedge short
+    assert by_sym["SPY"].order_type == "limit"  # system7
+
+
+def test_qty_matches_shares_column(signals):
+    """position sizing は shares 列に委譲され改変されない。"""
+    orders = signals_to_orders(signals, account_equity=50000.0, dry_run=True)
+    by_sym = {o.symbol: o for o in orders}
+    assert by_sym["AAPL"].qty == 10
+    assert by_sym["TSLA"].qty == 8
+    assert by_sym["SPY"].qty == 3
+
+
+def test_client_order_id_generated(signals):
+    orders = signals_to_orders(signals, account_equity=100000.0, dry_run=True)
+    coids = {o.client_order_id for o in orders}
+    assert "system1-AAPL-20260630" in coids
+    assert all(o.client_order_id for o in orders)
+
+
+def test_duplicate_signals_deduplicated():
+    """(symbol, system, entry_date) 重複は 1 注文に統合。"""
+    df = pd.DataFrame(
+        [
+            {"symbol": "AAPL", "system": "system1", "side": "long", "shares": 10, "entry_date": "2026-06-30"},
+            {"symbol": "AAPL", "system": "system1", "side": "long", "shares": 10, "entry_date": "2026-06-30"},
+        ]
+    )
+    orders = signals_to_orders(df, account_equity=100000.0, dry_run=True)
+    assert len(orders) == 1
+
+
+def test_open_position_suppresses_duplicate_buy():
+    """既にロング保有中の銘柄は買い増ししない。"""
+    df = pd.DataFrame(
+        [{"symbol": "AAPL", "system": "system1", "side": "long", "shares": 10, "entry_date": "2026-06-30"}]
+    )
+    orders = signals_to_orders(
+        df, account_equity=100000.0, dry_run=True, open_positions={"AAPL": 10.0}
+    )
+    assert orders == []
+
+
+def test_open_position_allows_opposite_side():
+    """ショート保有中に long シグナルは (ドテン) 許可される。"""
+    df = pd.DataFrame(
+        [{"symbol": "AAPL", "system": "system1", "side": "long", "shares": 10, "entry_date": "2026-06-30"}]
+    )
+    orders = signals_to_orders(
+        df, account_equity=100000.0, dry_run=True, open_positions={"AAPL": -5.0}
+    )
+    assert len(orders) == 1
+    assert orders[0].side == "buy"
+
+
+def test_empty_or_missing_shares_returns_empty():
+    assert signals_to_orders(pd.DataFrame(), account_equity=1.0, dry_run=True) == []
+    no_shares = pd.DataFrame([{"symbol": "AAPL", "system": "system1", "side": "long"}])
+    assert signals_to_orders(no_shares, account_equity=1.0, dry_run=True) == []
+
+
+def test_limit_without_price_falls_back_to_market():
+    """limit システムでも entry_price が無ければ market にフォールバック。"""
+    df = pd.DataFrame(
+        [{"symbol": "TSLA", "system": "system2", "side": "short", "shares": 5, "entry_date": "2026-06-30"}]
+    )
+    orders = signals_to_orders(df, account_equity=100000.0, dry_run=True)
+    assert orders[0].order_type == "market"
+    assert orders[0].limit_price is None


### PR DESCRIPTION
## 目的
EODHD 有料 API ($20/月) を **Alpaca 無料 IEX feed** に置換し、月額データコストを **$0 化**する。
戦略ロジック (`core/system1`〜`core/system7`, `CacheManager`) は**無改造**。データ取得コードのみ差替。

## 変更内容
- **`common/alpaca_data.py`** (新規): `get_alpaca_data(symbol)` を追加。旧 `get_eodhd_data(symbol)` の **drop-in replacement**。
  - signature / columns (`Open, High, Low, Close, AdjClose, Volume`) / index (`DatetimeIndex(name="Date", tz-naive, 昇順)`) / dtypes (OHLC・AdjClose=float64, Volume=int64) が**完全一致**。
  - 認証情報未設定なら `ValueError` で fail-fast、取得失敗時は `None` (EODHD 互換)。
  - feed は default `iex`。SIP ($99/月) は既定 OFF。無料 tier のレート制限 (200 req/min) 対応の簡易 throttle 入り。
- **`scripts/cache_daily_data.py`**: `get_eodhd_data` の呼出箇所は **grep で 1 か所**と判明 (orchestrator の "2か所" は概算) → `get_alpaca_data` に差替 (import 含む、最小 diff)。旧 `get_eodhd_data` 定義は legacy として残置。
- **`common/stooq_data.py`** (新規): IEX 出来高過小時の無料フォールバック **stub (未実装、TODO)**。
- **`tests/test_alpaca_data_smoke.py`** (新規): live smoke (creds 無なら skip) + offline スキーマ検証 + fail-fast 検証。
- **`.env.example`**: `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` 追加、`EODHD_API_KEY` は *(deprecated, retained for legacy scripts)* 明記。
- **`README.md`**: "データソース (Data source)" 章を新設 (Alpaca 切替 / API key 取得先 / IEX feed default / 出来高過小の既知の罠)。
- **`requirements.txt`**: `alpaca-py>=0.30.0` に pin。

## 罠対応
- **罠4 (symbol format)**: `_to_alpaca_symbol()` で `.US` suffix 除去 (`AAPL.US` → `AAPL`)。
- **罠2/罠3 (tz / 日足 timestamp)**: Alpaca の tz-aware UTC bar timestamp を America/New_York に変換 → tz-naive 正規化。EODHD の取引日 (tz-naive 00:00) と一致。offline test で `2024-01-02` 等の日付一致を検証。
- **AdjClose**: raw + `adjustment='all'` の 2 リクエストで EODHD の `close` (未調整) / `adjusted_close` (調整済) を再現。調整値取得失敗時は `AdjClose=Close` にフォールバック。

## テスト
- 新規 smoke test ファイル単体: **2 passed / 1 skipped** (skip = live smoke、API key 要)。
- フルスイート: `211 failed / 1290 passed / 59 skipped`。この **211 failed は完全に pre-existing** — 本変更を `git stash` したクリーンツリーで同一コマンドを実行しても `211 failed / 1290 passed` で**完全一致** → **自変更起因の新規 failure はゼロ**。失敗原因は既存の repo drift (`common.cache_manager_old` 削除、`core.system4._compute_indicators` 削除等、Alpaca と無関係)。

## ⚠️ SIP/IEX 判定 (review 前 checklist — 要 user API key)
IEX feed の出来高は NASDAQ/NYSE 全体の **2〜3% しか反映されない** → Volume 過小 → `min ADV` 系流動性フィルタが全銘柄棄却するリスクあり。ホストに Alpaca 認証情報が無く live smoke が skip のため、**Volume 桁数の実測は未完了**。

**review 前 checklist:**
- [ ] `.env` に `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` を設定
- [ ] `pytest tests/test_alpaca_data_smoke.py -s` を実行し、直近 **Volume 桁数を実測**
- [ ] 桁数が EODHD 想定 (概ね 7〜8 桁) より 1〜2 桁小さければ IEX 過小評価が顕在化 → 以下を判断:
  - **SIP feed に切替** (`ALPACA_FEED=sip`、有料 $99/月)、または
  - **stooq フォールバック実装** (`common/stooq_data.py`、無料・日足のみ)

Draft PR。上記 checklist の実測・判定後に ready for review へ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
