### PR TITLE
fix(pipeline): unfreeze daily cache/rolling + silent-freeze guard

### DIFF
--- a/common/cache_freshness.py
+++ b/common/cache_freshness.py
@@ -1,0 +1,176 @@
+"""Cache freshness / advancement guards.
+
+Encodes the failure mode behind the 2026-07-12..14 dashboard freeze: the daily
+pipeline kept reporting success (exit 0) while the rolling cache never advanced —
+signals recomputed the same stale snapshot every day (a *silent no-op*), and no
+guard flagged it.
+
+These pure helpers operate on lightweight "manifests" — ``{symbol: {"last_date":
+"YYYY-MM-DD", "n_rows": int, ...}}`` — so they are cheap to run over a whole cache
+dir and trivial to unit-test with synthetic data (no network, no real cache).
+
+Intended uses:
+  * post-fetch / post-rolling-rebuild: assert something actually advanced
+    (``is_silent_noop``) and nothing regressed (``detect_regressions``);
+  * daily freshness monitor: compare rolling vs its upstream (full_backup/base)
+    and warn when rolling lags (``lag_business_days``).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+
+def _to_date(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.strptime(str(s)[:10], "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def max_last_date(manifest: dict[str, dict]) -> str | None:
+    """Newest ``last_date`` across all symbols, or None if the manifest is empty."""
+    dates = [v.get("last_date") for v in manifest.values() if v and v.get("last_date")]
+    return max(dates) if dates else None
+
+
+def modal_last_date(manifest: dict[str, dict]) -> str | None:
+    """Most common ``last_date`` (ties broken toward the newer date).
+
+    Robust to a single fresh file (which fools ``max_last_date``) and to a long
+    tail of delisted names: the actively-traded bulk dominates the mode.
+    """
+    from collections import Counter
+
+    c = Counter(
+        v.get("last_date") for v in manifest.values() if v and v.get("last_date")
+    )
+    if not c:
+        return None
+    return max(c.items(), key=lambda kv: (kv[1], kv[0] or ""))[0]
+
+
+def detect_regressions(before: dict[str, dict], after: dict[str, dict]) -> list[str]:
+    """Symbols whose last_date moved BACKWARD or whose row count shrank.
+
+    Either signals that a write destroyed past bars — the opposite of the
+    "monotonic non-decreasing per file" contract the cache must uphold.
+    """
+    bad: list[str] = []
+    for sym, a in after.items():
+        b = before.get(sym)
+        if not b:
+            continue
+        bd, ad = _to_date(b.get("last_date")), _to_date(a.get("last_date"))
+        if bd and ad and ad < bd:
+            bad.append(sym)
+            continue
+        b_rows, a_rows = b.get("n_rows"), a.get("n_rows")
+        if (
+            isinstance(b_rows, int)
+            and isinstance(a_rows, int)
+            and b_rows > 0
+            and a_rows < b_rows
+        ):
+            bad.append(sym)
+    return bad
+
+
+def count_advanced(before: dict[str, dict], after: dict[str, dict]) -> int:
+    """How many symbols advanced their last_date (or are newly present with data)."""
+    advanced = 0
+    for sym, a in after.items():
+        ad = _to_date(a.get("last_date"))
+        if ad is None:
+            continue
+        b = before.get(sym)
+        if b is None:
+            advanced += 1
+            continue
+        bd = _to_date(b.get("last_date"))
+        if bd is None or ad > bd:
+            advanced += 1
+    return advanced
+
+
+def is_silent_noop(
+    before: dict[str, dict], after: dict[str, dict], *, min_advanced: int = 1
+) -> bool:
+    """True when an "update" ran but (almost) nothing advanced.
+
+    A healthy fetch/rebuild on a business day advances at least ``min_advanced``
+    symbols. Zero advancement while claiming success is the silent-freeze bug.
+    """
+    return count_advanced(before, after) < max(1, int(min_advanced))
+
+
+def symbols_behind_upstream(
+    derived: dict[str, dict],
+    upstream: dict[str, dict],
+    *,
+    universe: set[str] | None = None,
+) -> list[str]:
+    """Symbols whose derived (rolling) last_date is OLDER than their upstream's.
+
+    This is the robust freeze signal: comparing max-date-vs-max-date is fooled by a
+    single fresh file, and comparing medians is dragged down by delisted names that
+    legitimately stopped trading. Per-symbol lag counts only symbols that fell behind
+    *their own* upstream — delisted names (equally old upstream) are not counted.
+
+    ``universe`` (optional) restricts the comparison to the signal universe, so
+    symbols that are fetched into full_backup but intentionally NOT rebuilt into
+    rolling (e.g. ETFs / non-common names outside the trading universe) do not
+    masquerade as a freeze.
+    """
+    behind: list[str] = []
+    for sym, u in upstream.items():
+        if universe is not None and sym not in universe:
+            continue
+        d = derived.get(sym)
+        if not d:
+            continue
+        du, dd = _to_date(u.get("last_date")), _to_date(d.get("last_date"))
+        if du and dd and dd < du:
+            behind.append(sym)
+    return behind
+
+
+def fraction_behind_upstream(
+    derived: dict[str, dict],
+    upstream: dict[str, dict],
+    *,
+    universe: set[str] | None = None,
+) -> float:
+    """Fraction of shared symbols whose derived cache lags its upstream (0.0..1.0)."""
+    common = [
+        s for s in upstream if s in derived and (universe is None or s in universe)
+    ]
+    if not common:
+        return 0.0
+    return len(symbols_behind_upstream(derived, upstream, universe=universe)) / len(
+        common
+    )
+
+
+def lag_business_days(newest: str | None, reference: str | None) -> int | None:
+    """Business-day gap between ``reference`` (expected newest) and ``newest``.
+
+    Positive => the cache lags the reference by that many weekdays (freeze signal).
+    ``None`` if either date is unparseable.
+    """
+    n, r = _to_date(newest), _to_date(reference)
+    if n is None or r is None:
+        return None
+    if r <= n:
+        return 0
+    days = 0
+    cur = n
+    from datetime import timedelta
+
+    while cur < r:
+        cur += timedelta(days=1)
+        if cur.weekday() < 5:  # Mon-Fri
+            days += 1
+    return days

--- a/scripts/check_rolling_freshness.py
+++ b/scripts/check_rolling_freshness.py
@@ -1,0 +1,179 @@
+"""Rolling-cache freshness guard (daily pipeline WARN step).
+
+Would have caught the 2026-07-12..14 dashboard freeze: rolling cache stuck while
+the pipeline reported success. Compares the newest date in the rolling cache
+against its upstream (full_backup) and warns when rolling lags by more than a
+tolerance in business days.
+
+Exit codes: 0 = fresh, 2 = stale (WARN — pipeline keeps going but flags it),
+1 = error (couldn't read caches).
+
+Deliberately cheap: reads only the last line of each CSV (no full parse).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.cache_freshness import (  # noqa: E402
+    fraction_behind_upstream,
+    lag_business_days,
+    max_last_date,
+    modal_last_date,
+    symbols_behind_upstream,
+)
+
+
+def _load_universe(path: Path | None) -> set[str] | None:
+    if path is None or not path.is_file():
+        return None
+    syms: set[str] = set()
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            s = line.strip().upper()
+            if s and not s.startswith("#"):
+                syms.add(s)
+    except OSError:
+        return None
+    return syms or None
+
+
+def _last_date_of_csv(path: str) -> str | None:
+    try:
+        with open(path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            if size == 0:
+                return None
+            block = min(size, 4096)
+            f.seek(size - block)
+            tail = f.read(block)
+        lines = [ln for ln in tail.split(b"\n") if ln.strip()]
+        if not lines:
+            return None
+        row = lines[-1].decode("utf-8", "replace")
+        for field in row.split(",")[:2]:
+            c = field.strip().strip('"')
+            if len(c) >= 10 and c[4] == "-" and c[7] == "-":
+                return c[:10]
+    except OSError:
+        return None
+    return None
+
+
+def scan_last_dates(cache_dir: Path) -> dict[str, dict]:
+    manifest: dict[str, dict] = {}
+    if not cache_dir.is_dir():
+        return manifest
+    with os.scandir(cache_dir) as it:
+        for entry in it:
+            if entry.is_file() and entry.name.endswith(".csv"):
+                manifest[entry.name[:-4]] = {"last_date": _last_date_of_csv(entry.path)}
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Rolling cache freshness guard.")
+    p.add_argument("--rolling-dir", default=None)
+    p.add_argument("--upstream-dir", default=None, help="full_backup dir (reference)")
+    p.add_argument(
+        "--tolerance-bdays",
+        type=int,
+        default=1,
+        help="max acceptable business-day lag (max-date, contextual only)",
+    )
+    p.add_argument(
+        "--max-frac-behind",
+        type=float,
+        default=0.05,
+        help="WARN if more than this fraction of universe symbols lag upstream",
+    )
+    p.add_argument(
+        "--universe-file",
+        default=None,
+        help="signal universe (one symbol/line); scopes the freeze check "
+        "so non-universe ETFs are not counted. default data/universe_auto.txt",
+    )
+    args = p.parse_args(argv)
+
+    try:
+        from config.settings import get_settings
+
+        s = get_settings(create_dirs=False)
+        rolling_dir = Path(args.rolling_dir or s.cache.rolling_dir)
+        upstream_dir = Path(args.upstream_dir or s.cache.full_dir)
+    except Exception as exc:  # noqa: BLE001
+        if args.rolling_dir and args.upstream_dir:
+            rolling_dir = Path(args.rolling_dir)
+            upstream_dir = Path(args.upstream_dir)
+        else:
+            print(f"[freshness] ERROR: cannot resolve cache dirs: {exc}")
+            return 1
+
+    rolling = scan_last_dates(rolling_dir)
+    upstream = scan_last_dates(upstream_dir)
+    if not rolling or not upstream:
+        print(
+            f"[freshness] ERROR: empty cache (rolling={len(rolling)} upstream={len(upstream)})"
+        )
+        return 1
+
+    # Resolve signal universe (scopes out non-universe ETFs fetched into full_backup
+    # but intentionally not rebuilt into rolling).
+    uni_path = (
+        Path(args.universe_file)
+        if args.universe_file
+        else (ROOT_DIR / "data" / "universe_auto.txt")
+    )
+    universe = _load_universe(uni_path)
+
+    r_mode, u_mode = modal_last_date(rolling), modal_last_date(upstream)
+    mode_lag = lag_business_days(r_mode, u_mode)
+
+    print(
+        f"[freshness] rolling modal={r_mode} (max={max_last_date(rolling)}, {len(rolling)} files) | "
+        f"upstream modal={u_mode} (max={max_last_date(upstream)}, {len(upstream)} files)"
+    )
+
+    if universe:
+        behind = symbols_behind_upstream(rolling, upstream, universe=universe)
+        frac = fraction_behind_upstream(rolling, upstream, universe=universe)
+        n_common = sum(1 for s in upstream if s in rolling and s in universe)
+        print(
+            f"[freshness] universe={uni_path.name} ({len(universe)}); "
+            f"behind {len(behind)}/{n_common} ({frac:.2%}); sample={behind[:8]}"
+        )
+        if frac > args.max_frac_behind:
+            print(
+                f"[freshness] WARN: {frac:.1%} of universe symbols lag upstream "
+                f"(> {args.max_frac_behind:.0%}). rolling cache は前進していません "
+                f"(凍結の疑い)。build_rolling_with_indicators.py の実行を確認してください。"
+            )
+            return 2
+        print("[freshness] OK: rolling universe is fresh relative to upstream.")
+        return 0
+
+    # No universe file: fall back to modal-date comparison (robust to noise).
+    print("[freshness] (universe file absent; using modal-date comparison)")
+    if mode_lag is None:
+        print("[freshness] ERROR: unparseable modal dates")
+        return 1
+    if mode_lag > args.tolerance_bdays:
+        print(
+            f"[freshness] WARN: rolling modal date lags upstream by {mode_lag} "
+            f"business days (凍結の疑い)。build_rolling_with_indicators.py を確認。"
+        )
+        return 2
+    print("[freshness] OK: rolling modal date is fresh relative to upstream.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/daily_pipeline.ps1
+++ b/scripts/daily_pipeline.ps1
@@ -67,6 +67,7 @@ param(
     [string]$Date = "",
     [string]$Symbols = "",
     [switch]$SkipCache = $false,
+    [switch]$SkipRollingSync = $false,
     [switch]$SkipNarrator = $false,
     [switch]$SkipPublish = $false,
     [switch]$DryRunPublish = $false,
@@ -190,13 +191,44 @@ try {
         Write-Log "[cache] SkipCache 指定によりスキップ"
     }
     else {
+        # --auto-latest: 「今日」を要求して Polygon 403 (当日 EOD 前) で空振りするのを避け、
+        # full_backup 最新日の翌取引日〜直近 NYSE 取引日 (実際に取得可能な確定日) を対象にする。
+        # (旧実装 --start/--end $Date は 06:00 JST 時点で当日 EOD 未確定→403→full_backup が
+        #  一切前進せず rolling 凍結の主因になっていた。2026-07-14 修正)
         $cacheArgs = @(
             (Join-Path $ProjectRoot "scripts\cache_daily_polygon.py"),
-            "--start", $Date, "--end", $Date
+            "--auto-latest"
         )
         $c = Invoke-Step -Name "cache" -PyArgs $cacheArgs
         if ($c -ne 0) { $Failures += "cache(exit=$c)" }
     }
+
+    # --- Step 1b: rolling sync (full_backup/base -> rolling) -------------
+    # cache step は full_backup + base のみ更新し、signals が読む rolling は更新しない。
+    # 取得したばかりの確定日を signals に反映させるため rolling を同期する。
+    # (未同期だと rolling が古いままで最新営業日チェックが全銘柄を除外し 0 signals に、
+    #  あるいは古いスナップショットを毎日再計算する凍結状態になる。2026-07-14 修正)
+    if ($SkipRollingSync) {
+        Write-Log "[rolling_sync] SkipRollingSync 指定によりスキップ"
+    }
+    else {
+        $rsArgs = @(
+            (Join-Path $ProjectRoot "scripts\build_rolling_with_indicators.py")
+        )
+        $rs = Invoke-Step -Name "rolling_sync" -PyArgs $rsArgs
+        if ($rs -ne 0) { $Failures += "rolling_sync(exit=$rs)" }
+    }
+
+    # --- Step 1c: freshness guard (silent-freeze detector) --------------
+    # rolling が full_backup に対して前進しているかを検証。停滞 (exit=2) は $Failures に
+    # 積んで WARN 通知を発火させる。これが無いと「全 step OK」を出しつつ古いスナップショットを
+    # 毎日再計算する silent freeze (2026-07-12..14 のダッシュ凍結) を検知できない。
+    $fgArgs = @(
+        (Join-Path $ProjectRoot "scripts\check_rolling_freshness.py")
+    )
+    $fg = Invoke-Step -Name "freshness_guard" -PyArgs $fgArgs
+    if ($fg -eq 2) { $Failures += "freshness_guard(rolling_stale)" }
+    elseif ($fg -eq 1) { Write-Log "[freshness_guard] WARN: 検査自体が失敗 (exit=1)" }
 
     # --- Step 2: signals -------------------------------------------------
     $sigArgs = @(

--- a/scripts/publish_data_to_vercel.ps1
+++ b/scripts/publish_data_to_vercel.ps1
@@ -150,9 +150,42 @@ if ($NoPush) {
     exit 0
 }
 
-& git push origin $Branch 2>&1 | ForEach-Object { Write-Log $_ }
-if ($LASTEXITCODE -ne 0) {
-    Write-Log "ERROR: git push 失敗 (exit=$LASTEXITCODE)"
+# 2026-07-14 fix (root cause B): local $Branch が origin より遅れていると push が
+# non-fast-forward で reject され、data commit は溜まる一方で Vercel には永遠に届かず
+# ダッシュが凍結する (07-12 で停止していた原因)。しかも daily_main_follow は
+# generate 側の exit code しか見ないため「push 失敗」が silent に握り潰されていた。
+# 対策: push が失敗したら fetch + rebase (autostash で dirty tree を退避) して origin
+# 先頭に data commit を載せ替え、1 回だけ retry する。それでも駄目なら LOUD に fail。
+function Invoke-PushWithRebaseHeal {
+    & git push origin $Branch 2>&1 | ForEach-Object { Write-Log $_ }
+    if ($LASTEXITCODE -eq 0) { return $true }
+
+    Write-Log "WARN: push rejected (likely non-fast-forward). fetch + rebase-onto-origin で自己修復を試行。"
+    & git fetch origin $Branch 2>&1 | ForEach-Object { Write-Log $_ }
+    # autostash で未コミット作業ツリーを退避しつつ、ローカルの data commit を origin 先頭へ rebase。
+    & git -c rebase.autostash=true rebase "origin/$Branch" 2>&1 | ForEach-Object { Write-Log $_ }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log "ERROR: rebase 失敗 (conflict?)。abort して手動対応が必要。"
+        & git rebase --abort 2>&1 | ForEach-Object { Write-Log $_ }
+        return $false
+    }
+    Write-Log "rebase 成功。origin 先頭へ載せ替え済み。push を retry。"
+    & git push origin $Branch 2>&1 | ForEach-Object { Write-Log $_ }
+    return ($LASTEXITCODE -eq 0)
+}
+
+if (-not (Invoke-PushWithRebaseHeal)) {
+    Write-Log "ERROR: git push 失敗 (self-heal 後も未 push)。ダッシュボードは更新されません。"
+    # LOUD 通知: silent success を避ける。NTFY_TOPIC があれば WARN を飛ばす。
+    if ($env:NTFY_TOPIC) {
+        $base = if ($env:NTFY_URL) { $env:NTFY_URL.TrimEnd('/') } else { "https://ntfy.sh" }
+        try {
+            $h = @{ "X-Title" = "publish_data PUSH FAIL $Date"; "X-Priority" = "5"; "X-Tags" = "warning" }
+            Invoke-RestMethod -Uri "$base/$($env:NTFY_TOPIC)" -Method Post -Headers $h `
+                -Body "dashboard data push failed (non-FF/self-heal exhausted): $Branch $Date" | Out-Null
+        }
+        catch { Write-Log "ntfy WARN 送信失敗: $_" }
+    }
     exit 1
 }
 

--- a/tests/test_cache_freshness_guard.py
+++ b/tests/test_cache_freshness_guard.py
@@ -1,0 +1,141 @@
+"""Regression tests for the cache-freshness guards (2026-07-14 dashboard freeze).
+
+These lock in detection of the exact failure mode that froze the dashboard at
+2026-07-12: the rolling cache stopped advancing while the pipeline still reported
+success, so signals recomputed the same stale snapshot forever (a silent no-op),
+and past bars must never be destroyed by a rebuild (monotonic non-decreasing).
+"""
+
+from __future__ import annotations
+
+from common.cache_freshness import (
+    count_advanced,
+    detect_regressions,
+    fraction_behind_upstream,
+    is_silent_noop,
+    lag_business_days,
+    max_last_date,
+    modal_last_date,
+    symbols_behind_upstream,
+)
+
+
+def _mf(**kw):
+    """Build a manifest {sym: {"last_date":..., "n_rows":...}} from sym=date pairs."""
+    return {sym: {"last_date": d, "n_rows": 100} for sym, d in kw.items()}
+
+
+def test_max_last_date_and_empty():
+    assert max_last_date(_mf(SPY="2026-07-10", BNY="2026-07-08")) == "2026-07-10"
+    assert max_last_date({}) is None
+
+
+def test_silent_noop_detected_when_nothing_advances():
+    # byte-identical before/after == the freeze: signals rehash the same day.
+    before = _mf(SPY="2026-07-08", BNY="2026-07-08", AAPL="2026-07-08")
+    after = _mf(SPY="2026-07-08", BNY="2026-07-08", AAPL="2026-07-08")
+    assert is_silent_noop(before, after) is True
+    assert count_advanced(before, after) == 0
+
+
+def test_advancement_is_not_a_noop():
+    before = _mf(SPY="2026-07-08", BNY="2026-07-08", AAPL="2026-07-08")
+    after = _mf(SPY="2026-07-10", BNY="2026-07-10", AAPL="2026-07-10")
+    assert is_silent_noop(before, after) is False
+    assert count_advanced(before, after) == 3
+
+
+def test_partial_advance_below_threshold_flagged():
+    before = _mf(A="2026-07-08", B="2026-07-08", C="2026-07-08")
+    after = _mf(A="2026-07-10", B="2026-07-08", C="2026-07-08")
+    assert count_advanced(before, after) == 1
+    assert is_silent_noop(before, after) is False  # 1 >= default min_advanced=1
+    assert is_silent_noop(before, after, min_advanced=2) is True
+
+
+def test_newly_present_symbol_counts_as_advanced():
+    before = _mf(A="2026-07-08")
+    after = _mf(A="2026-07-08", NEW="2026-07-10")
+    assert count_advanced(before, after) == 1
+
+
+def test_regression_backward_date_flagged():
+    before = _mf(SPY="2026-07-10", BNY="2026-07-10")
+    after = _mf(SPY="2026-07-08", BNY="2026-07-10")  # SPY lost 2 days
+    assert detect_regressions(before, after) == ["SPY"]
+
+
+def test_regression_row_shrink_flagged():
+    before = {"SPY": {"last_date": "2026-07-10", "n_rows": 500}}
+    after = {"SPY": {"last_date": "2026-07-10", "n_rows": 300}}  # bars destroyed
+    assert detect_regressions(before, after) == ["SPY"]
+
+
+def test_no_regression_on_healthy_append():
+    before = {"SPY": {"last_date": "2026-07-08", "n_rows": 498}}
+    after = {"SPY": {"last_date": "2026-07-10", "n_rows": 500}}
+    assert detect_regressions(before, after) == []
+
+
+def test_symbols_behind_upstream_ignores_delisted():
+    # rolling frozen at 07-08 while full_backup advanced to 07-10 for live names;
+    # DEAD is delisted (upstream also old) so it must NOT count as "behind".
+    upstream = _mf(SPY="2026-07-10", BNY="2026-07-10", DEAD="2026-03-01")
+    rolling = _mf(SPY="2026-07-08", BNY="2026-07-08", DEAD="2026-03-01")
+    assert set(symbols_behind_upstream(rolling, upstream)) == {"SPY", "BNY"}
+    assert abs(fraction_behind_upstream(rolling, upstream) - 2 / 3) < 1e-9
+
+
+def test_fraction_behind_zero_when_synced():
+    upstream = _mf(SPY="2026-07-10", BNY="2026-07-10")
+    rolling = _mf(SPY="2026-07-10", BNY="2026-07-10")
+    assert fraction_behind_upstream(rolling, upstream) == 0.0
+
+
+def test_max_date_alone_is_fooled_by_one_fresh_file():
+    # THE bug the guard originally had: bulk frozen, one file fresh -> max lag 0,
+    # but fraction-behind correctly flags the freeze.
+    upstream = {f"S{i}": {"last_date": "2026-07-10"} for i in range(100)}
+    rolling = {f"S{i}": {"last_date": "2026-07-01"} for i in range(100)}
+    rolling["S0"]["last_date"] = "2026-07-10"  # single fresh file
+    assert lag_business_days(max_last_date(rolling), max_last_date(upstream)) == 0
+    assert fraction_behind_upstream(rolling, upstream) == 0.99
+
+
+def test_modal_last_date_robust_to_one_fresh_file():
+    m = {f"S{i}": {"last_date": "2026-07-01"} for i in range(100)}
+    m["S0"]["last_date"] = "2026-07-10"  # one fresh file
+    assert max_last_date(m) == "2026-07-10"  # max is fooled
+    assert modal_last_date(m) == "2026-07-01"  # mode is not
+
+
+def test_universe_scoping_excludes_non_universe_etfs():
+    # Post-rebuild reality: universe names rebuilt to 07-10; non-universe ETFs
+    # (fetched into full_backup, not in the trading universe) stuck at 07-01.
+    upstream = _mf(AAPL="2026-07-10", MSFT="2026-07-10", GLDETF="2026-07-10")
+    rolling = _mf(AAPL="2026-07-10", MSFT="2026-07-10", GLDETF="2026-07-01")
+    # unscoped: GLDETF drags fraction up (false freeze)
+    assert fraction_behind_upstream(rolling, upstream) > 0.3
+    # scoped to the trading universe: 0% behind (correct — not a freeze)
+    uni = {"AAPL", "MSFT"}
+    assert fraction_behind_upstream(rolling, upstream, universe=uni) == 0.0
+    assert symbols_behind_upstream(rolling, upstream, universe=uni) == []
+
+
+def test_universe_scoping_still_catches_real_freeze():
+    upstream = _mf(AAPL="2026-07-10", MSFT="2026-07-10")
+    rolling = _mf(AAPL="2026-07-08", MSFT="2026-07-08")  # universe frozen
+    uni = {"AAPL", "MSFT"}
+    assert fraction_behind_upstream(rolling, upstream, universe=uni) == 1.0
+
+
+def test_lag_business_days_freeze_signature():
+    # rolling frozen at 07-01 while upstream is 07-10 -> 7 business days behind.
+    assert lag_business_days("2026-07-01", "2026-07-10") == 7
+    # rolling 07-08 vs upstream 07-10 -> 2 business days behind (the 07-14 case).
+    assert lag_business_days("2026-07-08", "2026-07-10") == 2
+    # up to date.
+    assert lag_business_days("2026-07-10", "2026-07-10") == 0
+    # weekend gap is not counted: Fri 07-10 -> Mon 07-13 is 1 business day.
+    assert lag_business_days("2026-07-10", "2026-07-13") == 1
+    assert lag_business_days(None, "2026-07-10") is None


### PR DESCRIPTION
## Why
The dashboard (signal-monitor.vercel.app) froze at 2026-07-12 (Signals + Alpaca tabs); today_signals were byte-identical across 07-10/12/13/14 (BNY entry_price=150.14, notional \$34,866.09 unchanged to the cent). Two root causes, both confirmed from production logs:

**A — data freeze.** The scheduled generator (`C:\tmp\qts-daily-main` = origin/main + patch) ran `cache_daily_polygon.py --start/--end {today}`. At 06:00 JST Polygon 403s "today" (UTC EOD unpublished) → `days=0 written=0`, so **full_backup never advanced**; and that branch has **no rolling-sync step**, so rolling was never rebuilt. Signals recomputed the same 07-08 snapshot daily while the pipeline logged `全 step OK` (silent success). The `--auto-latest` + rolling-sync fixes existed only as uncommitted-local edits in the primary tree — never on origin/main.

**B — delivery freeze.** The daily publish *commits* fresh files but `git push` was **rejected non-fast-forward** (local `claude/monitor-webapp` behind origin after other worktrees pushed), and the caller only checked the generate exit code — so the push failure was silent and Vercel never got new data.

## What
- `daily_pipeline.ps1`: cache → `--auto-latest`; new `[rolling_sync]` step (build_rolling); new `[freshness_guard]` step that pushes a stale rolling onto `$Failures` so the WARN ntfy fires instead of a green "all OK".
- `publish_data_to_vercel.ps1`: on non-fast-forward push, fetch + rebase-onto-origin (autostash) + retry once; LOUD ntfy WARN + exit 1 if self-heal fails.
- `common/cache_freshness.py` + `scripts/check_rolling_freshness.py`: freeze guards (silent-noop / per-file regression / universe-scoped fraction-behind, robust to a single fresh file, delisted names, and non-universe ETFs).
- `tests/test_cache_freshness_guard.py`: 15 regression tests.

## Verified operationally (this session, paper-only)
- Fetch `--auto-latest`: full_backup 07-09/07-10 written, `written=12515 failed=0`; **8,349 advanced / 0 regressions** across 15,764 files; modal **07-08→07-10**; SPY 07-08→07-10.
- Rolling rebuild: universe 07-01/07-08 → **07-10**, 6,587 advanced / 0 regressions; SPY rolling 07-01→07-10.
- Fresh signal regen: **BNY entry_price 150.14 → 151.92** (07-10 close), payload SHA changed — the byte-frozen loop is broken.
- Freshness guard: WARN(2) on frozen state, OK(0) after rebuild (0.15% universe-behind).

## Not included (deliberate)
- STUpass `setup_pass` in today_signals: re-confirmed still shows 10 (=cap) for sys3/4/5 on fresh data. Root cause is `_compute_setup_pass` in `common/today_signals.py` counting over the post-top_n `prepared` set — a **different** path from the monitor `diagnostics` fix on `claude/monitor-webapp` (4db3500), so that fix never affected this funnel. This is a display-only metric in the signal engine core and needs its own change + control tests; tracked separately, not bundled here.

paper-only; no live trading touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)