### PR TITLE
fix(ntfy): stop emoji X-Title from silently killing exec-summary pushes (latin-1 header guard)

### DIFF
--- a/common/publishers/ntfy.py
+++ b/common/publishers/ntfy.py
@@ -116,6 +116,37 @@ def _sanitize_ascii_title(title: str) -> str:
     return out[:_TITLE_LIMIT]
 
 
+def _latin1_safe_headers(headers: dict[str, str]) -> dict[str, str]:
+    """HTTP ヘッダー値を latin-1 エンコード可能に落とす最終防波堤。
+
+    requests / urllib3 は HTTP ヘッダーを latin-1 でエンコードする。X-Title に
+    emoji 等の非 latin-1 文字が入ると ``requests.post`` が
+    ``'latin-1' codec can't encode`` を投げ、ntfy 送信が丸ごと失敗する。
+
+    2026-07-13 incident: open_auto_run の exec summary が title
+    「⚠️ 07-13 exec …」(先頭 emoji) で 4 retry 全滅し、通知が無音で消えた。
+    ``_sanitize_ascii_title`` は仕様上 emoji を保持する (build_title の
+    📊/⚠️ を残す) ため、送信直前のこの層で非 latin-1 文字を落とす。emoji の
+    視覚情報は X-Tags (shortcode = bar_chart/warning) 側が担うので、title から
+    emoji が落ちても通知アイコンは維持される。
+
+    非 latin-1 を含む値は印字可能 ASCII (0x20-0x7E) のみへ絞り、空白を圧縮する
+    (制御文字・改行はヘッダーに不正なため除外)。空になったら "notification"。
+    """
+    safe: dict[str, str] = {}
+    for key, value in headers.items():
+        s = str(value)
+        try:
+            s.encode("latin-1")
+            safe[key] = s
+            continue
+        except UnicodeEncodeError:
+            kept = "".join(ch for ch in s if 0x20 <= ord(ch) <= 0x7E)
+            cleaned = " ".join(kept.split())
+            safe[key] = cleaned or "notification"
+    return safe
+
+
 def _mask_topic(topic: str | None) -> str:
     """Return an unguessable-shape but useful-in-logs marker for the ntfy topic.
 
@@ -274,6 +305,10 @@ class NtfyPublisher(Publisher):
             )
 
         import requests
+
+        # 最終防波堤: 非 latin-1 (emoji 等) が X-Title に残っていると requests が
+        # ヘッダー encode で例外を投げ、送信が丸ごと落ちる (2026-07-13 incident)。
+        headers = _latin1_safe_headers(headers)
 
         last_detail = ""
         last_status: int | None = None

--- a/tests/test_execution_summary_20260707.py
+++ b/tests/test_execution_summary_20260707.py
@@ -14,7 +14,11 @@ from common.publishers.execution_summary import (  # noqa: E402
     build_title,
     format_execution_summary,
 )
-from common.publishers.ntfy import _sanitize_ascii_title  # noqa: E402
+from common.publishers.ntfy import (  # noqa: E402
+    NtfyPublisher,
+    _latin1_safe_headers,
+    _sanitize_ascii_title,
+)
 
 
 def _recon() -> dict:
@@ -117,3 +121,62 @@ def test_format_returns_tuple():
     title, body = format_execution_summary(_recon())
     assert isinstance(title, str) and isinstance(body, str)
     assert title and body
+
+
+def test_latin1_safe_headers_strips_emoji_title():
+    """emoji 入り X-Title は latin-1 エンコード可能に落とされること。
+
+    2026-07-13 regression: build_title は「⚠️ 07-13 exec …」のように先頭 emoji を
+    付ける。HTTP ヘッダーは latin-1 encode されるため、この title を素で
+    requests に渡すと 'latin-1' codec can't encode で送信が丸ごと失敗する。
+    """
+    title = build_title(_recon())  # entry_failed=1 → "⚠️ …"
+    # 素の title は latin-1 に載らない (バグの前提を固定)
+    import pytest
+
+    with pytest.raises(UnicodeEncodeError):
+        title.encode("latin-1")
+
+    safe = _latin1_safe_headers({"X-Title": title, "X-Tags": "bar_chart,warning"})
+    # 落とした後は latin-1 でエンコードでき、count 情報は残る
+    safe["X-Title"].encode("latin-1")  # raises しない
+    assert "sig49" in safe["X-Title"]
+    assert "entry27" in safe["X-Title"]
+    assert "exit14" in safe["X-Title"]
+    # ASCII tags はそのまま
+    assert safe["X-Tags"] == "bar_chart,warning"
+
+
+def test_send_text_emoji_title_does_not_raise(monkeypatch):
+    """send_text が emoji title でも例外を投げず ntfy へ POST できること。
+
+    修正前は requests.post のヘッダー encode で latin-1 例外が漏れ、
+    exec summary 通知が 4 retry 全滅していた (open_auto_run 2026-07-13)。
+    """
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    def _fake_post(url, data=None, headers=None, timeout=None):
+        # requests 本来の latin-1 ヘッダー encode を再現し、非 latin-1 が
+        # 残っていれば例外を投げる (= バグが再発したらここで落ちる)。
+        for value in (headers or {}).values():
+            str(value).encode("latin-1")
+        captured["headers"] = headers
+        captured["url"] = url
+        return _Resp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    pub = NtfyPublisher(topic="unit-test-topic")
+    title, body = format_execution_summary(_recon())  # title に emoji を含む
+    result = pub.send_text(title, body, tags="bar_chart,warning")
+
+    assert result.ok is True
+    assert result.status_code == 200
+    # POST に渡った X-Title は latin-1 safe
+    captured["headers"]["X-Title"].encode("latin-1")


### PR DESCRIPTION
## 症状
07-13 22:52 の `open_auto_run` の exec-summary 通知が **4 retry 全滅**し、ntfy が iPhone に届かなかった。最後に飛んだ ntfy は **07-10 06:22（signal 経路、status=ok）**。

```
WARNING: ntfy post 例外 (attempt 1-4): 'latin-1' codec can't encode characters in position 0-1
INFO: execution summary 配信: ok=False detail=exception: 'latin-1' codec can't encode characters in position 0-1
```

## 根因
HTTP ヘッダーは requests/urllib3 が **latin-1** でエンコードする。exec-summary 経路（`send_text`）が使う `_sanitize_ascii_title` は**仕様上 emoji を保持**する（`build_title` が先頭に 📊/⚠️ を付ける）。この emoji が `X-Title` に乗ると `requests.post` が `'latin-1' codec can't encode` を投げ、送信が丸ごと失敗 → 通知が無音で消える。

- `position 0-1` = `⚠️`（entry_failed>0 時）、`position 0` = `📊` と再現一致。
- signal 予告経路（`_to_safe_ascii_title`、既に ASCII 化）は無関係で正常。

## 修正（可逆・小さく）
`_transport()` の `requests.post` 直前に `_latin1_safe_headers()` を最終防波堤として追加（`send`/`send_text` 両方に効く）。latin-1 に載らない値は印字可能 ASCII（空白圧縮）へ縮退。emoji の視覚情報は `X-Tags` の shortcode（bar_chart/warning）が担うので通知アイコンは維持。ASCII の signal 経路では no-op。`_sanitize_ascii_title` の「emoji 保持」契約は変えず送信境界で防ぐ。

## 検証
- 単体: `_latin1_safe_headers` が emoji title を latin-1-safe な ASCII（sig49 entry27 exit14 温存）へ縮退／`send_text` が emoji title で例外を投げず ok=True（requests の latin-1 header encode を再現する mock）。
- 実ネット: 修正コードで emoji タイトルを **1 通だけ diagnostic 送信 → HTTP 200 sent**（topic qua…(22)、07-10 成功時と同一）。
- black --check / ruff 緑。関連テスト 20 passed。

## 今夜の影響
今夜 22:35 の open_auto_run（`C:\tmp\qts-main-run`）にも同一修正を適用済みで、mock 検証で exec-summary が ok=True status=200 を確認。本 PR は canonical な main へ恒久反映するもの。

paper/read-only のみ・ライブ発注なし・破壊的操作なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
