### PR TITLE
fix(monitor,cache): funnel「未計測」逆戻り + cache exit=2 を根治

### DIFF
--- a/scripts/cache_daily_polygon.py
+++ b/scripts/cache_daily_polygon.py
@@ -320,10 +320,7 @@ def resolve_auto_range(
     休日・週末は NYSE カレンダーで自動的に飛ばされる。
     max_lookback_trading_days で range 下限をガードし過剰 backfill を防ぐ。
     """
-    from common.utils_spy import (
-        get_latest_nyse_trading_day,
-        get_next_nyse_trading_day,
-    )
+    from common.utils_spy import get_latest_nyse_trading_day, get_next_nyse_trading_day
 
     now = pd.Timestamp.now(tz="America/New_York").tz_localize(None).normalize()
     end_ts = pd.Timestamp(get_latest_nyse_trading_day(now)).normalize()

--- a/scripts/cache_daily_polygon.py
+++ b/scripts/cache_daily_polygon.py
@@ -274,10 +274,105 @@ def _parse_date(s: str) -> date:
     return datetime.strptime(s, "%Y-%m-%d").date()
 
 
+def _full_backup_latest_date(settings: object, ref_symbol: str = "SPY") -> date | None:
+    """full_backup の市場基準銘柄 (既定 SPY) が保持する最新日を返す。無ければ None。"""
+    try:
+        full_dir = Path(settings.cache.full_dir)  # type: ignore[attr-defined]
+    except Exception:
+        return None
+    for name in (f"{ref_symbol}.csv", f"{ref_symbol}.parquet", f"{ref_symbol}.feather"):
+        p = full_dir / name
+        if not p.exists():
+            continue
+        try:
+            if p.suffix == ".csv":
+                df = pd.read_csv(p)
+            elif p.suffix == ".parquet":
+                df = pd.read_parquet(p)
+            else:
+                df = pd.read_feather(p)
+        except Exception:
+            continue
+        col = next((c for c in ("Date", "date", "DATE") if c in df.columns), None)
+        try:
+            if col is not None:
+                last = pd.to_datetime(df[col], errors="coerce").max()
+            else:
+                last = pd.to_datetime(df.index, errors="coerce").max()
+            if pd.isna(last):
+                continue
+            return pd.Timestamp(last).date()
+        except Exception:
+            continue
+    return None
+
+
+def resolve_auto_range(
+    settings: object, *, max_lookback_trading_days: int = 10
+) -> tuple[date, date] | None:
+    """「today 固定」でなく、実際に取得すべき確定取引日の range を決める。
+
+    start = full_backup 最新日の翌 NYSE 取引日 (gap を backfill)、
+    end   = 現時点 (システム時計) 以前の直近 NYSE 取引日。
+    end はベンダーが当日 EOD 前だと 403 を返し得るが、cache_daily は空日として
+    自動 skip するため、range に含めても害はなく、確定済みの最新日 (例 07-02) が
+    取得される。start > end (キャッシュ最新) の場合は None を返す (fetch 不要)。
+    休日・週末は NYSE カレンダーで自動的に飛ばされる。
+    max_lookback_trading_days で range 下限をガードし過剰 backfill を防ぐ。
+    """
+    from common.utils_spy import (
+        get_latest_nyse_trading_day,
+        get_next_nyse_trading_day,
+    )
+
+    now = pd.Timestamp.now(tz="America/New_York").tz_localize(None).normalize()
+    end_ts = pd.Timestamp(get_latest_nyse_trading_day(now)).normalize()
+
+    full_latest = _full_backup_latest_date(settings)
+    if full_latest is not None:
+        try:
+            start_ts = pd.Timestamp(
+                get_next_nyse_trading_day(pd.Timestamp(full_latest))
+            ).normalize()
+        except Exception:
+            start_ts = end_ts
+    else:
+        start_ts = end_ts
+
+    # 過剰 backfill ガード: end から max_lookback_trading_days 取引日より前には遡らない
+    floor_ts = end_ts
+    for _ in range(max(0, int(max_lookback_trading_days))):
+        try:
+            floor_ts = pd.Timestamp(
+                get_latest_nyse_trading_day(floor_ts - pd.Timedelta(days=1))
+            ).normalize()
+        except Exception:
+            break
+    if start_ts < floor_ts:
+        start_ts = floor_ts
+
+    if start_ts > end_ts:
+        return None
+    return start_ts.date(), end_ts.date()
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Polygon Grouped Daily backfill.")
-    p.add_argument("--start", required=True, type=_parse_date, help="start YYYY-MM-DD")
-    p.add_argument("--end", required=True, type=_parse_date, help="end YYYY-MM-DD")
+    p.add_argument(
+        "--start", type=_parse_date, help="start YYYY-MM-DD (omit with --auto-latest)"
+    )
+    p.add_argument(
+        "--end", type=_parse_date, help="end YYYY-MM-DD (omit with --auto-latest)"
+    )
+    p.add_argument(
+        "--auto-latest",
+        action="store_true",
+        help=(
+            "--start/--end を無視し、full_backup 最新日の翌取引日〜直近 NYSE 取引日を"
+            "自動で対象にする (ベンダーが当日 EOD 前で未提供な日や休日・週末は自動 skip)。"
+            "日次パイプラインが『今日』を要求して 403 で空振りするのを防ぐ。"
+        ),
+    )
     p.add_argument("--symbols", default=None, help="comma-separated symbol filter")
     p.add_argument(
         "--max-symbols", type=int, default=None, help="upper bound for symbols"
@@ -315,6 +410,23 @@ def main(argv: list[str] | None = None) -> int:
         level=args.log_level.upper(),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+
+    if getattr(args, "auto_latest", False):
+        from config.settings import get_settings
+
+        _settings = get_settings(create_dirs=True)
+        rng = resolve_auto_range(_settings)
+        if rng is None:
+            logger.info(
+                "auto-latest: full_backup は既に最新 (fetch 対象日なし)。skip。"
+            )
+            return 0
+        args.start, args.end = rng
+        logger.info("auto-latest: 対象 range = %s .. %s", args.start, args.end)
+    elif args.start is None or args.end is None:
+        logger.error("--start/--end は必須です (または --auto-latest を指定)")
+        return 1
+
     if args.end < args.start:
         logger.error("--end (%s) < --start (%s)", args.end, args.start)
         return 1

--- a/scripts/daily_polygon_monitor.py
+++ b/scripts/daily_polygon_monitor.py
@@ -419,6 +419,18 @@ def build_pipeline_report(
 
     trdlist_counts: dict[str, int] = {}
     entry_counts: dict[str, int] = {}
+    # signals エンジンが today_signals.funnel に既に確定させた Tgt/FILpass/STUpass/Exit。
+    # coverage step の grouped-daily 実測は「今日」を要求するため 06:00 JST の定例 run では
+    # 当日 EOD 前で 403 → grouped 空 → measured={} で Tgt/FIL/STU が silent に null 化し、
+    # ダッシュボードが「未計測」に逆戻りする。grouped が空/欠損のときは、signals が実際に
+    # 使った anchored ユニバース上の funnel を fallback ソースとして採用する。
+    funnel_counts: dict[str, dict[str, int]] = {}
+    _FUNNEL_TO_PHASE = {
+        "target": "Tgt",
+        "filter_pass": "FILpass",
+        "setup_pass": "STUpass",
+        "exit_count": "Exit",
+    }
     if signals_dir is not None:
         sig_path = signals_dir / f"today_signals_{target_date.replace('-', '')}.json"
         if sig_path.exists():
@@ -431,6 +443,14 @@ def build_pipeline_report(
                         trdlist_counts[sysname] = int(ci)
                     if isinstance(so, (int, float)):
                         entry_counts[sysname] = int(so)
+                    fn = entry.get("funnel") or {}
+                    fc = {
+                        phase: int(fn[src])
+                        for src, phase in _FUNNEL_TO_PHASE.items()
+                        if isinstance(fn.get(src), (int, float))
+                    }
+                    if fc:
+                        funnel_counts[sysname] = fc
             except Exception as exc:  # pragma: no cover
                 logger.warning("today_signals 読込失敗 (%s): %s", sig_path, exc)
 
@@ -444,7 +464,9 @@ def build_pipeline_report(
             return trdlist_counts.get(sysname)
         if name == "Entry":
             return entry_counts.get(sysname)
-        return None
+        # Tgt/FILpass/STUpass/Exit: grouped-daily 実測が無い場合の fallback として
+        # signals エンジンの funnel を採用する (定例 06:00 run の 403 空振り対策)。
+        return (funnel_counts.get(sysname) or {}).get(name)
 
     systems_out: dict[str, Any] = {}
     for sysname, phase_defs in SYSTEM_PIPELINE_PHASES.items():
@@ -453,7 +475,11 @@ def build_pipeline_report(
             if empty
             else _measurable_counts_for_system(sysname, grouped_df, dv_cache)
         )
-        universe_count = measured.get("Tgt", 0)
+        # ratio_of_universe の分母。grouped 実測 Tgt が無ければ funnel fallback の Tgt を使う。
+        universe_count = measured.get("Tgt")
+        if universe_count is None:
+            universe_count = _signal_fill(sysname, "Tgt")
+        universe_count = universe_count or 0
 
         phases_out: list[dict[str, Any]] = []
         prev_count: int | None = None
@@ -491,7 +517,9 @@ def build_pipeline_report(
         "systems": systems_out,
         "notes": [
             "phases are reference counts, not evaluation criteria.",
-            "monitor measures Tgt / FILpass only; STUpass/Exit are unmeasured (null).",
+            "measured=true は grouped-daily 実測 (Tgt/FILpass) を意味する。",
+            "grouped が空 (当日 EOD 前 403 等) の場合、Tgt/FILpass/STUpass/Exit は "
+            "today_signals.funnel から補完する (measured=false のまま count は非null)。",
             "ratio_of_prev = count / previous measured phase; ratio_of_universe = count / Tgt.",
         ],
     }

--- a/tests/system/test_daily_pipeline_ps1_contract.py
+++ b/tests/system/test_daily_pipeline_ps1_contract.py
@@ -30,23 +30,22 @@ class TestDailyPipelineCliContract:
     """ps1 の中身から expected CLI 契約を抽出して固定する."""
 
     def test_step1_cache_command_shape(self, ps1_text: str):
-        """★ flatten bug トリガとなった step1 契約:
-        `scripts/cache_daily_polygon.py --start {Date} --end {Date}` の形態.
+        """★ step1 cache 契約: `scripts/cache_daily_polygon.py --auto-latest` の形態.
+
+        履歴: 旧契約は `--start {Date} --end {Date}` の 1 日 fetch だったが、
+        定例 06:00 JST run では「今日」が US EOD 前で Polygon 403 空振り → cache
+        exit=2 になっていた。#138 で ps1 を `--auto-latest` (full_backup 最新日の翌
+        取引日〜直近 NYSE 取引日を自動対象) に切替。この契約をここで固定する。
         """
         # 対応 python が呼ばれている
         assert (
             "scripts\\cache_daily_polygon.py" in ps1_text
             or "scripts/cache_daily_polygon.py" in ps1_text
         ), "step1 で cache_daily_polygon.py が呼ばれていない"
-        # --start / --end 両方指定
-        assert "--start" in ps1_text
-        assert "--end" in ps1_text
-        # $Date で 1 日 fetch (--start == --end 形態)
-        # NOTE: これが flatten bug のトリガだが, script 側 (_merge_with_existing_full_csv)
-        # で防御済み. その契約を明示的にここで固定する.
-        assert '"--start", $Date, "--end", $Date' in ps1_text, (
-            "1 日 fetch 形態 (--start == --end) が消失した. 変更が意図的なら "
-            "flatten regression の再チェックが必要"
+        # --auto-latest 形態 (今日固定 fetch をやめ、確定済み range を自動解決)
+        assert "--auto-latest" in ps1_text, (
+            "cache step が --auto-latest 形態でない。旧 --start/--end 形態に戻ると "
+            "06:00 JST 定例 run で当日 EOD 前 403 → cache exit=2 が再発する。"
         )
 
     def test_step2_signals_command_shape(self, ps1_text: str):

--- a/tests/test_cache_auto_latest.py
+++ b/tests/test_cache_auto_latest.py
@@ -1,0 +1,108 @@
+"""Regression: cache_daily_polygon.py --auto-latest 契約.
+
+背景 (2026-07-15):
+    daily_pipeline.ps1 (#138) は cache step を `--auto-latest` で叩くよう変更済みだが、
+    cache_daily_polygon.py 側の実装が origin/main に landing しておらず (--start/--end
+    required のまま)、argparse が `error: the following arguments are required:
+    --start, --end` を出して **exit=2** で毎日 cache step が失敗していた。
+
+    本テストは:
+      1. argparse が --auto-latest を受理し、--start/--end 無しでも SystemExit しない
+      2. main(["--auto-latest"]) が (full_backup 最新なら) exit=0 で skip する
+      3. --start/--end も --auto-latest も無ければ argparse exit=2 でなく rc=1 で loud fail
+      4. resolve_auto_range が「既に最新」で None を返す (fetch skip)
+    を固定する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+
+import scripts.cache_daily_polygon as cdp
+
+
+def test_argparser_accepts_auto_latest_without_start_end() -> None:
+    """--auto-latest 単独で parse できる (旧: --start/--end required で SystemExit した)."""
+    parser = cdp.build_arg_parser()
+    args = parser.parse_args(["--auto-latest"])
+    assert args.auto_latest is True
+    assert args.start is None and args.end is None
+
+
+def test_main_auto_latest_skips_when_up_to_date(monkeypatch) -> None:
+    """full_backup が最新 (resolve→None) のとき exit=0 で skip。cache exit=2 回帰の核心."""
+    monkeypatch.setattr(
+        "config.settings.get_settings",
+        lambda create_dirs=True: SimpleNamespace(),
+    )
+    monkeypatch.setattr(cdp, "resolve_auto_range", lambda settings, **kw: None)
+
+    rc = cdp.main(["--auto-latest"])
+    assert rc == 0
+
+
+def test_main_missing_range_is_loud_rc1_not_argparse_exit2(monkeypatch) -> None:
+    """--start/--end も --auto-latest も無ければ rc=1 (silent argparse exit=2 にしない)."""
+    rc = cdp.main([])
+    assert rc == 1
+
+
+def test_resolve_auto_range_returns_none_when_full_backup_latest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """full_backup 最新日 == 直近取引日なら翌取引日 > end となり None (fetch 不要)."""
+    full_dir = tmp_path / "full_backup"
+    full_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {"Date": ["2026-07-13", "2026-07-14"], "Close": [100.0, 101.0]}
+    ).to_csv(full_dir / "SPY.csv", index=False)
+
+    settings = SimpleNamespace(cache=SimpleNamespace(full_dir=str(full_dir)))
+
+    fixed_end = pd.Timestamp("2026-07-14")
+    monkeypatch.setattr(
+        "common.utils_spy.get_latest_nyse_trading_day",
+        lambda ts=None: fixed_end,
+    )
+    monkeypatch.setattr(
+        "common.utils_spy.get_next_nyse_trading_day",
+        lambda ts: pd.Timestamp("2026-07-15"),  # 07-14 の翌取引日
+    )
+
+    rng = cdp.resolve_auto_range(settings)
+    assert rng is None
+
+
+def test_resolve_auto_range_returns_range_when_behind(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """full_backup が遅れていれば (start, end) を返し start<=end。"""
+    full_dir = tmp_path / "full_backup"
+    full_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {"Date": ["2026-07-09", "2026-07-10"], "Close": [100.0, 101.0]}
+    ).to_csv(full_dir / "SPY.csv", index=False)
+
+    settings = SimpleNamespace(cache=SimpleNamespace(full_dir=str(full_dir)))
+
+    fixed_end = pd.Timestamp("2026-07-14")
+
+    def fake_latest(ts=None):
+        if ts is None:
+            return fixed_end
+        t = pd.Timestamp(ts).normalize()
+        return t if t < fixed_end else fixed_end
+
+    monkeypatch.setattr("common.utils_spy.get_latest_nyse_trading_day", fake_latest)
+    monkeypatch.setattr(
+        "common.utils_spy.get_next_nyse_trading_day",
+        lambda ts: pd.Timestamp("2026-07-13"),  # 07-10 の翌取引日
+    )
+
+    rng = cdp.resolve_auto_range(settings)
+    assert rng is not None
+    start, end = rng
+    assert start <= end == fixed_end.date()

--- a/tests/test_cache_daily_polygon_merge.py
+++ b/tests/test_cache_daily_polygon_merge.py
@@ -249,8 +249,12 @@ class TestMergeWithExistingFullCsv:
 
         # current: warning ログを出しつつ new のみ返す
         assert len(merged) == 1
+        # 本テストの本質は「読取失敗を silent に握り潰さず loud に WARNING する」こと。
+        # 実装の message は英語 "read failure ... new only." (旧: 日本語フレーズ) のため、
+        # 言語非依存に「WARNING レベル + 該当ファイルへの言及」で loudness を固定する。
         assert any(
-            "履歴失う危険" in rec.message for rec in caplog.records
+            rec.levelname == "WARNING" and csv_path.name in rec.message
+            for rec in caplog.records
         ), "既存 CSV 読取失敗時に WARNING が出ていない = silent path"
 
 

--- a/tests/test_pipeline_funnel_fallback.py
+++ b/tests/test_pipeline_funnel_fallback.py
@@ -1,0 +1,135 @@
+"""Regression: pipeline_*.json funnel が「未計測」に silent 逆戻りしないことを固定する.
+
+背景 (2026-07-15):
+    coverage step (daily_polygon_monitor.build_pipeline_report) は Tgt/FILpass を
+    「今日」の Polygon grouped-daily から実測する。だが定例 06:00 JST run では当日 EOD
+    前で grouped が 403 → 空 DataFrame → measured={} となり Tgt/FILpass/STUpass が全て
+    null (=ダッシュボード「未計測」)。一方 signals エンジンは today_signals.funnel に
+    target/filter_pass/setup_pass を既に確定させている。この funnel を fallback ソース
+    として採用し、grouped が空でも funnel 値で count を埋める。
+
+    [[feedback-silent-cache-bug-lesson]]: データ欠損を silent に null 化せず、既に
+    確定している値へ loud に fallback する。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.daily_polygon_monitor import build_pipeline_report
+
+
+def _write_signals(
+    sig_dir: Path, date_compact: str, *, with_funnel: bool = True
+) -> None:
+    systems = {}
+    # sys1: 通常ケース, sys6: STUpass=0, sys7: SPY 専用 (funnel target=universe)
+    specs = {
+        "sys1": dict(target=5223, filter_pass=1515, setup_pass=686, cand=10, entry=7),
+        "sys6": dict(target=5223, filter_pass=1008, setup_pass=0, cand=0, entry=0),
+        "sys7": dict(target=5223, filter_pass=1, setup_pass=0, cand=0, entry=0),
+    }
+    for name, s in specs.items():
+        entry = {
+            "signals": [],
+            "n_candidates_input": s["cand"],
+            "n_signals_output": s["entry"],
+        }
+        if with_funnel:
+            entry["funnel"] = {
+                "target": s["target"],
+                "filter_pass": s["filter_pass"],
+                "setup_pass": s["setup_pass"],
+                "candidate_count": s["cand"],
+                "entry_count": s["entry"],
+                "exit_count": None,
+            }
+        systems[name] = entry
+    payload = {"version": "1.0", "date": "2026-07-15", "systems": systems}
+    (sig_dir / f"today_signals_{date_compact}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _phase(report: dict, sysname: str, phase_name: str) -> dict:
+    return next(
+        p for p in report["systems"][sysname]["phases"] if p["name"] == phase_name
+    )
+
+
+def test_funnel_fallback_when_grouped_empty(tmp_path: Path) -> None:
+    """grouped 空 (403 相当) でも Tgt/FILpass/STUpass が funnel から埋まる (未計測回帰の核心)."""
+    _write_signals(tmp_path, "20260715", with_funnel=True)
+
+    report = build_pipeline_report(None, {}, "2026-07-15", signals_dir=tmp_path)
+
+    tgt = _phase(report, "sys1", "Tgt")
+    fil = _phase(report, "sys1", "FILpass")
+    stu = _phase(report, "sys1", "STUpass")
+    # count は funnel 由来で非 null (= ダッシュボードが数値表示する条件)
+    assert tgt["count"] == 5223
+    assert fil["count"] == 1515
+    assert stu["count"] == 686
+    # grouped 実測ではないので measured=False (provenance を偽らない)
+    assert tgt["measured"] is False
+    assert fil["measured"] is False
+    # 比率も埋まる (未計測なら prev/univ が '—' 表示になる)
+    assert fil["ratio_of_universe"] == round(1515 / 5223, 6)
+    assert stu["ratio_of_prev"] == round(686 / 1515, 6)
+
+
+def test_no_funnel_key_stays_null_graceful(tmp_path: Path) -> None:
+    """today_signals に funnel が無い旧形式では Tgt/FILpass/STUpass は null のまま (例外を出さない)."""
+    _write_signals(tmp_path, "20260715", with_funnel=False)
+
+    report = build_pipeline_report(None, {}, "2026-07-15", signals_dir=tmp_path)
+
+    assert _phase(report, "sys1", "Tgt")["count"] is None
+    assert _phase(report, "sys1", "STUpass")["count"] is None
+    # TRDlist/Entry は n_candidates_input/n_signals_output から従来通り埋まる
+    assert _phase(report, "sys1", "TRDlist")["count"] == 10
+    assert _phase(report, "sys1", "Entry")["count"] == 7
+
+
+def test_grouped_measured_takes_priority_over_funnel(tmp_path: Path) -> None:
+    """grouped 実測がある場合は measured=True でそちらを優先。STUpass は funnel fallback。"""
+    import pandas as pd
+
+    _write_signals(tmp_path, "20260715", with_funnel=True)
+    # SPY + 高値高 DV の銘柄群を grouped に用意 (sys1 の min_price/DV gate を通す)
+    grouped = pd.DataFrame(
+        {
+            "Open": [100.0, 200.0, 4.0],
+            "High": [101.0, 201.0, 4.1],
+            "Low": [99.0, 199.0, 3.9],
+            "Close": [100.0, 200.0, 4.0],
+            "Volume": [5_000_000, 5_000_000, 5_000_000],
+        },
+        index=pd.Index(["AAA", "BBB", "PENNY"], name="symbol"),
+    )
+    dv_cache = {
+        "AAA": {"dollarvolume20": 80_000_000.0, "dollarvolume50": 80_000_000.0},
+        "BBB": {"dollarvolume20": 80_000_000.0, "dollarvolume50": 80_000_000.0},
+        "PENNY": {"dollarvolume20": 1_000.0, "dollarvolume50": 1_000.0},
+    }
+
+    report = build_pipeline_report(
+        grouped, dv_cache, "2026-07-15", signals_dir=tmp_path
+    )
+
+    tgt = _phase(report, "sys1", "Tgt")
+    stu = _phase(report, "sys1", "STUpass")
+    # Tgt は grouped 実測 (measured=True) — funnel の 5223 ではなく grouped の銘柄数
+    assert tgt["measured"] is True
+    assert tgt["count"] != 5223
+    # STUpass は grouped で実測不能 → funnel fallback (measured=False, count=686)
+    assert stu["measured"] is False
+    assert stu["count"] == 686
+
+
+def test_exit_stays_null_when_signals_has_no_exit(tmp_path: Path) -> None:
+    """funnel.exit_count が null なら Exit も null のまま (誤って埋めない = 誠実な未計測)."""
+    _write_signals(tmp_path, "20260715", with_funnel=True)
+    report = build_pipeline_report(None, {}, "2026-07-15", signals_dir=tmp_path)
+    assert _phase(report, "sys1", "Exit")["count"] is None


### PR DESCRIPTION
## 症状 (2026-07-15 06:00 JST 定例 run)

1. **cache exit=2**: `daily_pipeline_20260715_060006.log` の `[cache] 終了 (exit=2)`。
2. **funnel「未計測」逆戻り**: quant-trading-monitor の Signals タブで sys3 等の
   Tgt/FILpass/STUpass/Exit が「未計測」・prev/univ が `—`。以前 #137/#138 で
   Tgt~5,169 等が出ていたのに逆戻り (TRDlist=10/Entry=7 は表示)。

## 根因 (2つは独立、共通の引金は「今日データ未確定」)

| # | 根因 |
|---|------|
| cache exit=2 | ps1 (#138, origin/main) は cache を `--auto-latest` で叩くが、`cache_daily_polygon.py` の実装が origin/main に landing しておらず `--start/--end required` のまま → argparse `error: the following arguments are required: --start, --end` → exit=2。非致命 (rolling_sync/freshness_guard で recover) だが毎日失敗表示。origin/main の ps1 contract test も red 化していた。 |
| funnel 未計測 | `build_pipeline_report` は Tgt/FILpass を「今日」の Polygon grouped-daily から実測するが、06:00 JST は当日 EOD 前で **403 → grouped 空 → `measured={}` → null**。`today_signals.funnel` に `target/filter_pass/setup_pass` が既に確定しているのに未使用だった。 |

**因果の否定**: cache exit=2 は funnel 未計測の原因では**ない**。`today_signals_20260715.json` の funnel は完全に埋まっており (target=5223, filter_pass, setup_pass)、signals は cache 失敗と無関係に成功している。未計測は coverage step が独立に 403 したため。

## 修正

- **Fix A** (`daily_polygon_monitor.py`): grouped 空/欠損時に `today_signals.funnel` を fallback ソースとして採用 (`target→Tgt, filter_pass→FILpass, setup_pass→STUpass, exit_count→Exit`)。count が非 null になりダッシュボードが数値表示。`measured` は grouped 実測時のみ true (provenance を偽らない)。STUpass も補完可能に。silent に null 化せず既定値へ loud fallback。
- **Fix B** (`cache_daily_polygon.py`): `--auto-latest` を実装 (#138 未 landing 分)。`resolve_auto_range` が full_backup 最新日の翌取引日〜直近 NYSE 取引日を解決し、既に最新なら `None→skip(exit 0)`。「今日」を要求しないため 403 空振りが構造的に消える。`--start/--end` は optional 化 (後方互換)。

## 検証

- 実 `today_signals_20260715.json` (funnel あり) + grouped=None で `build_pipeline_report` を実行 → 全 system で Tgt=5223 / FILpass / STUpass が非 null・prev/univ 比率も算出。
- 新規回帰テスト 9 + 更新 contract test。**44 passed** (関連 file: 67 passed)。
- `black 25.9.0` / `ruff 0.14.1` clean。

### 付随 (pre-existing、本 PR で green 化)
- `test_daily_pipeline_ps1_contract.py::test_step1_cache_command_shape`: origin/main で red だった (ps1 は `--auto-latest` だが test は旧 `--start/--end` を期待)。契約を更新。
- `test_cache_daily_polygon_merge.py::test_unreadable_existing_csv_returns_new_only`: origin/main で red (code は英語 WARNING、test は旧日本語 phrase を期待)。読取失敗の loudness 検証を言語非依存化 (assertion のみ、runtime 不変)。

## 反映見込み
- main マージ後、次 daily_main_follow (07-16 06:00 JST) が origin/main を fetch → 再生成 → funnel 再表示。cache step は skip(exit 0) に。
- 07-15 分の即時再表示は別途 monitor-webapp 再 publish で対応可 (本 PR はコード修正のみ)。

paper 限定・ライブ発注/破壊的操作なし。