### PR TITLE
monitor: surface silent exit-step & total-cache freezes + rolling→filter→setup IT

### DIFF
--- a/common/alpaca_trading.py
+++ b/common/alpaca_trading.py
@@ -1377,13 +1377,24 @@ def _snapshot_from_alpaca_position(p: Any) -> PositionSnapshot | None:
         return None
 
 
-def fetch_position_snapshots(client: Any) -> list[PositionSnapshot]:
-    """Alpaca client から現 positions を取得し、PositionSnapshot list を返す。"""
+def fetch_position_snapshots(
+    client: Any, *, raise_on_error: bool = False
+) -> list[PositionSnapshot]:
+    """Alpaca client から現 positions を取得し、PositionSnapshot list を返す。
+
+    ``raise_on_error=True`` の場合、``get_all_positions`` の失敗を silent ``[]`` に
+    畳まず ``PositionsFetchError`` を raise する。exit_check が「取得失敗 (broker
+    unreachable)」と「本当に空 (flat book)」を区別できるようにするため
+    (entry 側 ``_fetch_open_positions`` と同じ fail-closed 方針)。default False は
+    既存 caller (``paper_trading_status``) の挙動を保つ。
+    """
     out: list[PositionSnapshot] = []
     try:
         raw = client.get_all_positions()
-    except Exception as exc:  # pragma: no cover
+    except Exception as exc:
         logger.warning("get_all_positions 失敗: %s", exc)
+        if raise_on_error:
+            raise PositionsFetchError(f"Alpaca positions fetch failed: {exc}") from exc
         return out
     for p in raw or []:
         snap = _snapshot_from_alpaca_position(p)

--- a/scripts/check_rolling_freshness.py
+++ b/scripts/check_rolling_freshness.py
@@ -29,6 +29,7 @@ from common.cache_freshness import (  # noqa: E402
     modal_last_date,
     symbols_behind_upstream,
 )
+from common.utils_spy import get_latest_nyse_trading_day  # noqa: E402
 
 
 def _load_universe(path: Path | None) -> set[str] | None:
@@ -101,6 +102,21 @@ def main(argv: list[str] | None = None) -> int:
         help="signal universe (one symbol/line); scopes the freeze check "
         "so non-universe ETFs are not counted. default data/universe_auto.txt",
     )
+    p.add_argument(
+        "--max-abs-lag-bdays",
+        type=int,
+        default=2,
+        help="WARN if upstream (full_backup) newest date lags the latest NYSE "
+        "trading day by more than this many business days (total-freeze "
+        "detector; catches rolling+upstream both frozen, which the relative "
+        "check reads as fresh). Generous default avoids vendor EOD-lag noise.",
+    )
+    p.add_argument(
+        "--today",
+        default=None,
+        help="reference 'today' (YYYY-MM-DD, ET) for the absolute-staleness "
+        "check; default = now in America/New_York. Mainly for tests.",
+    )
     args = p.parse_args(argv)
 
     try:
@@ -141,6 +157,37 @@ def main(argv: list[str] | None = None) -> int:
         f"[freshness] rolling modal={r_mode} (max={max_last_date(rolling)}, {len(rolling)} files) | "
         f"upstream modal={u_mode} (max={max_last_date(upstream)}, {len(upstream)} files)"
     )
+
+    # --- absolute-staleness (total-freeze) check ---------------------------
+    # 既存の rolling-vs-upstream 比較は「両方同時に凍結」を検知できない (lag=0 で
+    # fresh に見える)。upstream(full_backup) 自体が NYSE カレンダーの直近取引日から
+    # どれだけ遅れているかを絶対評価し、多日フリーズを surface する。
+    # 2026-07-12..14 のダッシュ凍結 (cache step が確定日を取れず全体停滞) は、
+    # この経路なら検知できた。exit 2 は soft WARN (pipeline は継続、$Failures に計上)。
+    try:
+        import pandas as pd  # local import: 起動コストを絶対チェック時のみに限定
+
+        ref = (
+            pd.Timestamp(args.today)
+            if args.today
+            else pd.Timestamp.now(tz="America/New_York").tz_localize(None)
+        )
+        latest_trading = get_latest_nyse_trading_day(ref)
+        latest_iso = latest_trading.date().isoformat()
+        u_max = max_last_date(upstream)
+        abs_lag = lag_business_days(u_max, latest_iso)
+        if abs_lag is not None and abs_lag > args.max_abs_lag_bdays:
+            print(
+                f"[freshness] WARN: upstream(full_backup) newest={u_max} は直近 NYSE "
+                f"取引日 ({latest_iso}) から {abs_lag} 営業日遅れています "
+                f"(> {args.max_abs_lag_bdays})。キャッシュ全体が凍結している疑い "
+                "(cache step が確定日を取得できていない)。cache_daily_polygon.py の "
+                "実行と Polygon 接続を確認してください。"
+            )
+            return 2
+    except Exception as exc:  # noqa: BLE001
+        # 絶対チェックは best-effort。失敗しても既存の相対チェックは実行する。
+        print(f"[freshness] (absolute-staleness check skipped: {exc})")
 
     if universe:
         behind = symbols_behind_upstream(rolling, upstream, universe=universe)

--- a/scripts/daily_pipeline.ps1
+++ b/scripts/daily_pipeline.ps1
@@ -352,6 +352,7 @@ try {
         $ec = Invoke-Step -Name "exit_check" -PyArgs $ecArgs
         if ($ec -eq 1) { $Failures += "exit_check(exit=1)" }
         elseif ($ec -eq 2) { $Failures += "exit_check(safety_abort)" }
+        elseif ($ec -eq 3) { $Failures += "exit_check(broker_unreachable)" }
     }
 
     # --- Step 5d: execution summary (submit 後の実発注サマリを recon 化 + 通知) ---

--- a/scripts/paper_exit_check.py
+++ b/scripts/paper_exit_check.py
@@ -41,6 +41,7 @@ from common import broker_alpaca as ba  # noqa: E402
 from common.alpaca_trading import (  # noqa: E402
     ExitReasonCode,
     LiveAccountGuardError,
+    PositionsFetchError,
     PositionSnapshot,
     PreparedExit,
     assert_paper_env,
@@ -336,6 +337,9 @@ def main(argv: list[str] | None = None) -> int:
     snapshots: list[PositionSnapshot] = []
     existing_protect_coids: set[str] = set()
     existing_exit_coids: set[str] = set()
+    # broker が到達不能で positions を取れなかった場合、「0 exits = 成功」と誤認
+    # させないための anomaly フラグ (--no-alpaca の意図的 offline とは区別する)。
+    broker_unreachable = False
 
     if not args.no_alpaca:
         if args.confirm:
@@ -349,12 +353,22 @@ def main(argv: list[str] | None = None) -> int:
         except Exception as exc:
             print(f"[warn] Alpaca client 取得失敗 (offline mode で継続): {exc}")
             client = None
+            broker_unreachable = True
 
     if client is not None:
-        snapshots = fetch_position_snapshots(client)
-        existing_protect_coids = fetch_existing_protect_coids(client)
-        existing_exit_coids = fetch_existing_exit_coids(client)
-        _hydrate_from_alpaca_coids(snapshots, client)
+        try:
+            snapshots = fetch_position_snapshots(client, raise_on_error=True)
+        except PositionsFetchError as exc:
+            # client は取れたが positions fetch が失敗 (transient outage 等)。
+            # silent [] に畳むと「flat book」と区別できず exit が全 skip されても
+            # exit0 で成功に見える → anomaly として surface する。
+            print(f"[warn] positions 取得失敗 (broker unreachable): {exc}")
+            snapshots = []
+            broker_unreachable = True
+        else:
+            existing_protect_coids = fetch_existing_protect_coids(client)
+            existing_exit_coids = fetch_existing_exit_coids(client)
+            _hydrate_from_alpaca_coids(snapshots, client)
 
     # --- 2) tracker / entry_orders_index --------------------------------
     tracker = load_tracker()
@@ -433,6 +447,7 @@ def main(argv: list[str] | None = None) -> int:
             "count": len(exits),
             "submitted": submitted_ok,
             "failed": submit_failed,
+            "broker_unreachable": broker_unreachable,
             "spy_high": spy_high,
             "spy_max70": spy_max70,
             "systems": {
@@ -458,6 +473,17 @@ def main(argv: list[str] | None = None) -> int:
         f"mode={mode} submitted={submitted_ok} failed={submit_failed}"
     )
     print(f"[write] {output_path}")
+    # broker 到達不能で positions を確認できなかった場合、exit が 0 件でも「成功
+    # (flat book)」と誤認させない。distinct code 3 で daily_pipeline に surface
+    # する (entry 側の no_orders_generated=3 と同じ観測性方針)。市場が閉じた後の
+    # 沈黙 exit 失敗 = position 滞留の温床なので必ず flag する。
+    if broker_unreachable:
+        print(
+            "[WARN] broker (Alpaca) に到達できず現保有 positions を確認できませんでした。"
+            "exit 判定は行われていません (0 exits は flat book ではなく取得失敗)。"
+            "接続を確認し、必要なら再実行してください。"
+        )
+        return 3
     return 0 if submit_failed == 0 else 1
 
 

--- a/tests/system/test_rolling_filter_setup_chain.py
+++ b/tests/system/test_rolling_filter_setup_chain.py
@@ -1,0 +1,95 @@
+"""Integration: rolling → indicators → filter → setup → candidate の連鎖が
+実データ形状の frame で seam を跨いで機能すること (silent 3-stage break の回帰)。
+
+背景 (2026-07-19 audit — gap ii):
+    既存の signal test は stage 単位、または事前計算済みの setup/filter 列を
+    fixture に焼き込んでおり、indicator→filter や filter→setup の列名/契約が
+    割れて candidates が 0 件に silent 落ちする seam を end-to-end で検知して
+    いなかった。本 test は raw OHLCV から実パイプライン関数
+    (add_indicators / filter_system1 / prepare_data_vectorized_system1 /
+    generate_candidates_system1) を通し、各 seam が生きていることを確認する。
+
+    System1 (ROC200 momentum long) を代表に、明確な上昇トレンドを合成して
+    filter (Close>=5 & DV20>=50M) と setup (SMA25>SMA50 & ROC200>0) を両方
+    満たすようにし、chain が候補を生む (= seam が全部生きている) ことを assert する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _uptrend_ohlcv(n: int = 260) -> pd.DataFrame:
+    """DV20>=50M & 明確な上昇トレンドの合成 OHLCV (System1 の filter+setup 通過用)。"""
+    idx = pd.bdate_range("2025-01-01", periods=n)
+    close = np.linspace(50.0, 150.0, n)
+    df = pd.DataFrame(
+        {
+            "Open": close * 0.995,
+            "High": close * 1.01,
+            "Low": close * 0.985,
+            "Close": close,
+            "Volume": np.full(n, 1_500_000.0),
+        },
+        index=idx,
+    )
+    df.index.name = "Date"
+    return df
+
+
+def test_rolling_filter_setup_chain_system1_produces_candidate():
+    from common.indicators_common import add_indicators
+    from common.today_filters import filter_system1
+    from core.system1 import (
+        generate_candidates_system1,
+        prepare_data_vectorized_system1,
+    )
+
+    sym = "UPTR"
+    raw = _uptrend_ohlcv()
+
+    # --- seam 1: rolling frame -> indicators (numeric, not all-NaN) ----------
+    ind = add_indicators(raw)
+    for col in ("sma25", "sma50", "roc200"):
+        assert col in ind.columns, f"indicator '{col}' missing (indicator stage broke)"
+        assert ind[col].notna().any(), f"'{col}' all-NaN (indicator stage broke)"
+
+    # --- seam 2: indicators -> filter ---------------------------------------
+    stats: dict = {}
+    passed = filter_system1([sym], {sym: ind}, stats)
+    assert stats.get("total") == 1
+    assert stats.get("dv_pass") == 1, "engineered uptrend should pass DV20>=50M"
+    assert (
+        sym in passed
+    ), "filter dropped a qualifying symbol (indicator→filter seam broke)"
+
+    # --- seam 3: prepare (filter+setup) -> setup True on qualifying row ------
+    # 実パイプラインの rolling cache は指標を precompute 済 → prepare は reuse する。
+    # ここでは seam 1 の add_indicators 出力 (=rolling cache 相当) を食わせる。
+    prepared = prepare_data_vectorized_system1(
+        {sym: ind}, symbols=[sym], reuse_indicators=True
+    )
+    assert sym in prepared and not prepared[sym].empty
+    pdf = prepared[sym]
+    assert "setup" in pdf.columns, "setup column missing (filter→setup seam broke)"
+    assert (
+        bool(pdf["setup"].iloc[-1]) is True
+    ), "qualifying uptrend last row should be setup=True (setup logic broke)"
+
+    # --- seam 4: setup -> candidate generation (latest_only = daily path) ----
+    res = generate_candidates_system1(
+        prepared, top_n=10, latest_only=True, include_diagnostics=True
+    )
+    candidates = res[0]
+    assert candidates, (
+        "chain yielded 0 candidates for a strong uptrend "
+        "(setup→candidate seam broke — this is the silent-3-stage failure mode)"
+    )

--- a/tests/test_check_rolling_freshness_absolute.py
+++ b/tests/test_check_rolling_freshness_absolute.py
@@ -1,0 +1,100 @@
+"""Regression: freshness guard が「rolling も upstream も同時凍結」を検知すること。
+
+背景 (2026-07-19 audit — blind spot a):
+    ``scripts/check_rolling_freshness.py`` は rolling を upstream(full_backup) と
+    相対比較するだけだったため、cache step が確定日を取得できず **両方が同じ古い日で
+    凍結** すると lag=0 = fresh に見えた。2026-07-12..14 のダッシュ凍結
+    (キャッシュ全体停滞) はこの盲点そのもの。
+
+    追加した絶対チェック: upstream の最新日が NYSE カレンダーの直近取引日から
+    ``--max-abs-lag-bdays`` (既定 2, vendor EOD-lag を吸収) を超えて遅れていたら
+    exit 2 (soft WARN) で surface する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import scripts.check_rolling_freshness as crf  # noqa: E402
+
+
+def _write_csv(d: Path, sym: str, last_date: str) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{sym}.csv").write_text(
+        f"Date,Close\n2026-01-02,100\n{last_date},101\n", encoding="utf-8"
+    )
+
+
+def test_total_freeze_is_detected(tmp_path: Path):
+    """rolling も upstream も 07-01 で凍結 → 相対 lag=0 でも絶対チェックで exit 2。"""
+    rolling = tmp_path / "rolling"
+    upstream = tmp_path / "full"
+    for sym in ("AAA", "BBB"):
+        _write_csv(rolling, sym, "2026-07-01")
+        _write_csv(upstream, sym, "2026-07-01")
+
+    rc = crf.main(
+        [
+            "--rolling-dir",
+            str(rolling),
+            "--upstream-dir",
+            str(upstream),
+            "--today",
+            "2026-07-19",  # 直近取引日 = 2026-07-17 (金); 07-01 から ~12 営業日遅れ
+        ]
+    )
+    assert rc == 2
+
+
+def test_fresh_upstream_does_not_false_fire(tmp_path: Path):
+    """upstream が直近取引日と一致 → 絶対チェックは発火せず 0。"""
+    rolling = tmp_path / "rolling"
+    upstream = tmp_path / "full"
+    uni = tmp_path / "universe.txt"
+    uni.write_text("AAA\nBBB\n", encoding="utf-8")
+    for sym in ("AAA", "BBB"):
+        _write_csv(rolling, sym, "2026-07-17")
+        _write_csv(upstream, sym, "2026-07-17")
+
+    rc = crf.main(
+        [
+            "--rolling-dir",
+            str(rolling),
+            "--upstream-dir",
+            str(upstream),
+            "--universe-file",
+            str(uni),
+            "--today",
+            "2026-07-17",  # 金曜、取引日
+        ]
+    )
+    assert rc == 0
+
+
+def test_within_tolerance_does_not_fire(tmp_path: Path):
+    """vendor EOD-lag 相当 (2 営業日以内) は誤検知しない。"""
+    rolling = tmp_path / "rolling"
+    upstream = tmp_path / "full"
+    uni = tmp_path / "universe.txt"
+    uni.write_text("AAA\n", encoding="utf-8")
+    # 直近取引日 07-17(金) に対し upstream 07-15(水) = 2 営業日遅れ = 許容内。
+    _write_csv(rolling, "AAA", "2026-07-15")
+    _write_csv(upstream, "AAA", "2026-07-15")
+    rc = crf.main(
+        [
+            "--rolling-dir",
+            str(rolling),
+            "--upstream-dir",
+            str(upstream),
+            "--universe-file",
+            str(uni),
+            "--today",
+            "2026-07-17",
+        ]
+    )
+    assert rc == 0

--- a/tests/test_paper_exit_check_broker_unreachable.py
+++ b/tests/test_paper_exit_check_broker_unreachable.py
@@ -1,0 +1,111 @@
+"""Regression: exit_check が broker 到達不能を silent success させないこと。
+
+背景 (2026-07-19 audit):
+    ``scripts/paper_exit_check.py`` は Alpaca client / positions の取得に失敗すると
+    ``snapshots=[]`` で継続し、exit を 1 件も生成しないまま ``return 0`` していた。
+    daily_pipeline から見ると「0 exits = 成功 (flat book)」と区別できず、market が
+    閉じた後に transient outage が起きると exit が全滑りしても success に見え、
+    position が滞留する温床だった (entry 側は既に ``PositionsFetchError`` で
+    fail-closed していたのに exit 側だけ silent だった)。
+
+    修正後は broker 到達不能を distinct exit code 3 + WARN + 出力 meta
+    ``broker_unreachable=true`` で surface する。``--no-alpaca`` の意図的 offline や
+    本当に position 0 件の flat book は 0 のまま (誤検知しない)。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from common.alpaca_trading import PositionsFetchError  # noqa: E402
+import scripts.paper_exit_check as pec  # noqa: E402
+
+
+class _RaisingClient:
+    """get_all_positions が transient outage で raise する fake client。"""
+
+    def get_all_positions(self):  # noqa: D401
+        raise RuntimeError("simulated Alpaca outage (503)")
+
+
+class _FlatClient:
+    def get_all_positions(self):
+        return []
+
+
+def _run_main(
+    tmp_path: Path, monkeypatch, *, extra: list[str] | None = None
+) -> tuple[int, dict]:
+    out = tmp_path / "exit_orders_20260719.json"
+    args = [
+        "--date",
+        "2026-07-19",
+        "--output-json",
+        str(out),
+        "--results-dir",
+        str(tmp_path),
+    ]
+    if extra:
+        args.extend(extra)
+    rc = pec.main(args)
+    data = json.loads(out.read_text(encoding="utf-8")) if out.exists() else {}
+    return rc, data
+
+
+def test_client_fetch_failure_returns_3_and_flags(tmp_path: Path, monkeypatch):
+    """ba.get_client が raise → broker_unreachable, exit 3。"""
+
+    def _boom(*a, **k):
+        raise RuntimeError("cannot construct client (no creds / network)")
+
+    monkeypatch.setattr(pec.ba, "get_client", _boom)
+    rc, data = _run_main(tmp_path, monkeypatch)
+    assert rc == 3
+    assert data.get("broker_unreachable") is True
+    assert data.get("count") == 0
+
+
+def test_positions_fetch_failure_returns_3_and_flags(tmp_path: Path, monkeypatch):
+    """client は取れたが get_all_positions が raise → broker_unreachable, exit 3。"""
+    monkeypatch.setattr(pec.ba, "get_client", lambda *a, **k: _RaisingClient())
+    # coid fetchers は到達しない (PositionsFetchError で else ブロックに入らない)。
+    rc, data = _run_main(tmp_path, monkeypatch)
+    assert rc == 3
+    assert data.get("broker_unreachable") is True
+    assert data.get("count") == 0
+
+
+def test_genuine_flat_book_returns_0_not_flagged(tmp_path: Path, monkeypatch):
+    """client OK で positions 0 件 = 本当の flat book → 0, 未 flag (誤検知しない)。"""
+    monkeypatch.setattr(pec.ba, "get_client", lambda *a, **k: _FlatClient())
+    monkeypatch.setattr(pec, "fetch_existing_protect_coids", lambda c: set())
+    monkeypatch.setattr(pec, "fetch_existing_exit_coids", lambda c: set())
+    monkeypatch.setattr(pec, "_hydrate_from_alpaca_coids", lambda s, c: None)
+    rc, data = _run_main(tmp_path, monkeypatch)
+    assert rc == 0
+    assert data.get("broker_unreachable") is False
+    assert data.get("count") == 0
+
+
+def test_no_alpaca_offline_is_not_flagged(tmp_path: Path, monkeypatch):
+    """--no-alpaca の意図的 offline は broker_unreachable ではない (0 のまま)。"""
+    rc, data = _run_main(tmp_path, monkeypatch, extra=["--no-alpaca"])
+    assert rc == 0
+    assert data.get("broker_unreachable") is False
+
+
+def test_fetch_position_snapshots_raise_on_error_contract():
+    """fetch_position_snapshots: raise_on_error で例外を surface / default は [] 後方互換。"""
+    # default (False): silent [] を保つ (paper_trading_status など既存 caller 保護)。
+    assert pec.fetch_position_snapshots(_RaisingClient()) == []
+    # opt-in (True): PositionsFetchError を raise。
+    with pytest.raises(PositionsFetchError):
+        pec.fetch_position_snapshots(_RaisingClient(), raise_on_error=True)


### PR DESCRIPTION
## Why
Audit (2026-07-19) found two **live** silent-success paths on the daily critical path where a failure returns exit 0 (healthy-looking) while doing nothing — directly feeding the exit-misfire / position-pileup problem — plus a missing integration test for the "silent 3-stage" chain break.

## What
**1. exit_check broker-unreachable → distinct exit 3 (was silent 0)**
`scripts/paper_exit_check.py`: if `get_client()` or `get_all_positions()` fails (transient Alpaca outage), the old code set `snapshots=[]` → 0 exits → `return 0`, indistinguishable from a genuine flat book. After market close this silently stalls all exits and piles up positions. The entry side already fail-closes via `PositionsFetchError`; the exit side did not.
- `fetch_position_snapshots` gains `raise_on_error` (default **off** = backward-compatible for `paper_trading_status`).
- exit_check now flags `broker_unreachable`, prints a loud WARN, writes `broker_unreachable` into the output meta, and returns **code 3**.
- `daily_pipeline.ps1` maps `ec==3` → `Failures "exit_check(broker_unreachable)"`.

**2. freshness guard total-freeze detector**
`scripts/check_rolling_freshness.py` only compared rolling **vs** upstream (relative), so if **both** froze at an old date (the 2026-07-12..14 dashboard-freeze class), lag=0 read as "fresh". Added an **absolute-staleness** check: WARN (exit 2, already handled softly) when `upstream(full_backup)` newest lags the latest NYSE trading day by more than `--max-abs-lag-bdays` (default **2**, generous to absorb vendor EOD lag).

**3. rolling→indicators→filter→setup→candidate integration test**
`tests/system/test_rolling_filter_setup_chain.py` runs a synthetic frame through the **real** pipeline functions and asserts each seam is alive (catches the silent-3-stage "0 candidates" break that per-stage tests miss).

## Safety
- **paper-only; no trading-behavior change.** Only observability, exit codes, and tests change. In every affected failure path, zero orders were being generated anyway.
- `raise_on_error` defaults off → `paper_trading_status` unaffected.
- Absolute-staleness returns exit 2 = soft WARN (pipeline continues, flags in `$Failures`); tolerance 2 bdays avoids vendor-lag false positives.

## Tests
3 new test files (11 cases) all green; ps1-contract + existing exit-check/freshness tests unaffected. black / isort / ruff clean.