### PR TITLE
fix(exec): Alpaca tick 準拠で native 保護注文の sub-penny 拒否を根治

### DIFF
--- a/common/alpaca_trading.py
+++ b/common/alpaca_trading.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
 import json
 import logging
 import math
@@ -65,6 +66,51 @@ TIER_NOTIONAL_USD: dict[str, float] = {
 def resolve_tier_notional(tier: str) -> float:
     key = (tier or "").strip().lower()
     return TIER_NOTIONAL_USD.get(key, TIER_NOTIONAL_USD["small"])
+
+
+# -----------------------------------------------------------------------
+# price tick rounding (Alpaca sub-penny guard)
+# -----------------------------------------------------------------------
+#
+# Alpaca は US equity の limit / stop 価格に「最小刻み (tick)」制約を課す:
+#   - price >= $1.00  ->  $0.01 刻み (小数2桁)
+#   - price <  $1.00  ->  $0.0001 刻み (小数4桁)
+# これに反する sub-penny 価格 (>=$1 なのに小数3桁以上) を native limit/stop で
+# 発注すると ``sub-penny increment does not fulfill minimum pricing criteria``
+# (code 42210000) で全拒否される。
+#
+# 従来の native protection order 生成は stop/target を一律 ``round(price, 4)``
+# して発注していたため、>=$1 銘柄 (例: BABA 109.4519 / GSHD 52.0288) の
+# stop/target が 4桁のまま code 42210000 で reject され resting 保護が置けなか
+# った。native limit/stop 価格を Alpaca へ渡す前に必ず本ヘルパーを通すこと。
+#
+# NOTE: 端株 (fractional) の synthetic 保護 exit は order_type="market" であり
+# stop_price/limit_price は audit 用フィールドに過ぎない (Alpaca は成行の価格を
+# 無視する)。よって synthetic 側の丸めは本 tick 制約の対象外で、端株の挙動は
+# 変えない (端株の native stop 不可対応は別管轄)。
+_TICK_ABOVE_1 = Decimal("0.01")
+_TICK_BELOW_1 = Decimal("0.0001")
+
+
+def round_to_alpaca_tick(price: float | None) -> float | None:
+    """native stop / limit 価格を Alpaca の最小 tick に丸める (nearest tick)。
+
+    Alpaca tick ルール:
+        price >= $1.00 -> $0.01   (小数2桁)
+        price <  $1.00 -> $0.0001 (小数4桁)
+
+    - ``ROUND_HALF_UP`` (最寄り tick) で丸めるので stop/target が意図した水準
+      からずれない (最大でも 0.5 tick)。方向丸めはしない。
+    - ``None`` / 非正 (<=0) の入力はそのまま返す (caller 側で下限を別途 guard 済)。
+    """
+    if price is None:
+        return None
+    p = float(price)
+    if p <= 0:
+        # long stop は max(0.01, ...) 等で caller が下限保証済。負値・0 は触らない。
+        return p
+    tick = _TICK_ABOVE_1 if p >= 1.0 else _TICK_BELOW_1
+    return float(Decimal(str(p)).quantize(tick, rounding=ROUND_HALF_UP))
 
 
 # =========================================================================
@@ -619,7 +665,10 @@ def signals_to_orders(
             raw_px = row.get("entry_price")
             try:
                 if raw_px not in (None, ""):
-                    limit_price = float(raw_px)
+                    # sub-penny guard: >=$1 の limit entry を小数4桁のまま
+                    # 発注すると Alpaca が code 42210000 で拒否するため、native
+                    # protection order と同じ tick ルールで丸める。
+                    limit_price = round_to_alpaca_tick(float(raw_px))
             except (TypeError, ValueError):
                 limit_price = None
             if limit_price is None:
@@ -1565,7 +1614,7 @@ def _build_protection_orders(
                     order_type="stop",
                     reason=ExitReasonCode.PROTECT_STOP,
                     entry_date=snap.entry_date,
-                    stop_price=round(stop_price, 4),
+                    stop_price=round_to_alpaca_tick(stop_price),
                     client_order_id=coid,
                     dry_run=True,
                     time_in_force="gtc",
@@ -1589,7 +1638,7 @@ def _build_protection_orders(
                     order_type="limit",
                     reason=ExitReasonCode.PROTECT_TARGET,
                     entry_date=snap.entry_date,
-                    limit_price=round(target_price, 4),
+                    limit_price=round_to_alpaca_tick(target_price),
                     client_order_id=coid,
                     dry_run=True,
                     time_in_force="gtc",

--- a/tests/test_alpaca_exit_orders.py
+++ b/tests/test_alpaca_exit_orders.py
@@ -26,6 +26,7 @@ from common.alpaca_trading import (
     hydrate_system_tags,
     parse_entry_date_from_client_order_id,
     parse_system_from_client_order_id,
+    round_to_alpaca_tick,
     submit_paper_exit_order,
 )
 
@@ -318,6 +319,129 @@ class TestBuildExitOrders:
     def test_zero_qty_is_skipped(self):
         snap = _snap("AAPL", "system1", "long", 0, 195.0, "2026-07-01")
         exits = build_exit_orders_from_positions([snap], today="2026-07-02")
+        assert exits == []
+
+
+# -------------------------------------------------------------------------
+# Alpaca tick rounding (sub-penny native-protection reject guard)
+#
+# 回帰 (2026-07-15): native protection の stop/target を一律 round(price, 4)
+# して発注していたため、>=$1 銘柄の 4桁価格 (BABA 109.4519 / GSHD 52.0288) が
+# code 42210000 (sub-penny) で全拒否され resting 保護ストップが置けなかった。
+# 修正後は tick ルール (>=$1 -> 2桁 / <$1 -> 4桁) で丸めて必ず valid tick に
+# なることを固定する。端株の synthetic (market) 保護は対象外で挙動不変。
+# -------------------------------------------------------------------------
+
+
+def _is_valid_alpaca_tick(price) -> bool:
+    """Alpaca tick ルールに適合するか: >=$1 は 2桁、<$1 は 4桁刻み。"""
+    if price is None:
+        return False
+    if price >= 1.0:
+        return round(price, 2) == pytest.approx(price)
+    return round(price, 4) == pytest.approx(price)
+
+
+class TestRoundToAlpacaTick:
+    def test_baba_stop_becomes_valid_penny_tick(self):
+        # 今夜拒否された実値: BABA stop 109.4519 -> 109.45 (2桁)
+        assert round_to_alpaca_tick(109.4519) == pytest.approx(109.45)
+        assert _is_valid_alpaca_tick(round_to_alpaca_tick(109.4519))
+
+    def test_gshd_stop_becomes_valid_penny_tick(self):
+        # GSHD 52.0288 -> 52.03 (2桁, HALF_UP で切り上げ)
+        assert round_to_alpaca_tick(52.0288) == pytest.approx(52.03)
+        assert _is_valid_alpaca_tick(round_to_alpaca_tick(52.0288))
+
+    def test_at_or_above_one_dollar_is_two_decimals(self):
+        assert round_to_alpaca_tick(1.00) == pytest.approx(1.0)
+        assert round_to_alpaca_tick(1.005) == pytest.approx(1.01)  # HALF_UP
+        assert round_to_alpaca_tick(250.0) == pytest.approx(250.0)
+
+    def test_below_one_dollar_keeps_four_decimals(self):
+        # <$1 は 4桁刻みが許される -> 精度を落とさない
+        assert round_to_alpaca_tick(0.5432) == pytest.approx(0.5432)
+        assert round_to_alpaca_tick(0.54329) == pytest.approx(0.5433)  # 4桁 HALF_UP
+        # 2桁に丸めてはいけない (情報損失の回帰防止)
+        assert round_to_alpaca_tick(0.5432) != pytest.approx(0.54)
+
+    def test_uses_half_up_not_bankers_rounding(self):
+        # round(52.025, 2) は banker's/float で 52.02 になり得る。
+        # tick ヘルパーは Decimal + HALF_UP なので 52.03 に固定。
+        assert round_to_alpaca_tick(52.025) == pytest.approx(52.03)
+
+    def test_none_and_non_positive_passthrough(self):
+        assert round_to_alpaca_tick(None) is None
+        assert round_to_alpaca_tick(0.0) == pytest.approx(0.0)
+        assert round_to_alpaca_tick(-3.14) == pytest.approx(-3.14)
+
+
+class TestNativeProtectionTickCompliance:
+    def test_stop_price_sub_penny_is_rounded_to_valid_tick(self):
+        # system1 long: stop = avg_entry - 5*ATR20
+        #   149.4519 - 5*8.0 = 109.4519 (今夜の BABA と同じ 4桁 raw stop)
+        snap = _snap("BABA", "system1", "long", 12, 149.4519, "2026-07-14")
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-15",
+            atr_by_symbol={"BABA": {20: 8.0}},
+        )
+        stop = [e for e in exits if e.reason == ExitReasonCode.PROTECT_STOP]
+        assert len(stop) == 1
+        # BEFORE(bug): 109.4519 (code 42210000 で拒否)  AFTER: 109.45 (valid)
+        assert stop[0].order_type == "stop"  # native resting stop
+        assert stop[0].stop_price == pytest.approx(109.45)
+        assert _is_valid_alpaca_tick(stop[0].stop_price)
+
+    def test_target_price_sub_penny_is_rounded_to_valid_tick(self):
+        # system5 long: target = avg_entry + 1*ATR10
+        #   50.0288 + 1*2.0 = 52.0288 (GSHD と同じ 4桁 raw target)
+        snap = _snap("GSHD", "system5", "long", 6, 50.0288, "2026-07-14")
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-15",
+            atr_by_symbol={"GSHD": {10: 2.0}},
+        )
+        target = [e for e in exits if e.reason == ExitReasonCode.PROTECT_TARGET]
+        assert len(target) == 1
+        assert target[0].order_type == "limit"  # native resting limit
+        assert target[0].limit_price == pytest.approx(52.03)
+        assert _is_valid_alpaca_tick(target[0].limit_price)
+        # 同ポジションの stop も valid tick であること
+        stop = [e for e in exits if e.reason == ExitReasonCode.PROTECT_STOP]
+        assert len(stop) == 1
+        assert _is_valid_alpaca_tick(stop[0].stop_price)
+
+    def test_sub_dollar_stop_keeps_four_decimals(self):
+        # <$1 銘柄: 0.9432 - 5*0.08 = 0.5432 -> 4桁を維持 (2桁に丸めない)
+        snap = _snap("PENNY", "system1", "long", 100, 0.9432, "2026-07-14")
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-15",
+            atr_by_symbol={"PENNY": {20: 0.08}},
+        )
+        stop = [e for e in exits if e.reason == ExitReasonCode.PROTECT_STOP]
+        assert len(stop) == 1
+        assert stop[0].stop_price == pytest.approx(0.5432)
+        assert _is_valid_alpaca_tick(stop[0].stop_price)
+        # 2桁丸めだったら 0.54 に潰れる -> 4桁維持を確認
+        assert stop[0].stop_price != pytest.approx(0.54)
+
+    def test_existing_protect_coid_still_dedups_after_tick_fix(self):
+        # held_for_orders(40310000) 相当の重複防止 = existing coid skip は
+        # tick 修正後も挙動不変であること (sub-penny を生む価格でも skip)。
+        snap = _snap("BABA", "system1", "long", 12, 149.4519, "2026-07-14")
+        existing = {
+            "protect-system1-BABA-20260714-protect-trail",
+            "protect-system1-BABA-20260714-protect-stop",
+        }
+        exits = build_exit_orders_from_positions(
+            [snap],
+            today="2026-07-15",
+            atr_by_symbol={"BABA": {20: 8.0}},
+            existing_protect_coids=existing,
+        )
+        # system1 は trailing + stop のみ。両 coid が既存なら新規発注ゼロ。
         assert exits == []
 
 


### PR DESCRIPTION
## 背景 (07-14 open_auto_run で検証済み)

exit の native 保護注文 **20 件中 14 件が code 42210000 (sub-penny increment) で全拒否**。
根因は `_build_protection_orders` が stop/target を一律 `round(price, 4)` で **4小数**発注していた点。Alpaca は **価格 ≥$1 は $0.01 刻み (2小数) 必須**なので、BABA `109.4519` / GSHD `52.0288` が tick 制約に違反して弾かれ、**resting 保護ストップが置けず** time/breakout 代替頼みの構造欠陥になっていた。

> 残り 6 件は `held_for_orders (40310000)` = 重複再発注の正しい拒否 = 無害。

## 修正

| 箇所 | before | after |
|---|---|---|
| `_build_protection_orders` stop_price | `round(stop_price, 4)` | `round_to_alpaca_tick(stop_price)` |
| `_build_protection_orders` limit_price (target) | `round(target_price, 4)` | `round_to_alpaca_tick(target_price)` |
| `signals_to_orders` limit entry_price (同種の sub-penny 拒否) | `float(raw_px)` | `round_to_alpaca_tick(float(raw_px))` |

- **`round_to_alpaca_tick(price)`** を追加 (`Decimal` + `ROUND_HALF_UP` = nearest tick)。
  - `price >= $1.00` → `$0.01` 刻み (小数2桁)
  - `price <  $1.00` → `$0.0001` 刻み (小数4桁)
  - `None` / 非正はそのまま passthrough (caller 側で下限 guard 済)。
- **端株 (fractional) は対象外**: `_build_synthetic_protection_orders` は `order_type="market"` (成行 DAY 全数クローズ) で stop/limit は **audit メタデータに過ぎず Alpaca は成行の価格を無視**するため sub-penny 拒否は発生しない。端株の挙動は不変。

## 丸め before → after

| raw | 旧 `round(,4)` | 新 tick | 判定 |
|---|---|---|---|
| BABA `109.4519` | `109.4519` ❌ reject | `109.45` | ✅ valid ($0.01) |
| GSHD `52.0288` | `52.0288` ❌ reject | `52.03` | ✅ valid (HALF_UP 切上) |
| penny `0.5432` | `0.5432` | `0.5432` | ✅ 4桁維持 (2桁に潰さない) |
| `52.025` | `52.02` (float/banker) | `52.03` | ✅ HALF_UP |

## テスト (`tests/test_alpaca_exit_orders.py`)

- `TestRoundToAlpacaTick`: BABA/GSHD → valid tick / ≥$1→2桁 / <$1→4桁 / HALF_UP / None・非正 passthrough
- `TestNativeProtectionTickCompliance`: E2E で stop/target が valid tick・<$1 は 4桁維持・**existing coid dedup (held_for_orders 相当) は挙動不変**
- 既存の protection/time/breakout テストは全て green (回帰なし)

`pytest tests/test_alpaca_exit_orders.py tests/test_signals_to_orders.py` → **48 passed** / black・ruff・isort clean。

## 制約遵守

paper 限定・**建玉に触れず・破壊操作なし**・ライブ発注なし。次 run で 14 件の native stop/target が **resting** する見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)