### PR TITLE
fix(exit): 端株ポジションが exit にかからない silent-drop を修正

### DIFF
--- a/common/alpaca_trading.py
+++ b/common/alpaca_trading.py
@@ -1137,6 +1137,14 @@ _PROTECT_TRAIL_SUFFIX = "protect-trail"
 _PROTECT_TARGET_SUFFIX = "protect-target"
 _EXIT_TIME_SUFFIX = "exit-time"
 _EXIT_BREAKOUT_SUFFIX = "exit-breakout"
+# 端株 (fractional) 用 synthetic protection の coid suffix。Alpaca は端株に
+# native stop/limit/trailing を出せないため、日次 exit_check で現値が stop/target
+# を突破していれば成行DAYの全数クローズをこの suffix で 1 件だけ発注する。
+_EXIT_SYN_STOP_SUFFIX = "exit-synstop"
+_EXIT_SYN_TARGET_SUFFIX = "exit-syntarget"
+
+# 整数株判定の許容誤差。float 表現誤差 (例 5.0000000001) は整数株として扱う。
+_QTY_WHOLE_TOL = 1e-9
 
 
 class ExitReasonCode:
@@ -1168,8 +1176,52 @@ class PositionSnapshot:
     entry_date: str | None = None  # ISO date "YYYY-MM-DD"
 
     @property
-    def abs_qty(self) -> int:
-        return int(abs(self.qty))
+    def abs_qty(self) -> float:
+        """符号なしの実 position qty (端株を保持する)。
+
+        以前は ``int(abs(self.qty))`` で端株 (qty<1 や小数株) を 0 に切り捨て、
+        ``build_exit_orders_from_positions`` の ``if snap.abs_qty <= 0`` により
+        time / breakout / protection の全 exit 種別から **silent 除外** していた
+        (2026-07-12 端株 exit 未計画バグ)。equity 連動サイジングは端株を日常的に
+        作るため、多数の建玉が閉じられなくなっていた。切り捨てを廃止する。
+        """
+        return abs(float(self.qty))
+
+    @property
+    def is_fractional(self) -> bool:
+        """整数株でない (端株) かどうか。
+
+        Alpaca は端株に native な stop/limit/trailing を出せず成行 DAY のみ
+        受け付ける。整数株は従来どおり native protection を発注し、端株は
+        synthetic (日次現値突破→成行 DAY 全数クローズ) へ振り分ける判定に使う。
+        """
+        aq = self.abs_qty
+        return abs(aq - round(aq)) > _QTY_WHOLE_TOL
+
+    @property
+    def current_price(self) -> float | None:
+        """market_value / qty から現値を逆算する (Alpaca live quote 由来)。
+
+        market_value が無い / qty=0 なら None。synthetic stop/target の突破
+        判定に使う (取得不能なら synthetic は発注しない safe fallback)。
+        """
+        if self.market_value is None:
+            return None
+        aq = self.abs_qty
+        if aq <= 0:
+            return None
+        return abs(float(self.market_value)) / aq
+
+    def exit_qty(self) -> float:
+        """exit order に載せる qty。整数株は int、端株は float(9桁丸め) を返す。
+
+        整数株を int で返すのは native stop/limit・既存 JSON/ログの後方互換を
+        壊さないため。端株は Alpaca が最大 9 桁小数まで受け付ける。
+        """
+        aq = self.abs_qty
+        if not self.is_fractional:
+            return int(round(aq))
+        return round(aq, 9)
 
 
 @dataclass(slots=True)
@@ -1181,7 +1233,7 @@ class PreparedExit:
 
     symbol: str
     system: str
-    qty: int
+    qty: float  # 整数株は int、端株は小数 (Alpaca は端株を成行DAYのみ受付)
     side: str  # "buy" (short cover) or "sell" (long close)
     order_type: str  # "market" / "stop" / "trailing_stop" / "limit"
     reason: str  # ExitReasonCode.*
@@ -1370,7 +1422,7 @@ def _build_time_exit(
     return PreparedExit(
         symbol=snap.symbol,
         system=snap.system or "unknown",
-        qty=snap.abs_qty,
+        qty=snap.exit_qty(),
         side=close_side,
         order_type="market",
         reason=ExitReasonCode.TIME,
@@ -1406,7 +1458,7 @@ def _build_spy_breakout_exit(
     return PreparedExit(
         symbol=snap.symbol,
         system=snap.system or "system7",
-        qty=snap.abs_qty,
+        qty=snap.exit_qty(),
         side=close_side,
         order_type="market",
         reason=ExitReasonCode.BREAKOUT,
@@ -1414,6 +1466,45 @@ def _build_spy_breakout_exit(
         client_order_id=coid,
         dry_run=True,
     )
+
+
+def _stop_price_for(
+    snap: PositionSnapshot, rules: Any, atr_value: float | None
+) -> float | None:
+    """ATR ベースの protective stop 価格。ATR 無し / rules 無しなら None。
+
+    long: entry - stop_dist (最低 0.01), short: entry + stop_dist。
+    native protection (整数株) と synthetic (端株) の双方から使う共通式。
+    """
+    if rules is None or atr_value is None or atr_value <= 0:
+        return None
+    stop_dist = float(atr_value) * float(rules.stop_atr_multiplier)
+    if snap.side == "long":
+        return max(0.01, snap.avg_entry_price - stop_dist)
+    return snap.avg_entry_price + stop_dist
+
+
+def _target_price_for(
+    snap: PositionSnapshot, rules: Any, atr_value: float | None
+) -> float | None:
+    """profit target 価格 (S2/S3/S6=%, S5=ATR)。target 未定義なら None。
+
+    native protection (整数株) と synthetic (端株) の双方から使う共通式。
+    """
+    if rules is None:
+        return None
+    ttype = getattr(rules, "profit_target_type", "none")
+    if ttype == "percentage" and rules.profit_target_value > 0:
+        mult = 1.0 + (float(rules.profit_target_value) / 100.0)
+        if snap.side == "long":
+            return snap.avg_entry_price * mult
+        return snap.avg_entry_price / mult
+    if ttype == "atr" and atr_value is not None and atr_value > 0:
+        dist = float(atr_value) * float(rules.profit_target_value)
+        if snap.side == "long":
+            return snap.avg_entry_price + dist
+        return snap.avg_entry_price - dist
+    return None
 
 
 def _build_protection_orders(
@@ -1445,7 +1536,7 @@ def _build_protection_orders(
                 PreparedExit(
                     symbol=snap.symbol,
                     system=snap.system,
-                    qty=snap.abs_qty,
+                    qty=snap.exit_qty(),
                     side=close_side,
                     order_type="trailing_stop",
                     reason=ExitReasonCode.PROTECT_TRAIL,
@@ -1458,12 +1549,8 @@ def _build_protection_orders(
             )
 
     # stop-loss (全 system): ATR ベース。ATR 値が無いと計算できないので skip。
-    if atr_value is not None and atr_value > 0:
-        stop_dist = float(atr_value) * float(rules.stop_atr_multiplier)
-        if snap.side == "long":
-            stop_price = max(0.01, snap.avg_entry_price - stop_dist)
-        else:
-            stop_price = snap.avg_entry_price + stop_dist
+    stop_price = _stop_price_for(snap, rules, atr_value)
+    if stop_price is not None:
         coid = (
             f"protect-{snap.system}-{snap.symbol}-{entry_date_compact}-"
             f"{_PROTECT_STOP_SUFFIX}"
@@ -1473,7 +1560,7 @@ def _build_protection_orders(
                 PreparedExit(
                     symbol=snap.symbol,
                     system=snap.system,
-                    qty=snap.abs_qty,
+                    qty=snap.exit_qty(),
                     side=close_side,
                     order_type="stop",
                     reason=ExitReasonCode.PROTECT_STOP,
@@ -1486,20 +1573,7 @@ def _build_protection_orders(
             )
 
     # profit target (S2/S3/S6 = %, S5 = ATR)
-    target_price: float | None = None
-    ttype = getattr(rules, "profit_target_type", "none")
-    if ttype == "percentage" and rules.profit_target_value > 0:
-        mult = 1.0 + (float(rules.profit_target_value) / 100.0)
-        if snap.side == "long":
-            target_price = snap.avg_entry_price * mult
-        else:
-            target_price = snap.avg_entry_price / mult
-    elif ttype == "atr" and atr_value is not None and atr_value > 0:
-        dist = float(atr_value) * float(rules.profit_target_value)
-        if snap.side == "long":
-            target_price = snap.avg_entry_price + dist
-        else:
-            target_price = snap.avg_entry_price - dist
+    target_price = _target_price_for(snap, rules, atr_value)
     if target_price is not None and target_price > 0:
         coid = (
             f"protect-{snap.system}-{snap.symbol}-{entry_date_compact}-"
@@ -1510,7 +1584,7 @@ def _build_protection_orders(
                 PreparedExit(
                     symbol=snap.symbol,
                     system=snap.system,
-                    qty=snap.abs_qty,
+                    qty=snap.exit_qty(),
                     side=close_side,
                     order_type="limit",
                     reason=ExitReasonCode.PROTECT_TARGET,
@@ -1525,9 +1599,119 @@ def _build_protection_orders(
     return proposals
 
 
+def _build_synthetic_protection_orders(
+    snap: PositionSnapshot,
+    rules: Any,
+    *,
+    atr_value: float | None,
+    current_price: float | None,
+    today: str,
+    existing_exit_coids: set[str],
+) -> list[PreparedExit]:
+    """端株 (fractional) position 用の synthetic 保護 exit を返す。
+
+    Alpaca は端株に native な stop/limit/trailing を出せない (成行 DAY のみ)。
+    そこで日次 exit_check 時に現値が stop / target を突破していれば、成行 DAY の
+    **全数クローズを 1 件だけ** 発注する (synthetic stop / synthetic target)。
+    突破していなければ何も出さず、翌 run で再評価する。
+
+    設計上の割り切り:
+      - trailing stop は HWM 状態が必要で stateless では合成できないため、
+        ATR stop-loss で下方を代替する (S1/S4 の端株も ATR stop で保護)。
+      - stop と target が同時に突破することは無い (long: stop<entry<target、
+        short: target<entry<stop) ので、二重クローズは起きない。優先は stop。
+      - close は full qty・成行 DAY・決定的 coid。同日再 run は同一 coid で
+        Alpaca 側 422 duplicate となり二重発注しない (existing_exit_coids に
+        含まれていれば発注自体を skip する二重防止も併設)。
+      - 現値が不明 (market_value も rolling Close も無い) なら発注しない
+        (safe fallback = 何もしない。満期は time-exit が別途カバーする)。
+    """
+    if rules is None or snap.system is None:
+        return []
+    if current_price is None or current_price <= 0:
+        logger.debug(
+            "synthetic exit skip: %s 現値不明 (market_value/rolling Close 無し)",
+            snap.symbol,
+        )
+        return []
+
+    close_side = "sell" if snap.side == "long" else "buy"
+    qty = snap.exit_qty()
+    date_compact = today.replace("-", "")
+
+    # (1) synthetic stop (ATR ベース)。突破していれば即クローズ。
+    stop_price = _stop_price_for(snap, rules, atr_value)
+    if stop_price is not None:
+        breached = (
+            current_price <= stop_price
+            if snap.side == "long"
+            else current_price >= stop_price
+        )
+        if breached:
+            coid = (
+                f"exit-{snap.system}-{snap.symbol}-{date_compact}-"
+                f"{_EXIT_SYN_STOP_SUFFIX}"
+            )
+            if coid in existing_exit_coids:
+                return []
+            return [
+                PreparedExit(
+                    symbol=snap.symbol,
+                    system=snap.system,
+                    qty=qty,
+                    side=close_side,
+                    order_type="market",
+                    reason=ExitReasonCode.PROTECT_STOP,
+                    entry_date=snap.entry_date,
+                    stop_price=round(stop_price, 4),
+                    client_order_id=coid,
+                    dry_run=True,
+                    time_in_force="day",
+                )
+            ]
+
+    # (2) synthetic target。突破していれば即クローズ。
+    target_price = _target_price_for(snap, rules, atr_value)
+    if target_price is not None and target_price > 0:
+        breached = (
+            current_price >= target_price
+            if snap.side == "long"
+            else current_price <= target_price
+        )
+        if breached:
+            coid = (
+                f"exit-{snap.system}-{snap.symbol}-{date_compact}-"
+                f"{_EXIT_SYN_TARGET_SUFFIX}"
+            )
+            if coid in existing_exit_coids:
+                return []
+            return [
+                PreparedExit(
+                    symbol=snap.symbol,
+                    system=snap.system,
+                    qty=qty,
+                    side=close_side,
+                    order_type="market",
+                    reason=ExitReasonCode.PROTECT_TARGET,
+                    entry_date=snap.entry_date,
+                    limit_price=round(target_price, 4),
+                    client_order_id=coid,
+                    dry_run=True,
+                    time_in_force="day",
+                )
+            ]
+
+    return []
+
+
 # -----------------------------------------------------------------------
 # top-level: build all exit proposals from positions
 # -----------------------------------------------------------------------
+
+
+def _coid_already_open(po: PreparedExit, existing_exit_coids: set[str]) -> bool:
+    """既に同一 client_order_id の exit- 注文が open なら True (二重発注防止)。"""
+    return bool(po.client_order_id) and po.client_order_id in existing_exit_coids
 
 
 def build_exit_orders_from_positions(
@@ -1537,16 +1721,25 @@ def build_exit_orders_from_positions(
     tracker: dict[str, Any] | None = None,
     entry_orders_index: dict[str, dict[str, Any]] | None = None,
     existing_protect_coids: set[str] | None = None,
+    existing_exit_coids: set[str] | None = None,
     spy_high: float | None = None,
     spy_max70: float | None = None,
     atr_by_symbol: dict[str, dict[int, float]] | None = None,
+    price_by_symbol: dict[str, float] | None = None,
 ) -> list[PreparedExit]:
     """position snapshots から exit 発注案を build する pure function。
 
     - time-based (S2/S3/S5/S6): holding_days >= max_holding_days なら 成行 close
     - SPY breakout (S7): spy_high >= spy_max70 なら 翌寄成行 close
-    - protection: 未発注 (existing_protect_coids に無い) なら trailing/stop/target を発注
+    - protection (整数株): 未発注 (existing_protect_coids に無い) なら
+      trailing/stop/target を native で発注
+    - protection (端株): native 不可のため synthetic (現値が stop/target を
+      突破していれば成行 DAY 全数クローズ) を発注
     - S1/S4 は time-based 無いので protection のみ
+
+    現値は snapshot.current_price (market_value/qty) を優先し、無い場合は
+    price_by_symbol (rolling Close 等) を fallback に使う。existing_exit_coids
+    に既に open な exit- coid があれば time/breakout/synthetic を skip (二重防止)。
 
     副作用なし。dry_run=True で返す。実発注 / dry_run flag は呼び出し側が差し替える。
     """
@@ -1556,7 +1749,9 @@ def build_exit_orders_from_positions(
         entry_orders_index=entry_orders_index,
     )
     existing_coids = existing_protect_coids or set()
+    existing_exit = existing_exit_coids or set()
     atr_lookup = atr_by_symbol or {}
+    price_lookup = price_by_symbol or {}
 
     out: list[PreparedExit] = []
     for snap in snapshots:
@@ -1586,17 +1781,35 @@ def build_exit_orders_from_positions(
             atr_value = per_atr.get(int(rules.stop_atr_period))
         protection: list[PreparedExit] = []
         if rules is not None and time_exit is None and breakout_exit is None:
-            protection = _build_protection_orders(
-                snap,
-                rules,
-                atr_value=atr_value,
-                existing_protect_coids=existing_coids,
-            )
+            if snap.is_fractional:
+                # 端株: native stop/limit/trailing 不可 → synthetic
+                # (現値が stop/target を突破していれば成行 DAY 全数クローズ)。
+                cur_px = snap.current_price
+                if cur_px is None:
+                    cur_px = price_lookup.get(snap.symbol)
+                protection = _build_synthetic_protection_orders(
+                    snap,
+                    rules,
+                    atr_value=atr_value,
+                    current_price=cur_px,
+                    today=today,
+                    existing_exit_coids=existing_exit,
+                )
+            else:
+                protection = _build_protection_orders(
+                    snap,
+                    rules,
+                    atr_value=atr_value,
+                    existing_protect_coids=existing_coids,
+                )
 
-        # (3) 優先順位: time/breakout の close order > protection 発注
-        if time_exit is not None:
+        # (3) 優先順位: time/breakout の close order > protection 発注。
+        # 既に同一 exit- coid が open (existing_exit) なら二重発注しない。
+        if time_exit is not None and not _coid_already_open(time_exit, existing_exit):
             out.append(time_exit)
-        if breakout_exit is not None:
+        if breakout_exit is not None and not _coid_already_open(
+            breakout_exit, existing_exit
+        ):
             out.append(breakout_exit)
         out.extend(protection)
 
@@ -1619,9 +1832,19 @@ def submit_paper_exit_order(
 ) -> PreparedExit:
     """1 件の PreparedExit を Alpaca Paper に発注する。dry_run=True で送信 skip。"""
     if po.qty <= 0:
-        raise ValueError(f"exit qty は正の整数: {po.qty}")
+        raise ValueError(f"exit qty は正の数: {po.qty}")
     if po.side not in ("buy", "sell"):
         raise ValueError(f"exit side は 'buy'/'sell': {po.side!r}")
+    # 端株 (整数株でない qty) は Alpaca 上、成行 DAY でしか約定できない。native
+    # stop/limit/trailing を端株で送ると reject されるため、silent に落ちる前に
+    # fail-fast する (回帰ガード)。builder は端株を market/day のみで生成する。
+    _frac_qty = abs(float(po.qty) - round(float(po.qty))) > _QTY_WHOLE_TOL
+    if _frac_qty and (po.order_type != "market" or po.time_in_force.lower() != "day"):
+        raise ValueError(
+            "端株 exit は成行DAYのみ: "
+            f"{po.symbol} qty={po.qty} order_type={po.order_type} "
+            f"tif={po.time_in_force}"
+        )
 
     po.dry_run = dry_run
     if dry_run:
@@ -1657,7 +1880,7 @@ def submit_paper_exit_order(
     po.status = str(getattr(order, "status", "") or "")
     _audit_log({"event": "exit_submitted", **po.to_row()})
     logger.info(
-        "Paper exit submitted: %s %s x%d %s id=%s status=%s reason=%s",
+        "Paper exit submitted: %s %s x%s %s id=%s status=%s reason=%s",
         po.side,
         po.symbol,
         po.qty,
@@ -1721,6 +1944,29 @@ def fetch_existing_protect_coids(client: Any) -> set[str]:
     return out
 
 
+def fetch_existing_exit_coids(client: Any) -> set[str]:
+    """Alpaca の open orders から exit- (time/breakout/synthetic) coid を集める。
+
+    端株の synthetic クローズや time-exit の成行注文が同日再 run で二重発注
+    されないよう、既に open な ``exit-`` 系 coid を dedup 材料として返す。
+    エラー時は空集合 (safe fallback = Alpaca 側の 422 duplicate に委ねる)。
+    """
+    out: set[str] = set()
+    try:
+        orders = ba.get_open_orders(client)
+    except Exception as exc:  # pragma: no cover
+        logger.warning("open orders 取得失敗 (exit coids): %s", exc)
+        return out
+    for o in orders or []:
+        try:
+            coid = str(getattr(o, "client_order_id", "") or "")
+            if coid.startswith("exit-"):
+                out.add(coid)
+        except Exception:
+            continue
+    return out
+
+
 __all__ = [
     "PreparedOrder",
     "PreparedExit",
@@ -1758,4 +2004,5 @@ __all__ = [
     "submit_paper_exit_order",
     "submit_paper_exit_orders",
     "fetch_existing_protect_coids",
+    "fetch_existing_exit_coids",
 ]

--- a/scripts/paper_exit_check.py
+++ b/scripts/paper_exit_check.py
@@ -43,6 +43,7 @@ from common.alpaca_trading import (  # noqa: E402
     PreparedExit,
     assert_paper_env,
     build_exit_orders_from_positions,
+    fetch_existing_exit_coids,
     fetch_existing_protect_coids,
     fetch_position_snapshots,
     parse_entry_date_from_client_order_id,
@@ -201,6 +202,39 @@ def _load_atr_by_symbol(symbols: list[str]) -> dict[str, dict[int, float]]:
     return out
 
 
+def _load_price_by_symbol(symbols: list[str]) -> dict[str, float]:
+    """rolling CSV の latest Close を symbol 別に取得 (端株 synthetic の現値 fallback)。
+
+    通常は snapshot.current_price (market_value/qty) が優先されるが、Alpaca が
+    market_value を返さない場合の fallback に使う。取得不能な symbol は省く。
+    """
+    out: dict[str, float] = {}
+    rolling_dir = ROOT / "data_cache" / "rolling"
+    if not rolling_dir.exists():
+        return out
+    for sym in symbols:
+        f = rolling_dir / f"{sym}.csv"
+        if not f.exists():
+            continue
+        try:
+            df = pd.read_csv(f)
+        except Exception:
+            continue
+        if df.empty:
+            continue
+        tail = df.iloc[-1]
+        for col in ("Close", "close", "adj_close", "Adj Close"):
+            if col in df.columns:
+                try:
+                    val = float(tail.get(col, 0) or 0)
+                    if val > 0:
+                        out[sym] = val
+                        break
+                except (TypeError, ValueError):
+                    continue
+    return out
+
+
 # -------------------------------------------------------------------------
 # main
 # -------------------------------------------------------------------------
@@ -285,6 +319,7 @@ def main(argv: list[str] | None = None) -> int:
     client: Any | None = None
     snapshots: list[PositionSnapshot] = []
     existing_protect_coids: set[str] = set()
+    existing_exit_coids: set[str] = set()
 
     if not args.no_alpaca:
         if args.confirm:
@@ -302,16 +337,19 @@ def main(argv: list[str] | None = None) -> int:
     if client is not None:
         snapshots = fetch_position_snapshots(client)
         existing_protect_coids = fetch_existing_protect_coids(client)
+        existing_exit_coids = fetch_existing_exit_coids(client)
         _hydrate_from_alpaca_coids(snapshots, client)
 
     # --- 2) tracker / entry_orders_index --------------------------------
     tracker = load_tracker()
     entry_orders_index = _collect_entry_orders_index(results_dir)
 
-    # --- 3) context (SPY, ATR) ------------------------------------------
+    # --- 3) context (SPY, ATR, 現値) ------------------------------------
     spy_high, spy_max70 = _load_spy_context()
     symbols = [s.symbol for s in snapshots]
     atr_by_symbol = _load_atr_by_symbol(symbols) if symbols else {}
+    # 端株 synthetic の現値 fallback (snapshot.current_price を優先)。
+    price_by_symbol = _load_price_by_symbol(symbols) if symbols else {}
 
     # --- 4) build exit proposals ----------------------------------------
     exits = build_exit_orders_from_positions(
@@ -320,9 +358,11 @@ def main(argv: list[str] | None = None) -> int:
         tracker=tracker,
         entry_orders_index=entry_orders_index,
         existing_protect_coids=existing_protect_coids,
+        existing_exit_coids=existing_exit_coids,
         spy_high=spy_high,
         spy_max70=spy_max70,
         atr_by_symbol=atr_by_symbol,
+        price_by_symbol=price_by_symbol,
     )
 
     dry_run = not args.confirm

--- a/tests/test_alpaca_exit_fractional.py
+++ b/tests/test_alpaca_exit_fractional.py
@@ -1,0 +1,370 @@
+"""端株 (fractional share) exit の回帰テスト (2026-07-12 silent-drop バグ修正)。
+
+背景:
+    equity 連動サイジングは端株 (qty<1 / 小数株) を日常的に作る。旧実装は
+    ``PositionSnapshot.abs_qty = int(abs(qty))`` で端株を 0 に切り捨て、
+    ``build_exit_orders_from_positions`` の ``if snap.abs_qty <= 0`` により
+    time / breakout / protection の **全 exit 種別から silent 除外** していた
+    (system3 の満期 6 建玉が exit 未計画になった)。
+
+抑えるべき仕様:
+    - abs_qty は端株を保持 (切り捨てない)。exit_qty は整数株=int / 端株=float。
+    - 端株の time / breakout / synthetic protection は必ず成行 DAY。
+    - 端株 protection は native 不可 → synthetic (現値が stop/target を突破
+      した時だけ成行 DAY 全数クローズを 1 件)。二重クローズしない。
+    - 整数株 (whole) は従来どおり native stop/limit/trailing (gtc) を維持。
+    - existing_exit_coids で同日再 run の二重発注を防ぐ。
+    - submit_paper_exit_order は端株×非(成行DAY) を fail-fast する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.alpaca_trading import (
+    ExitReasonCode,
+    PositionSnapshot,
+    PreparedExit,
+    build_exit_orders_from_positions,
+    submit_paper_exit_order,
+)
+
+# -------------------------------------------------------------------------
+# PositionSnapshot: abs_qty / is_fractional / current_price / exit_qty
+# -------------------------------------------------------------------------
+
+
+def _snap(
+    symbol,
+    system,
+    side,
+    qty,
+    entry_price,
+    entry_date,
+    *,
+    current_price=None,
+) -> PositionSnapshot:
+    """符号付き qty と (任意で) 現値から market_value を逆算した snapshot を作る。"""
+    signed_qty = qty if side == "long" else -qty
+    mv = None
+    if current_price is not None:
+        # long は +、short は - の market_value (Alpaca 準拠)。current_price は abs で復元。
+        mv = current_price * signed_qty
+    return PositionSnapshot(
+        symbol=symbol,
+        qty=signed_qty,
+        side=side,
+        avg_entry_price=entry_price,
+        market_value=mv,
+        system=system,
+        entry_date=entry_date,
+    )
+
+
+class TestSnapshotQtyHelpers:
+    def test_abs_qty_preserves_fraction(self):
+        assert PositionSnapshot("X", 0.5, "long", 1.0).abs_qty == pytest.approx(0.5)
+        assert PositionSnapshot("X", 3.7, "long", 1.0).abs_qty == pytest.approx(3.7)
+        assert PositionSnapshot("X", -0.25, "short", 1.0).abs_qty == pytest.approx(0.25)
+        assert PositionSnapshot("X", 5.0, "long", 1.0).abs_qty == pytest.approx(5.0)
+
+    def test_is_fractional(self):
+        assert PositionSnapshot("X", 0.5, "long", 1.0).is_fractional is True
+        assert PositionSnapshot("X", 3.7, "long", 1.0).is_fractional is True
+        assert PositionSnapshot("X", 5.0, "long", 1.0).is_fractional is False
+        # float 表現誤差は整数株扱い
+        assert PositionSnapshot("X", 5.0000000001, "long", 1.0).is_fractional is False
+
+    def test_exit_qty_whole_is_int_fraction_is_float(self):
+        whole = PositionSnapshot("X", 8.0, "long", 1.0).exit_qty()
+        assert whole == 8 and isinstance(whole, int)
+        frac = PositionSnapshot("X", 0.512345678, "long", 1.0).exit_qty()
+        assert isinstance(frac, float)
+        assert frac == pytest.approx(0.512345678)
+
+    def test_current_price_roundtrip(self):
+        s = _snap("X", "system3", "long", 0.5, 100.0, "2026-07-01", current_price=94.0)
+        assert s.current_price == pytest.approx(94.0)
+        # short: market_value は負でも abs で現値復元
+        s2 = _snap("X", "system6", "short", 0.5, 30.0, "2026-07-01", current_price=32.0)
+        assert s2.current_price == pytest.approx(32.0)
+
+    def test_current_price_none_when_no_market_value(self):
+        s = PositionSnapshot("X", 0.5, "long", 100.0, market_value=None)
+        assert s.current_price is None
+
+
+# -------------------------------------------------------------------------
+# 端株の time-exit (system3 満期 6 建玉の再現) — 旧実装は silent drop
+# -------------------------------------------------------------------------
+
+
+class TestFractionalTimeExit:
+    def test_fractional_long_time_exit_fires_as_market_day(self):
+        # system3 long 端株 0.512、満期 (holding=3 >= max_holding_days=3)
+        snap = _snap("AEHR", "system3", "long", 0.512, 100.0, "2026-06-29")
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"AEHR": {10: 2.0}}
+        )
+        time_exits = [e for e in exits if e.reason == ExitReasonCode.TIME]
+        assert len(time_exits) == 1, "端株の time-exit が silent drop されている"
+        te = time_exits[0]
+        assert te.side == "sell"
+        assert te.order_type == "market"
+        assert te.time_in_force == "day"  # 端株は成行 DAY 必須
+        assert te.qty == pytest.approx(0.512)
+
+    def test_fractional_position_is_not_dropped(self):
+        # 旧バグの核: qty<1 の建玉が exit 案から丸ごと消える回帰ガード
+        snap = _snap("AIP", "system3", "long", 0.3, 50.0, "2026-06-29")
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"AIP": {10: 1.0}}
+        )
+        assert (
+            exits
+        ), "端株建玉が exit 案から丸ごと除外されている (旧 int() 切り捨てバグ)"
+
+    def test_six_maturity_positions_all_planned(self):
+        # system3 満期 6 建玉 (AEHR/AIP/FORM/MXL/UCTT/VECO) が全て time-exit される
+        syms = ["AEHR", "AIP", "FORM", "MXL", "UCTT", "VECO"]
+        snaps = [_snap(s, "system3", "long", 0.4, 40.0, "2026-06-29") for s in syms]
+        atr = {s: {10: 1.0} for s in syms}
+        exits = build_exit_orders_from_positions(
+            snaps, today="2026-07-02", atr_by_symbol=atr
+        )
+        planned = {e.symbol for e in exits if e.reason == ExitReasonCode.TIME}
+        assert planned == set(syms)
+        assert all(e.order_type == "market" and e.time_in_force == "day" for e in exits)
+
+
+# -------------------------------------------------------------------------
+# 端株の synthetic protection (native stop/limit 不可)
+# -------------------------------------------------------------------------
+
+
+class TestFractionalSyntheticProtection:
+    def test_synthetic_stop_fires_on_breach(self):
+        # system3 long 端株、未満期。stop=100-2*2.5=95。現値94<=95 → synthetic stop
+        snap = _snap(
+            "MXL", "system3", "long", 0.5, 100.0, "2026-07-01", current_price=94.0
+        )
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"MXL": {10: 2.0}}
+        )
+        stops = [e for e in exits if e.reason == ExitReasonCode.PROTECT_STOP]
+        assert len(stops) == 1
+        s = stops[0]
+        assert s.order_type == "market"  # native "stop" ではなく成行
+        assert s.time_in_force == "day"
+        assert s.side == "sell"
+        assert s.qty == pytest.approx(0.5)
+        assert s.stop_price == pytest.approx(95.0)
+        assert s.client_order_id and s.client_order_id.endswith("exit-synstop")
+
+    def test_synthetic_stop_not_fired_when_price_above_stop(self):
+        snap = _snap(
+            "MXL", "system3", "long", 0.5, 100.0, "2026-07-01", current_price=96.0
+        )
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"MXL": {10: 2.0}}
+        )
+        assert exits == []  # stop(95) 未突破 & target(104) 未突破 → 何も出さない
+
+    def test_synthetic_target_fires_on_breach(self):
+        # target=100*1.04=104。現値105 → synthetic target (stop95 は未突破)
+        snap = _snap(
+            "UCTT", "system3", "long", 0.5, 100.0, "2026-07-01", current_price=105.0
+        )
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"UCTT": {10: 2.0}}
+        )
+        tgts = [e for e in exits if e.reason == ExitReasonCode.PROTECT_TARGET]
+        assert len(tgts) == 1
+        t = tgts[0]
+        assert t.order_type == "market" and t.time_in_force == "day"
+        assert t.limit_price == pytest.approx(104.0)
+        assert t.client_order_id and t.client_order_id.endswith("exit-syntarget")
+
+    def test_synthetic_short_stop_fires_on_breach(self):
+        # system6 short 端株、未満期。stop=30+1*3=33。現値34>=33 → synthetic stop (buy)
+        snap = _snap(
+            "GME", "system6", "short", 0.5, 30.0, "2026-07-01", current_price=34.0
+        )
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"GME": {10: 1.0}}
+        )
+        stops = [e for e in exits if e.reason == ExitReasonCode.PROTECT_STOP]
+        assert len(stops) == 1
+        assert stops[0].side == "buy"  # short cover
+        assert stops[0].order_type == "market"
+
+    def test_synthetic_skipped_when_current_price_unknown(self):
+        # market_value も price_by_symbol も無い → synthetic は発注しない (safe fallback)
+        snap = PositionSnapshot(
+            "MXL",
+            0.5,
+            "long",
+            100.0,
+            market_value=None,
+            system="system3",
+            entry_date="2026-07-01",
+        )
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"MXL": {10: 2.0}}
+        )
+        assert exits == []
+
+    def test_synthetic_uses_price_by_symbol_fallback(self):
+        # market_value 無しでも price_by_symbol が現値を供給すれば synthetic 判定できる
+        snap = PositionSnapshot(
+            "MXL",
+            0.5,
+            "long",
+            100.0,
+            market_value=None,
+            system="system3",
+            entry_date="2026-07-01",
+        )
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-02",
+            atr_by_symbol={"MXL": {10: 2.0}},
+            price_by_symbol={"MXL": 94.0},
+        )
+        stops = [e for e in exits if e.reason == ExitReasonCode.PROTECT_STOP]
+        assert len(stops) == 1
+        assert stops[0].order_type == "market"
+
+
+# -------------------------------------------------------------------------
+# 二重クローズ防止
+# -------------------------------------------------------------------------
+
+
+class TestNoDoubleClose:
+    def test_time_exit_beats_synthetic_single_close(self):
+        # 満期 かつ 現値がストップ突破でも、close は time-exit 1 件のみ
+        snap = _snap(
+            "AEHR", "system3", "long", 0.5, 100.0, "2026-06-29", current_price=90.0
+        )
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"AEHR": {10: 2.0}}
+        )
+        assert len(exits) == 1
+        assert exits[0].reason == ExitReasonCode.TIME
+
+    def test_existing_exit_coid_dedups_time_exit(self):
+        snap = _snap("AEHR", "system3", "long", 0.5, 100.0, "2026-06-29")
+        coid = "exit-system3-AEHR-20260702-exit-time"
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-02",
+            atr_by_symbol={"AEHR": {10: 2.0}},
+            existing_exit_coids={coid},
+        )
+        assert exits == []  # 既に open なので二重発注しない
+
+    def test_existing_exit_coid_dedups_synthetic(self):
+        snap = _snap(
+            "MXL", "system3", "long", 0.5, 100.0, "2026-07-01", current_price=94.0
+        )
+        coid = "exit-system3-MXL-20260702-exit-synstop"
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-02",
+            atr_by_symbol={"MXL": {10: 2.0}},
+            existing_exit_coids={coid},
+        )
+        assert exits == []
+
+
+# -------------------------------------------------------------------------
+# 整数株 (whole) 回帰: native protection を維持
+# -------------------------------------------------------------------------
+
+
+class TestWholeShareRegression:
+    def test_whole_long_keeps_native_gtc_protection(self):
+        # system1 整数株 long → native trailing_stop + stop (gtc)。synthetic に落ちない
+        snap = _snap("AAPL", "system1", "long", 10, 195.0, "2026-07-01")
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"AAPL": {20: 3.0}}
+        )
+        by_reason = {e.reason: e for e in exits}
+        assert ExitReasonCode.PROTECT_TRAIL in by_reason
+        assert ExitReasonCode.PROTECT_STOP in by_reason
+        assert by_reason[ExitReasonCode.PROTECT_TRAIL].order_type == "trailing_stop"
+        assert by_reason[ExitReasonCode.PROTECT_STOP].order_type == "stop"
+        # 整数株は gtc の resting order (成行 DAY ではない)
+        assert all(e.time_in_force == "gtc" for e in exits)
+        # qty は int 型
+        assert all(isinstance(e.qty, int) for e in exits)
+
+    def test_whole_time_exit_qty_is_int(self):
+        snap = _snap("TSLA", "system2", "short", 8, 250.0, "2026-06-30")
+        exits = build_exit_orders_from_positions(
+            [snap], today="2026-07-02", atr_by_symbol={"TSLA": {10: 5.0}}
+        )
+        te = [e for e in exits if e.reason == ExitReasonCode.TIME]
+        assert len(te) == 1
+        assert te[0].qty == 8 and isinstance(te[0].qty, int)
+
+
+# -------------------------------------------------------------------------
+# submit ガード (端株 × 非成行DAY は fail-fast)
+# -------------------------------------------------------------------------
+
+
+class TestSubmitFractionalGuards:
+    def _frac_market(self) -> PreparedExit:
+        return PreparedExit(
+            symbol="MXL",
+            system="system3",
+            qty=0.5,
+            side="sell",
+            order_type="market",
+            reason=ExitReasonCode.TIME,
+            time_in_force="day",
+            client_order_id="exit-system3-MXL-20260702-exit-time",
+        )
+
+    def test_fractional_market_day_dry_run_ok(self):
+        po = self._frac_market()
+        result = submit_paper_exit_order(po, dry_run=True)
+        assert result.dry_run is True
+        assert result.order_id is None
+
+    def test_fractional_stop_order_type_rejected(self):
+        po = self._frac_market()
+        po.order_type = "stop"
+        po.stop_price = 95.0
+        with pytest.raises(ValueError):
+            submit_paper_exit_order(po, dry_run=True)
+
+    def test_fractional_gtc_rejected(self):
+        po = self._frac_market()
+        po.time_in_force = "gtc"
+        with pytest.raises(ValueError):
+            submit_paper_exit_order(po, dry_run=True)
+
+    def test_zero_qty_still_rejected(self):
+        po = self._frac_market()
+        po.qty = 0
+        with pytest.raises(ValueError):
+            submit_paper_exit_order(po, dry_run=True)
+
+    def test_whole_share_stop_still_allowed(self):
+        # 整数株の native stop は従来どおり許可 (端株ガードに引っかからない)
+        po = PreparedExit(
+            symbol="AAPL",
+            system="system1",
+            qty=10,
+            side="sell",
+            order_type="stop",
+            reason=ExitReasonCode.PROTECT_STOP,
+            stop_price=180.0,
+            time_in_force="gtc",
+            client_order_id="protect-system1-AAPL-20260701-protect-stop",
+        )
+        result = submit_paper_exit_order(po, dry_run=True)
+        assert result.dry_run is True


### PR DESCRIPTION
## 概要
端株 (fractional share) ポジションが exit にかからず **silent-drop** されるバグを修正 (paper 専用・ライブ発注なし)。

## 根因
`PositionSnapshot.abs_qty` が `int(abs(self.qty))` で端株 (qty<1 / 小数株) を **0 に切り捨て**、`build_exit_orders_from_positions` の `if snap.abs_qty <= 0: continue` により **time / breakout / protection の全 exit 種別から silent 除外**されていた。equity 連動サイジングは端株を日常的に作るため、system3 の満期 6 建玉 (AEHR/AIP/FORM/MXL/UCTT/VECO) を含む多数が閉じられなくなっていた (safety-net の exit_verify が検出)。

## 修正
- **`abs_qty` を float 化**（切り捨て廃止）。`is_fractional` / `current_price`(=market_value/qty) / `exit_qty()`(整数株=int, 端株=float 9桁) を追加。`PreparedExit.qty` を float 許容に。
- **端株の time / breakout** は成行 DAY で全数クローズ。**整数株は従来どおり native stop/limit/trailing (gtc) を維持**（回帰安全）。
- **端株 protection** は Alpaca が native stop/limit/trailing を出せないため `_build_synthetic_protection_orders` を新設。日次現値が ATR stop / target を突破した時だけ **成行 DAY 全数クローズを 1 件**（決定的 coid `exit-synstop`/`exit-syntarget`）。trailing は stateless 合成不可のため ATR stop で代替。stop/target 価格式は `_stop_price_for`/`_target_price_for` に共通化。
- **二重クローズ防止**: `fetch_existing_exit_coids` + `existing_exit_coids` で time/breakout/synthetic を dedup。position 毎に単一クローズ（time 発火時は protection skip、stop と target は同時突破しない）。
- **`submit_paper_exit_order`**: 端株×非(成行DAY) を fail-fast、qty float 対応、ログ `%d`→`%s`。
- **`paper_exit_check.py`**: 現値 (rolling Close) fallback と existing_exit_coids を配線。

## 検証
- 新規 `tests/test_alpaca_exit_fractional.py` (端株 long/short の time/synthetic、二重クローズ無し、整数株回帰、submit ガード) + 既存 exit テスト = **54 passed**。周辺 qty/snapshot テスト **87 passed**（回帰なし）。
- 実ビルダー通しのドライラン: 満期6建玉→time_based market/day、端株 long stop/target・端株 short cover の synthetic、整数株 native、全件 submit(dry_run) ガード通過。
- pinned lint (black 25.9.0 / ruff 0.14.1 / isort) ローカル緑。

## スコープ外（別対応）
Streamlit UI の exit 経路 (`apps/app_today_signals.py` L2576/L4175) にも同型の切り捨てが残るが、Streamlit UI は廃止 (Vercel 移行) で live 未使用のため **WONTFIX**（`docs/HUMAN_TASK_streamlit_tailscale_20260701.md` に記録）。

paper 専用・ライブ発注なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
