### PR TITLE
fix(ci): docs-check の markdown-link-check に base-branch: main を追加

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -38,6 +38,11 @@ jobs:
                   file-path: "./README.md, ./CHANGELOG.md, ./CONTRIBUTING.md"
                   max-depth: -1
                   check-modified-files-only: "yes"
+                  # Repo default branch is `main`; the action otherwise defaults
+                  # base-branch to `master`, which does not exist here and makes
+                  # every docs-touching PR fail with
+                  # "fatal: couldn't find remote ref master".
+                  base-branch: "main"
 
     markdown-lint:
         runs-on: ubuntu-latest

--- a/docs/ci_docs_check_base_branch_fix_20260709.md
+++ b/docs/ci_docs_check_base_branch_fix_20260709.md
@@ -1,0 +1,24 @@
+# docs-check の markdown-link-check base-branch 修正 (2026-07-09)
+
+## 背景
+
+`.github/workflows/docs-check.yml` の markdown-link-check ステップは
+`check-modified-files-only: "yes"` を使うが `base-branch` を指定して
+いなかった。この action の既定 `base-branch` は `master` で、本リポジトリ
+の既定ブランチは `main` のため、変更ファイルの算出時に
+`fatal: couldn't find remote ref master` で失敗していた。
+
+docs 系ファイル (`docs/**/*.md`, `README.md`, `CHANGELOG.md`,
+`CONTRIBUTING.md`) を触る全 PR / push で再現するワークフロー設定バグ。
+
+## 修正
+
+markdown-link-check の `with` に `base-branch: "main"` を明示追加。
+他の docs-check 設定 (config-file, folder-path, file-path,
+check-modified-files-only, continue-on-error など) は不変。
+
+## 検証
+
+この doc 追加自体が docs-check ワークフローを trigger し、
+`base-branch: "main"` で変更ファイル算出が成功することを確認するための
+リンクを含まない最小ドキュメント。


### PR DESCRIPTION
## 概要

`docs-check.yml` の markdown-link-check ステップは `check-modified-files-only: "yes"` を使うが `base-branch` を未指定で、action `gaurav-nelson/github-action-markdown-link-check@v1` の既定 `base-branch` は `master`。本リポジトリの既定ブランチは `main` のため、変更ファイル算出時に `fatal: couldn't find remote ref master` で失敗し、docs 系ファイルを触る全 PR / push で markdown-link-check が赤になっていた（`continue-on-error: true` で非ブロッキングだが常時ノイズ）。

## 変更

- `with:` に `base-branch: "main"` を明示追加。
- 他の docs-check 設定（`config-file` / `folder-path` / `file-path` / `check-modified-files-only` / `continue-on-error`）は不変。
- 行末は LF 維持（既存 blob と一致、churn なし）。
- 検証用にリンクを含まない最小ドキュメント `docs/ci_docs_check_base_branch_fix_20260709.md` を同梱し、docs-check ワークフローを trigger して `base-branch=main` で markdown-link-check が緑になることを本 PR の CI で確認する。

## 影響

発注・paper 挙動には一切関与しない CI ワークフロー設定のみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
