### PR TITLE
feat(exec): cancel-before-close exit fix + E2E measurement ledger

### DIFF
--- a/common/broker_alpaca.py
+++ b/common/broker_alpaca.py
@@ -440,6 +440,53 @@ def cancel_all_orders(client) -> None:
         client.cancel_all_orders()
 
 
+def cancel_open_orders_for_symbols(client, symbols: Iterable[str]) -> dict[str, Any]:
+    """指定 symbol の *未約定注文だけ* を cancel する (GET → 個別 cancel by id)。
+
+    なぜ必要か: time-based の full-close (成行) を出す前に、その銘柄の resting
+    protective 注文 (stop/limit/trailing) が position qty を握っていると、Alpaca は
+    ``code 40310000 (insufficient qty available / held_for_orders)`` で成行 close を
+    reject し、position が exit できず期限超過として滞留する。close 対象銘柄の保護
+    注文を先に外すことで qty を解放する。**保有継続する銘柄の保護注文は触らない**。
+
+    - ``cancel_all_orders`` (全消し) と違い、渡した symbol にスコープを限定する。
+    - 個別 cancel の失敗は握り潰し (best-effort)。返り値でカウントを返す。
+    - paper / read-then-cancel。position 自体は触らない。
+    """
+    want = {str(s).upper() for s in symbols if str(s).strip()}
+    result: dict[str, Any] = {"canceled": 0, "symbols": [], "want": sorted(want)}
+    if not want:
+        return result
+    try:
+        open_orders = get_open_orders(client)
+    except Exception:
+        return result
+    touched: list[str] = []
+    for o in open_orders or []:
+        sym = str(getattr(o, "symbol", "") or "").upper()
+        if sym not in want:
+            continue
+        oid = getattr(o, "id", None)
+        if oid is None:
+            continue
+        ok = False
+        for meth in ("cancel_order_by_id", "cancel_order"):
+            fn = getattr(client, meth, None)
+            if fn is None:
+                continue
+            try:
+                fn(oid)
+                ok = True
+                break
+            except Exception:
+                continue
+        if ok:
+            result["canceled"] += 1
+            touched.append(sym)
+    result["symbols"] = sorted(set(touched))
+    return result
+
+
 def subscribe_order_updates(client, log_callback=None):
     """注文更新の WebSocket を購読して即時実行（ブロッキング）。"""
     _require_sdk()

--- a/docs/E2E_MEASUREMENT_20260719.md
+++ b/docs/E2E_MEASUREMENT_20260719.md
@@ -1,0 +1,61 @@
+# サービスイン向け E2E 実測 — 起点・記録・残件 (2026-07-19)
+
+## サービスイン基準
+**Alpaca paper で entry + exit が E2E で完結して連続 1 週間 (= 5 取引日) 実測。**
+entry だけ回っている状態を「サービスイン」とは呼ばない。
+
+## 現到達度 (正直な評価)
+E2E の **配線 (wiring) は完成**しているが、**連続運用は未達**。
+
+| 要素 | 状態 | 根拠 |
+|---|---|---|
+| entry 発注→paper fill | ✅ 動作 | ledger_reconciliation n_desync=0 (214/220 一致)。07-08 の 37 entry 全 fill 実測。|
+| exit 発注→paper fill | ⚠ 動作するが不完全 | time-based close は動くが、resting protective 注文が qty を握ると 40310000 で失敗 (下記ブロッカー)。|
+| reconcile (fill 台帳突合) | ✅ 動作 | alpaca_snapshot.ledger_reconciliation, n_desync=0。|
+| **連続 5 取引日 E2E-clean** | ❌ **未達** | 最長 2 日 (07-13, 07-14)。07-15 でブロッカー発火、07-16/17 は端末ダウンで**ランナー未実行**、07-19 は dry-run。overdue exit が 38 件滞留。|
+
+ledger (`logs/e2e_measurement/ledger.md`) 実測: **9 取引日中 E2E-clean は 2 日、最長連続 2 日**。
+
+## E2E を塞いでいる残件
+
+### 1. [コード] cancel-before-close 未実装 → time-exit が held_for_orders で失敗 (本 PR で修正)
+日次 exit フローは、time-based の成行 close を出す前に、その銘柄の resting
+protective 注文 (stop/limit/trailing) を cancel していなかった。protective が
+position qty を全量握る (held_for_orders = qty) と、成行 close が Alpaca
+`code 40310000 (insufficient qty available)` で reject され、**position が exit
+できず期限超過として滞留**する。
+- 実測: 07-15 に time-based close が **9 件失敗** (全て system2 short)。live open orders
+  で overdue の 9 short 全てが今も protective STOP を保持 → 次回もこのままでは失敗。
+- **修正 (本 PR)**: `paper_exit_check.py` が close 対象銘柄 (time/breakout) の resting
+  注文だけを先に cancel → qty 解放 → 成行 close。`--no-cancel-before-close` で無効化可。
+  保有継続銘柄の保護は不変。unit test 5 件。**live 検証は次の市場オープン (07-20) 待ち**。
+
+### 2. [運用] 実行継続性 — ランナーが取引日に必ず発火する保証がない
+order 実行ランナー `QuantTrading_OpenAutoRun` (月〜金 22:35 JST) は端末が
+起動している必要がある。07-16/17 は端末ダウンで**未実行** → その日の exit/entry が
+丸ごと欠落し、overdue が積み上がった。**catch-up は市場が閉じた後では効かない**
+(signal pipeline の cache catch-up とは別問題)。
+- durable fix 候補: (a) 22:35 JST に端末が起きている運用保証 (wake timer / 常時起動),
+  (b) 起床時に「未実行の取引日ぶんの overdue exit を market open で flush」する catch-up。
+  → 運用判断 (HUMAN_TASK 相当)。本セッションでは特定・記録のみ。
+
+## 1 週間実測の「起点」と「記録の仕組み」
+- **記録の仕組み**: `scripts/build_e2e_ledger.py` (read-only)。ランナーが既に書く
+  recon/exit_orders/paper_orders/alpaca_snapshot を 1 行/取引日に集約し
+  `logs/e2e_measurement/ledger.{jsonl,md}` に upsert。日次で再実行すれば積み上がる。
+- **clean な取引日の定義**: `ran(submitted) & time_exit_failed==0 & n_desync==0 &
+  overdue_exits==0`。protect_* の重複拒否は無害として除外。
+- **起点 (measurement start condition)**: 次の全てを満たす最初の取引日を Day 1 とする。
+  1. cancel-before-close 修正が runner tree に反映済 (arming)。
+  2. overdue backlog (現 38 件) が flush されて overdue_exits==0。
+  3. その日が `e2e_clean == true`。
+  以後 **連続 5 取引日 clean** で「1 週間 E2E 実測」達成。ledger の「最長連続」で判定。
+- **運用**: 毎日ランナー完了後に `python scripts/build_e2e_ledger.py` を叩く
+  (open_auto_run への配線は後追いでも可。まずは手動 or SelfMonitor から)。
+
+## 次アクション
+1. 本 PR (cancel-before-close + ledger) を main へ。
+2. **arming**: runner tree (`C:/tmp/qts-main-run`, `claude/open-auto-run`) に
+   cancel-before-close を反映するか判断 (無人 paper 発注の挙動変更のため要判断)。
+3. 07-20 (月) の実ランで overdue 38 件が flush され time_exit_failed==0 になることを
+   ledger で確認 → Day 1 判定。

--- a/scripts/build_e2e_ledger.py
+++ b/scripts/build_e2e_ledger.py
@@ -1,0 +1,194 @@
+"""E2E paper-trading measurement ledger (READ-ONLY consolidation).
+
+サービスイン基準 = 「Alpaca paper で entry + exit が E2E で完結して1週間実測」。
+その「durable な記録の仕組み」がこれ。日次ランナー (open_auto_run) が既に書く
+per-day 成果物を 1 行/取引日に集約し、E2E が実際に回った日を客観化する。
+
+読むだけ (発注・cancel・変更は一切しない)。入力 (results_csv/、全て日次生成):
+    - recon_{YYYYMMDD}.json         : entry/exit submitted・filled 等の実行サマリ
+    - exit_orders_{YYYYMMDD}.json   : exit の mode / submitted / failed
+    - paper_orders_{YYYYMMDD}.json  : entry の mode (submitted/dry_run)
+    - alpaca_snapshot_{YYYYMMDD}.json: equity・保有数・ledger desync・期限超過 exit 数
+
+出力:
+    - logs/e2e_measurement/ledger.jsonl  (1 行/日, upsert)
+    - logs/e2e_measurement/ledger.md     (人間可読サマリ)
+
+「E2E clean な取引日」の判定 (measurement 起点/継続の基準):
+    ran(submitted mode) かつ time_exit_failed==0 かつ n_desync==0 かつ overdue_exits==0。
+    (protect_* の重複拒否は保護が既に有効な印なので clean を妨げない。)
+    連続 5 取引日 clean で「1週間 E2E 実測」達成。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(p: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _dates(results_dir: Path) -> list[str]:
+    """recon か snapshot が存在する全日付 (YYYYMMDD) を昇順で。"""
+    out: set[str] = set()
+    for prefix in ("recon_", "alpaca_snapshot_"):
+        for f in results_dir.glob(f"{prefix}*.json"):
+            digits = "".join(c for c in f.stem if c.isdigit())[:8]
+            if len(digits) == 8:
+                out.add(digits)
+    return sorted(out)
+
+
+def _overdue_exits(snap: dict[str, Any] | None) -> int | None:
+    if not snap:
+        return None
+    n = 0
+    for p in snap.get("positions", []) or []:
+        if p.get("exit_expected") == "time_based" or (
+            p.get("days_remaining") is not None
+            and p["days_remaining"] <= 0
+            and p.get("max_holding_days", 0) > 0
+        ):
+            n += 1
+    return n
+
+
+def build_row(results_dir: Path, d8: str) -> dict[str, Any]:
+    iso = f"{d8[:4]}-{d8[4:6]}-{d8[6:]}"
+    recon = _load(results_dir / f"recon_{d8}.json")
+    eo = _load(results_dir / f"exit_orders_{d8}.json")
+    po = _load(results_dir / f"paper_orders_{d8}.json")
+    snap = _load(results_dir / f"alpaca_snapshot_{d8}.json")
+
+    port = (recon or {}).get("portfolio", {}) if recon else {}
+    exit_mode = (eo or {}).get("mode")
+    entry_mode = (po or {}).get("mode")
+    # "ran" = 実発注モードで exit/entry のどちらかが submitted 由来
+    ran = exit_mode == "submitted" or entry_mode == "submitted"
+
+    exit_failed = (eo or {}).get("failed")
+    # 失敗を「有害 (time/breakout の full close が失敗=ポジション未 exit)」と
+    # 「無害 (protect_* の再発注が held_for_orders で重複拒否=保護は既に有効)」に分離。
+    time_exit_failed = protect_dup_failed = None
+    if eo and isinstance(eo.get("exits"), list):
+        time_exit_failed = protect_dup_failed = 0
+        for e in eo["exits"]:
+            if not e.get("error"):
+                continue
+            reason = str(e.get("reason") or "")
+            if reason in ("time_based", "spy_breakout"):
+                time_exit_failed += 1
+            elif reason.startswith("protect"):
+                protect_dup_failed += 1
+    lr = (snap or {}).get("ledger_reconciliation", {}) if snap else {}
+    n_desync = lr.get("n_desync")
+    overdue = _overdue_exits(snap)
+    acct = (snap or {}).get("account", {}) if snap else {}
+
+    # clean は「有害な失敗」だけを見る: time/breakout close 失敗が 0、desync 0、
+    # 期限超過 exit 0。protect_* の重複拒否 (protect_dup_failed) は保護が既に有効な
+    # ことを意味するので clean を妨げない。
+    clean = bool(ran and (time_exit_failed == 0) and (n_desync == 0) and (overdue == 0))
+
+    return {
+        "date": iso,
+        "ran": ran,
+        "exit_mode": exit_mode,
+        "entry_mode": entry_mode,
+        "signals": port.get("signals"),
+        "orders_generated": port.get("orders_generated"),
+        "entry_submitted": port.get("entry_submitted"),
+        "entry_filled": port.get("entry_filled"),
+        "entry_failed": port.get("entry_failed"),
+        "entry_skipped": port.get("entry_skipped"),
+        "exit_submitted": port.get("exit_submitted"),
+        "exit_close_time": port.get("exit_close"),
+        "exit_protect": port.get("exit_protect"),
+        "exit_failed": exit_failed,
+        "time_exit_failed": time_exit_failed,
+        "protect_dup_failed": protect_dup_failed,
+        "n_desync": n_desync,
+        "overdue_exits": overdue,
+        "equity": acct.get("equity"),
+        "n_positions": (
+            (snap or {}).get("summary", {}).get("n_positions") if snap else None
+        ),
+        "e2e_clean": clean,
+        "artifacts": {
+            "recon": recon is not None,
+            "exit_orders": eo is not None,
+            "paper_orders": po is not None,
+            "snapshot": snap is not None,
+        },
+    }
+
+
+def _write_md(rows: list[dict[str, Any]], path: Path) -> None:
+    lines = [
+        "# E2E paper measurement ledger",
+        "",
+        "サービスイン基準 = Alpaca paper で entry+exit が E2E 完結して **連続5取引日** clean。",
+        "clean = ran(submitted) & time_exit_failed==0 & n_desync==0 & overdue_exits==0。",
+        "",
+        "harmful = time/breakout close 失敗 (ポジション未 exit)。dup = protect_* 重複拒否 (無害)。",
+        "",
+        "| date | ran | mode(x/e) | entry sub/fill/fail | exit sub/close | time-fail(harmful) | dup(benign) | desync | overdue | equity | pos | CLEAN |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for r in rows:
+        mode = f"{(r['exit_mode'] or '-')[:3]}/{(r['entry_mode'] or '-')[:3]}"
+        lines.append(
+            f"| {r['date']} | {'Y' if r['ran'] else '.'} | {mode} "
+            f"| {r['entry_submitted']}/{r['entry_filled']}/{r['entry_failed']} "
+            f"| {r['exit_submitted']}/{r['exit_close_time']} "
+            f"| {r['time_exit_failed']} | {r['protect_dup_failed']} "
+            f"| {r['n_desync']} | {r['overdue_exits']} "
+            f"| {r['equity']} | {r['n_positions']} | {'✅' if r['e2e_clean'] else '—'} |"
+        )
+    # streak summary
+    streak = 0
+    best = 0
+    for r in rows:
+        streak = streak + 1 if r["e2e_clean"] else 0
+        best = max(best, streak)
+    lines += [
+        "",
+        f"**最長 E2E-clean 連続取引日: {best} / 5**  "
+        f"(直近: {'clean' if rows and rows[-1]['e2e_clean'] else 'not clean'})",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--results-dir", default=str(ROOT / "results_csv"))
+    ap.add_argument("--out-dir", default=str(ROOT / "logs" / "e2e_measurement"))
+    args = ap.parse_args(argv)
+    results_dir = Path(args.results_dir)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = [build_row(results_dir, d8) for d8 in _dates(results_dir)]
+    (out_dir / "ledger.jsonl").write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+    _write_md(rows, out_dir / "ledger.md")
+    clean_days = sum(1 for r in rows if r["e2e_clean"])
+    print(f"[e2e_ledger] {len(rows)} trading-days scanned, {clean_days} E2E-clean")
+    print(f"[write] {out_dir / 'ledger.jsonl'}")
+    print(f"[write] {out_dir / 'ledger.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/paper_exit_check.py
+++ b/scripts/paper_exit_check.py
@@ -30,6 +30,7 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 import sys
+import time
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -38,6 +39,7 @@ import pandas as pd  # noqa: E402
 
 from common import broker_alpaca as ba  # noqa: E402
 from common.alpaca_trading import (  # noqa: E402
+    ExitReasonCode,
     LiveAccountGuardError,
     PositionSnapshot,
     PreparedExit,
@@ -303,6 +305,20 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Alpaca API を叩かず tracker のみで動く (test / offline 用)。",
     )
+    parser.add_argument(
+        "--no-cancel-before-close",
+        action="store_true",
+        help=(
+            "time/breakout の成行 close 前に対象銘柄の resting protective 注文を "
+            "cancel する挙動を無効化する (既定は有効)。"
+        ),
+    )
+    parser.add_argument(
+        "--cancel-settle-seconds",
+        type=float,
+        default=2.5,
+        help="cancel 後、qty 解放を待つ秒数 (default 2.5)。",
+    )
     args = parser.parse_args(argv)
 
     date_str = args.date or _today_str()
@@ -373,6 +389,27 @@ def main(argv: list[str] | None = None) -> int:
         for po in exits:
             po.dry_run = True
     else:
+        # --- cancel-before-close: 有害な held_for_orders 失敗を防ぐ -----------
+        # time/breakout の full-close (成行) を出す銘柄は、resting protective 注文
+        # (stop/limit/trailing) が qty を握って code 40310000 を招く。close 対象銘柄
+        # だけ先に protective を cancel して qty を解放する。保有継続銘柄は不変。
+        if not getattr(args, "no_cancel_before_close", False):
+            close_syms = {
+                po.symbol.upper()
+                for po in exits
+                if po.reason in (ExitReasonCode.TIME, ExitReasonCode.BREAKOUT)
+            }
+            if close_syms:
+                canc = ba.cancel_open_orders_for_symbols(client, close_syms)
+                print(
+                    f"[exit_check] cancel-before-close: canceled "
+                    f"{canc['canceled']} resting order(s) on {len(canc['symbols'])} "
+                    f"symbol(s) before market close"
+                )
+                if canc["canceled"]:
+                    # cancel は非同期。qty が解放されるまで短く待つ (best-effort)。
+                    time.sleep(float(getattr(args, "cancel_settle_seconds", 2.5)))
+
         # 実発注 pass
         for po in exits:
             try:

--- a/tests/test_cancel_before_close.py
+++ b/tests/test_cancel_before_close.py
@@ -1,0 +1,88 @@
+"""Unit tests for cancel-before-close (held_for_orders exit blocker fix).
+
+`cancel_open_orders_for_symbols` must cancel ONLY the requested symbols' resting
+orders (freeing qty for a time-based market close) and leave every other symbol's
+protective orders untouched. No network — a fake client records cancel calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common import broker_alpaca as ba
+
+
+class _FakeOrder:
+    def __init__(self, symbol: str, oid: str):
+        self.symbol = symbol
+        self.id = oid
+
+
+class _FakeClient:
+    def __init__(self, orders, *, fail_ids=frozenset()):
+        self._orders = orders
+        self.canceled: list[str] = []
+        self._fail_ids = set(fail_ids)
+
+    # get_open_orders() -> client.get_orders(GetOrdersRequest(status=OPEN))
+    def get_orders(self, _request):
+        return self._orders
+
+    def cancel_order_by_id(self, oid):
+        if oid in self._fail_ids:
+            raise RuntimeError("boom")
+        self.canceled.append(oid)
+
+
+def _orders():
+    return [
+        _FakeOrder("RGNX", "o1"),
+        _FakeOrder("BABA", "o2"),
+        _FakeOrder("AAPL", "o3"),  # must NOT be canceled
+        _FakeOrder("rgnx", "o4"),  # case-insensitive match
+    ]
+
+
+def test_cancels_only_requested_symbols():
+    client = _FakeClient(_orders())
+    res = ba.cancel_open_orders_for_symbols(client, {"RGNX", "BABA"})
+    assert res["canceled"] == 3  # o1, o2, o4
+    assert set(client.canceled) == {"o1", "o2", "o4"}
+    assert "o3" not in client.canceled  # AAPL protective order preserved
+    assert set(res["symbols"]) == {"RGNX", "BABA"}
+
+
+def test_empty_symbols_is_noop():
+    client = _FakeClient(_orders())
+    res = ba.cancel_open_orders_for_symbols(client, set())
+    assert res["canceled"] == 0
+    assert client.canceled == []
+
+
+def test_case_insensitive_input():
+    client = _FakeClient(_orders())
+    res = ba.cancel_open_orders_for_symbols(client, {"rgnx"})
+    assert set(client.canceled) == {"o1", "o4"}
+    assert res["canceled"] == 2
+
+
+def test_individual_cancel_failure_is_swallowed():
+    client = _FakeClient(_orders(), fail_ids={"o1"})
+    res = ba.cancel_open_orders_for_symbols(client, {"RGNX", "BABA"})
+    # o1 fails, o2 and o4 still cancel
+    assert res["canceled"] == 2
+    assert set(client.canceled) == {"o2", "o4"}
+
+
+def test_get_orders_failure_returns_zero():
+    class _Boom:
+        def get_orders(self, _r):
+            raise RuntimeError("network")
+
+    res = ba.cancel_open_orders_for_symbols(_Boom(), {"RGNX"})
+    assert res["canceled"] == 0
+    assert res["symbols"] == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Toward the service-in bar (**Alpaca paper entry+exit E2E for 1 continuous week**). Two parts.

## 1. Fix: time-based exits fail with held_for_orders (Alpaca 40310000)
The daily exit flow submitted a time-based **market close** without first canceling that symbol's **resting protective orders** (stop/limit/trailing). When a protective order holds the full position qty, the close is rejected with `code 40310000 (insufficient qty available)` and the position **never exits** -> it piles up as overdue.

**Evidence:** 2026-07-15 had **9 time-based closes fail**, all system2 shorts. Live open orders confirm all 9 overdue shorts (BABA, CLMT, GSHD, INSM, IRON, PARR, RGNX, SNDX, XENE) **still hold protective STOPs** -> the next run would fail identically. This is the direct cause of the 38 currently-overdue exits.

**Fix:** `paper_exit_check.py` cancels resting orders for exactly the symbols being market-closed (time/breakout) before submitting -> frees qty. Held-position protection untouched. New scoped helper `broker_alpaca.cancel_open_orders_for_symbols` (best-effort). Guarded by `--no-cancel-before-close`; `--cancel-settle-seconds` (default 2.5) waits out the async cancel. **5 unit tests** (fake client, no network). **Live verification pending the 2026-07-20 market open.**

## 2. E2E measurement ledger (read-only)
`scripts/build_e2e_ledger.py` consolidates the per-day artifacts the runner already writes (recon/exit_orders/paper_orders/alpaca_snapshot) into one row per trading day -> `logs/e2e_measurement/ledger.{jsonl,md}`. Defines the **E2E-clean day** bar (`ran & time_exit_failed==0 & n_desync==0 & overdue==0`), separating harmful time-close failures from benign protective-order dup rejects.

**Backfill (9 days):** only 07-13/14/15 actually ran; best clean streak = **2 days**; 07-16/17 missed (terminal down); **38 exits overdue** now. `docs/E2E_MEASUREMENT_20260719.md` gives the honest state, both blockers (this fix + execution-continuity), and the 1-week measurement start condition.

## Note on delivery
Merging to main does **not** arm the runner (`qts-main-run` / `open-auto-run` doesn't auto-sync main). Arming = applying the fix to that tree so Monday's unattended paper run uses it — flagged as a separate decision.

black + ruff clean; 5 new + 6 existing exit tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context)

Generated with Claude Code