### PR TITLE
fix(monitor): anchor freeze-adjusted "today" baseline to last_equity session (kill phantom P&L)

### DIFF
--- a/scripts/export_alpaca_snapshot.py
+++ b/scripts/export_alpaca_snapshot.py
@@ -450,12 +450,10 @@ def resolve_today_baseline(
     return (last_equity, "last_equity", None)
 
 
-def _fetch_prev_session_intraday_equity() -> float | None:
-    """前営業日 (直近完了セッション) の *intraday* 最終 equity を取得。
+def _history_by_day(period: str, timeframe: str, *, extended: bool) -> dict[str, float]:
+    """portfolio_history を引き、ET 日付 -> その日の *最終* equity にまとめる。
 
-    portfolio_history を intraday (1H, extended) で引き、ET 日付でグルーピング。
-    最新日=当日セッションとみなし、その一つ前の日の最終 intraday equity を返す。
-    取得失敗・データ不足時は None (=補正しない)。GET only / read-only / paper。
+    GET only / read-only / paper。取得失敗時は空 dict (=呼び出し側で補正しない)。
     """
     import requests
 
@@ -467,16 +465,20 @@ def _fetch_prev_session_intraday_equity() -> float | None:
         r = requests.get(
             f"{PAPER_BASE}/v2/account/portfolio/history",
             headers=headers,
-            params={"period": "7D", "timeframe": "1H", "extended_hours": "true"},
+            params={
+                "period": period,
+                "timeframe": timeframe,
+                "extended_hours": "true" if extended else "false",
+            },
             timeout=20,
         )
         j = r.json() if r.content else {}
     except Exception:  # pragma: no cover - network
-        return None
+        return {}
 
     ts = j.get("timestamp") or []
     eq = j.get("equity") or []
-    by_day: dict[str, float] = {}  # ET date -> その日の最終 intraday equity
+    by_day: dict[str, float] = {}  # ET date -> その日の最終 equity
     for i, t in enumerate(ts):
         e = _f(eq[i]) if i < len(eq) else None
         if e is None or e <= 0:
@@ -490,10 +492,59 @@ def _fetch_prev_session_intraday_equity() -> float | None:
         except Exception:
             continue
         by_day[day] = round(e, 2)  # timestamp 昇順なので後勝ち=その日最後
-    if len(by_day) < 2:
+    return by_day
+
+
+def _pick_baseline_intraday_equity(
+    last_equity: float | None,
+    daily_by_day: dict[str, float],
+    intraday_by_day: dict[str, float],
+) -> float | None:
+    """last_equity が指す完了セッションの *intraday 整合* equity を返す (pure)。
+
+    ``last_equity`` は Alpaca が報告する前営業日の *日次終値*。同じセッションを
+    daily(1D) 系列から value-match で特定し、その日の intraday(1H) 終値を基準候補
+    として返す。
+
+    off-by-one 回避: 日次パイプラインは **寄り付き前** (06:00 JST ≈ 前日夕方 ET)
+    に走り、週末/休場もあるため「intraday 系列の最新日」は当日ではなく **既に完了
+    した直近セッション** であることが多い。旧実装の ``sorted[-2]`` はこれを当日と
+    誤認し 1 セッション古い日を基準にしていた (phantom の原因)。last_equity に
+    アンカーすることで実行時刻・曜日に依らず正しい基準日を選ぶ。
+    """
+    if last_equity is None or not intraday_by_day:
         return None
-    prev_day = sorted(by_day)[-2]  # 最新=当日, その前=前営業日
-    return by_day.get(prev_day)
+    # 1) last_equity に一致する daily-close の日付を特定 (完了セッションの同定)。
+    target_day: str | None = None
+    if daily_by_day:
+        best: tuple[float, str] | None = None
+        for day, close in daily_by_day.items():
+            d = abs(close - last_equity)
+            if best is None or d < best[0]:
+                best = (d, day)
+        # last_equity は過去の完了セッション close と一致するはず (許容誤差内)。
+        if best is not None and best[0] <= max(1.0, abs(last_equity) * 0.001):
+            target_day = best[1]
+    # 2) 同定した日の intraday 終値を返す。
+    if target_day is not None and target_day in intraday_by_day:
+        return intraday_by_day[target_day]
+    # フォールバック: value-match 不成立時は intraday 系列の *最新* 完了日を採用。
+    # (旧 [-2] ではなく [-1]: 寄り前/週末では最新 intraday 日が直近完了セッション。)
+    return intraday_by_day[sorted(intraday_by_day)[-1]]
+
+
+def _fetch_prev_session_intraday_equity(last_equity: float | None) -> float | None:
+    """last_equity が指す完了セッションの intraday 整合 equity を取得。
+
+    daily(1D) と intraday(1H, extended) の両系列を引き、last_equity にアンカーして
+    正しい基準セッションを選ぶ。取得失敗・データ不足時は None (=補正しない)。
+    GET only / read-only / paper。
+    """
+    intraday_by_day = _history_by_day("7D", "1H", extended=True)
+    if not intraday_by_day:
+        return None
+    daily_by_day = _history_by_day("10D", "1D", extended=False)
+    return _pick_baseline_intraday_equity(last_equity, daily_by_day, intraday_by_day)
 
 
 def _accumulate_equity(results_dir: Path, today: str, equity: float | None) -> None:
@@ -913,7 +964,7 @@ def build_snapshot(
     if equity is not None and last_equity:
         pnl_today_abs_raw = round(equity - last_equity, 2)
         pnl_today_pct_raw = round((equity - last_equity) / last_equity * 100.0, 3)
-        prev_intraday = _fetch_prev_session_intraday_equity()
+        prev_intraday = _fetch_prev_session_intraday_equity(last_equity)
         pnl_today_baseline, pnl_today_basis, freeze_lag_gap = resolve_today_baseline(
             equity, last_equity, prev_intraday
         )

--- a/tests/test_export_alpaca_snapshot.py
+++ b/tests/test_export_alpaca_snapshot.py
@@ -233,6 +233,62 @@ def test_baseline_missing_equity_is_safe():
     assert ex.resolve_today_baseline(106000.0, 0.0, 105000.0)[1] == "last_equity"
 
 
+# --- baseline session pick (off-by-one regression, pure) -------------------
+# 実データ (2026-07-19 live probe, Sunday premarket run) で回帰を固定する。
+# 1D(daily-close) は 1H(intraday) より恒常的に ~$4,285 低い (Alpaca paper の
+# short 計上差と観測)。real-time equity は 1H と整合するため 1D が異常値。
+_D1 = {  # ET date -> daily-close (1D)
+    "2026-07-15": 102020.82,
+    "2026-07-16": 101130.14,
+    "2026-07-17": 100665.12,  # == account.last_equity (直近完了セッション)
+}
+_H1 = {  # ET date -> last intraday equity (1H/ext)
+    "2026-07-15": 106192.77,
+    "2026-07-16": 105703.75,
+    "2026-07-17": 104922.86,  # 07-17 の intraday 整合 close (正しい基準)
+}
+
+
+def test_pick_baseline_anchors_to_last_equity_session():
+    """off-by-one 回帰: 寄り前/週末実行でも last_equity の指すセッションを選ぶ。
+
+    旧 sorted[-2] は 07-16 (105703.75) を誤選択し phantom -$752 を出していた。
+    修正後は last_equity(=07-17 daily-close)にアンカーして 07-17 intraday
+    (104922.86) を返す → 当日 P&L はほぼ flat になる。
+    """
+    picked = ex._pick_baseline_intraday_equity(100665.12, _D1, _H1)
+    assert picked == pytest.approx(104922.86, abs=0.01)  # 07-17, NOT 07-16
+    # このセッション基準なら当日 P&L は実勢 (~$28, flat)。phantom(-$752)ではない。
+    equity_now = 104950.99
+    assert round(equity_now - picked, 2) == pytest.approx(28.13, abs=0.5)
+
+
+def test_pick_baseline_ignores_partial_today_daily_point():
+    """intraday 実行で 1D に当日 partial 点が混ざっても last_equity で正しく同定。"""
+    d1 = dict(_D1)
+    d1["2026-07-20"] = 105200.0  # 当日 partial (高い) が混ざるケース
+    h1 = dict(_H1)
+    h1["2026-07-20"] = 105100.0
+    # last_equity は依然 07-17 (前営業日 close)。当日 partial に釣られない。
+    picked = ex._pick_baseline_intraday_equity(100665.12, d1, h1)
+    assert picked == pytest.approx(104922.86, abs=0.01)  # 07-17
+
+
+def test_pick_baseline_fallback_latest_when_no_daily():
+    """1D 取得不可 (空) → intraday 最新日 (直近完了セッション) に fallback。
+
+    旧 [-2] ではなく [-1]: 寄り前/週末は最新 intraday 日が直近完了セッション。
+    """
+    picked = ex._pick_baseline_intraday_equity(100665.12, {}, _H1)
+    assert picked == pytest.approx(104922.86, abs=0.01)  # 最新 = 07-17
+
+
+def test_pick_baseline_empty_or_missing_is_safe():
+    """intraday 空 / last_equity 欠損なら None (=補正しない)。"""
+    assert ex._pick_baseline_intraday_equity(100665.12, _D1, {}) is None
+    assert ex._pick_baseline_intraday_equity(None, _D1, _H1) is None
+
+
 # --- ledger reconciliation (pure) -----------------------------------------
 def test_ledger_recon_all_consistent():
     """position が台帳ネットと一致すれば desync_free、mismatch 0。"""


### PR DESCRIPTION
## Problem
The dashboard's "today" P&L kept showing wrong numbers. On **2026-07-19** it showed a phantom **-\$752.76 (-0.71%)** when the paper account was actually **~flat** since Friday's close.

This is the *second* generation of the same phantom: the raw `equity - last_equity` gives a phantom **gain** (+\$4,285) because Alpaca paper's daily-close series runs ~\$4,258 low vs real equity; the freeze-adjust was added to route around that, but it introduced a phantom **loss** by picking the wrong session.

## Root cause -- off-by-one session pick
`_fetch_prev_session_intraday_equity` assumed *"latest 1H day == today's session"* and returned `sorted(by_day)[-2]` as the baseline. But the daily pipeline runs **pre-market** (06:00 JST ~= prior-evening ET) and on **weekends/holidays**, so the latest 1H day is already the **last completed session**, not today. Taking `[-2]` anchored the baseline one session too early:

| basis | value | result |
|---|---|---|
| raw (vs 1D last_equity 100,665.12) | +\$4,285.87 | phantom **gain** |
| old freeze-adjust (vs 07-16 intraday 105,703.75) | -\$752.76 | phantom **loss** (BUG) |
| **fixed (vs 07-17 intraday 104,922.86)** | **+\$28.13** | **~flat** (correct) |

Because the run is *always* pre-market, this off-by-one hit **every** daily snapshot, not just weekends.

## Fix
Anchor the baseline to the session `last_equity` actually represents. `last_equity` is Alpaca's prior **daily close**; value-match it against the 1D series to identify the session date, then use *that same date's* 1H (intraday-consistent) close as the baseline. Robust to run time / weekday / holidays.

- `_history_by_day()` extracted -- fetch a portfolio-history series -> `{ET date: last equity}`, reused for both 1D and 1H.
- `_pick_baseline_intraday_equity()` extracted as a **pure** function; falls back to the latest *completed* 1H day (`[-1]`, never the buggy `[-2]`) only if the 1D series is unavailable.
- 4 new unit tests pin the off-by-one regression against real 07-19 values.

## Verification (live Alpaca paper, read-only)
Corrected today P&L = **+\$28.13 (+0.03%)**, matching the 07-17 1H close (104,922.86) vs real-time equity (104,950.99). `basis` stays `freeze_adjusted` (the 1D close is genuinely lagged); equity / positions / unrealized untouched. Full-snapshot regen diff vs the live account changed **only** the 4 baseline fields.

`23 passed`, black + ruff clean.

Corrected 07-19 snapshot already republished to the monitor branch (Vercel) as a display-only patch; this PR is the durable code fix so the next daily run is correct at the source.

Co-Authored-By: Claude Opus 4.8 (1M context)

Generated with Claude Code