### PR TITLE
safety: land SelfMonitor + ExitVerify + drawdown breaker + data_fresh fix on main

### DIFF
--- a/common/drawdown_breaker.py
+++ b/common/drawdown_breaker.py
@@ -1,0 +1,248 @@
+"""drawdown circuit breaker — equity ドローダウンで全 flatten する安全弁 (paper 専用)。
+
+``portfolio_guard.evaluate_drawdown_flatten`` (副作用なしの純判定) の上に薄く重ねて
+
+    1. equity 履歴 (results_csv/alpaca_equity_history.json) からの **peak 解決**
+    2. **誤発火防止ガード** (config 無効 / equity 欠損 / 履歴が薄い / 絶対額が小さい)
+    3. paper 口座の **flatten 実行** (close_all_positions, cancel_orders=True)
+
+を提供する。**default は完全に無効** (config ``risk.portfolio.drawdown_flatten_pct``
+が 0 の間は ``armed=False`` で必ず no-op)。有効化は user が config に閾値を入れた
+ときのみ。live 口座には一切触れない (実行系は呼び出し側で ``assert_paper_env`` 済み前提)。
+
+設計方針 (docs/POSITION_MANAGEMENT_PHASE5_20260707.md §3.2 の延長):
+    - 判定は純関数 (assess) に閉じ込め、単体テストで全ガードを検証できるようにする。
+    - flatten は「1) config 有効 かつ 2) 閾値超え かつ 3) 全ガード通過 かつ
+      4) 呼び出し側が --confirm を明示」の 4 条件が揃ったときだけ。
+    - 単一の壊れた equity 値で全決済しないよう、履歴点数と絶対ドローダウン額でガード。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from common.portfolio_guard import FlattenDecision, evaluate_drawdown_flatten
+
+logger = logging.getLogger(__name__)
+
+# 誤発火防止のデフォルト。値を締めたいときは script 側の flag / config で上書き。
+DEFAULT_MIN_HISTORY_POINTS = 5
+DEFAULT_MIN_ABS_DRAWDOWN_USD = 0.0  # 0 = 無効 (絶対額ガードを掛けない)
+
+# config の drawdown_flatten_pct を有効化するときの **保守的な提案値**。
+# config 自体は 0.0 (無効) のままにしておき、user が opt-in するときの目安に使う。
+SUGGESTED_THRESHOLD_PCT = 0.15
+
+
+@dataclass
+class BreakerAssessment:
+    """circuit breaker の総合判定 (実行はしない・純データ)。"""
+
+    armed: bool  # config で有効化されているか (threshold > 0)
+    breached: bool  # 閾値を超えたか (ガード前の生判定)
+    would_flatten: bool  # breached かつ 全ガード通過 → flatten 対象
+    equity: float | None
+    peak_equity: float | None
+    drawdown_pct: float
+    threshold_pct: float
+    n_history_points: int
+    reason: str
+    guard_blocks: list[str] = field(default_factory=list)
+    decision: FlattenDecision | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "armed": self.armed,
+            "breached": self.breached,
+            "would_flatten": self.would_flatten,
+            "equity": self.equity,
+            "peak_equity": self.peak_equity,
+            "drawdown_pct": self.drawdown_pct,
+            "threshold_pct": self.threshold_pct,
+            "n_history_points": self.n_history_points,
+            "reason": self.reason,
+            "guard_blocks": self.guard_blocks,
+        }
+
+
+def load_equity_history(path: Path | str) -> list[dict[str, Any]]:
+    """alpaca_equity_history.json ([{t, equity}, ...]) を読む。壊れてても空 list。"""
+    p = Path(path)
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("equity 履歴の読込に失敗 (無視して空扱い): %s", exc)
+        return []
+    if not isinstance(data, list):
+        return []
+    return [row for row in data if isinstance(row, dict)]
+
+
+def resolve_peak_equity(
+    history: list[dict[str, Any]], current_equity: float | None
+) -> tuple[float | None, int]:
+    """履歴 + 現 equity の最大値を peak とする。履歴の有効点数も返す。
+
+    - 履歴点数 (n) は **現 equity を足す前** の有効点数 = 履歴の厚さ判定に使う。
+    - peak には現 equity も含める (新高値なら drawdown=0 になり breach しない)。
+    """
+    values: list[float] = []
+    for row in history:
+        try:
+            e = float(row.get("equity"))
+        except (TypeError, ValueError):
+            continue
+        if e > 0:
+            values.append(e)
+    n_points = len(values)
+    if current_equity is not None:
+        try:
+            cur = float(current_equity)
+            if cur > 0:
+                values.append(cur)
+        except (TypeError, ValueError):
+            pass
+    peak = max(values) if values else None
+    return peak, n_points
+
+
+def assess(
+    equity: float | None,
+    peak_equity: float | None,
+    threshold_pct: float | None,
+    *,
+    n_history_points: int,
+    min_history_points: int = DEFAULT_MIN_HISTORY_POINTS,
+    min_abs_drawdown_usd: float = DEFAULT_MIN_ABS_DRAWDOWN_USD,
+) -> BreakerAssessment:
+    """flatten すべきか総合判定する (副作用なし)。
+
+    誤発火防止:
+      - ``threshold_pct <= 0``: config 無効 → armed=False で即 no-op (default)。
+      - ``equity`` / ``peak_equity`` が欠損/非正 → guard_block (flatten しない)。
+      - 履歴点数が ``min_history_points`` 未満 → 薄い履歴で peak が不確か → guard_block。
+      - ``min_abs_drawdown_usd > 0`` かつ 絶対ドローダウン額がそれ未満 → guard_block。
+    ``would_flatten`` は「閾値超え かつ ガードが 1 つも掛からない」ときだけ True。
+    """
+    decision = evaluate_drawdown_flatten(equity, peak_equity, threshold_pct)
+    dd = decision.drawdown_pct
+    try:
+        th = float(threshold_pct) if threshold_pct is not None else 0.0
+    except (TypeError, ValueError):
+        th = 0.0
+
+    armed = th > 0
+    if not armed:
+        return BreakerAssessment(
+            armed=False,
+            breached=False,
+            would_flatten=False,
+            equity=equity,
+            peak_equity=peak_equity,
+            drawdown_pct=dd,
+            threshold_pct=th,
+            n_history_points=n_history_points,
+            reason="disabled(threshold<=0)",
+            guard_blocks=[],
+            decision=decision,
+        )
+
+    guard_blocks: list[str] = []
+    if equity is None or not (float(equity) > 0):
+        guard_blocks.append("no_equity")
+    if peak_equity is None or not (float(peak_equity) > 0):
+        guard_blocks.append("no_peak")
+    if n_history_points < min_history_points:
+        guard_blocks.append(f"thin_history({n_history_points}<{min_history_points})")
+
+    breached = bool(decision.flatten)
+    if (
+        breached
+        and min_abs_drawdown_usd > 0
+        and peak_equity is not None
+        and equity is not None
+    ):
+        abs_dd = float(peak_equity) - float(equity)
+        if abs_dd < min_abs_drawdown_usd:
+            guard_blocks.append(
+                f"below_abs_usd({abs_dd:.0f}<{min_abs_drawdown_usd:.0f})"
+            )
+
+    would_flatten = breached and not guard_blocks
+    if not breached:
+        reason = decision.reason  # within_threshold / no_peak / disabled 等
+    elif guard_blocks:
+        reason = "breached_but_guarded:" + ",".join(guard_blocks)
+    else:
+        reason = decision.reason  # drawdown_XX%>=threshold_YY%
+
+    return BreakerAssessment(
+        armed=True,
+        breached=breached,
+        would_flatten=would_flatten,
+        equity=equity,
+        peak_equity=peak_equity,
+        drawdown_pct=dd,
+        threshold_pct=th,
+        n_history_points=n_history_points,
+        reason=reason,
+        guard_blocks=guard_blocks,
+        decision=decision,
+    )
+
+
+def flatten_all_paper(client: Any) -> dict[str, Any]:
+    """paper 口座の全ポジションを成行 close + open order cancel する。
+
+    **前提**: 呼び出し側で ``assert_paper_env`` 済み。Alpaca ネイティブの
+    ``close_all_positions(cancel_orders=True)`` を使い、long/short・端株を broker 側で
+    正しく処理させる (side/qty 計算の自作バグを避ける)。open_auto_run の flatten-all と
+    同じ実装パターン。戻り値は監視/durable ログ用の要約 dict。
+    """
+    rows: list[dict[str, Any]] = []
+    order_ids: list[str] = []
+    ok = 0
+    failed = 0
+    try:
+        resps = client.close_all_positions(cancel_orders=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("close_all_positions 失敗: %s", exc)
+        return {"ok": 0, "failed": 0, "error": str(exc), "order_ids": [], "rows": []}
+
+    for r in resps or []:
+        sym = getattr(r, "symbol", None)
+        st = getattr(r, "status", None)
+        raw_oid = getattr(r, "order_id", None)
+        oid = str(raw_oid) if raw_oid else None
+        if st == 200 and oid:
+            ok += 1
+            order_ids.append(oid)
+        else:
+            failed += 1
+        rows.append(
+            {
+                "symbol": sym,
+                "order_id": oid,
+                "http_status": st,
+                "reason": "drawdown_flatten",
+            }
+        )
+    return {"ok": ok, "failed": failed, "order_ids": order_ids, "rows": rows}
+
+
+__all__ = [
+    "BreakerAssessment",
+    "DEFAULT_MIN_ABS_DRAWDOWN_USD",
+    "DEFAULT_MIN_HISTORY_POINTS",
+    "SUGGESTED_THRESHOLD_PCT",
+    "assess",
+    "flatten_all_paper",
+    "load_equity_history",
+    "resolve_peak_equity",
+]

--- a/docs/MONITOR_SAFETY_NETS_20260712.md
+++ b/docs/MONITOR_SAFETY_NETS_20260712.md
@@ -1,0 +1,131 @@
+# 監視「回して見守る」フェーズの生命線 2 本 (2026-07-12)
+
+paper 専用・ライブ発注なし。branch `claude/monitor-safety-nets-20260712`
+(base = `claude/open-auto-run`。production worktree `C:\tmp\qts-main-run` が実行中の branch)。
+
+過去に踏んだ silent 失敗 (「0 シグナル」「ダッシュ 07-07 固着」) と、未検証だった
+exit 発火 / 未配線だった drawdown flatten を塞ぐ。
+
+---
+
+## #1 自己監視アラート (silent-failure ガード)
+
+**`scripts/self_monitor_check.py`** + `self_monitor_check.ps1`
+
+毎朝 1 回、以下を検査し **1 通のサマリ ntfy** にする (NtfyPublisher = UTF-8-safe。
+素の `Invoke-RestMethod` / str POST の latin-1 silent death を回避)。異常時は urgent(5)。
+
+| check | 内容 | 異常判定 |
+|-------|------|----------|
+| `daily` | 06:00 デイリー (main 追従) が走ったか。`today_signals_YYYYMMDD.json` の mtime 鮮度 | 最新が `--max-age-hours`(既定26h) 超 → **CRIT** / 皆無 → CRIT |
+| `signals` | シグナルが潤沢か。`portfolio.total_signals` | 0 → **CRIT** / `--min-signals`(既定10) 未満 → **WARN** |
+| `publish` | Vercel publish 成功か。`monitor-webapp` ブランチの最新 commit 時刻 (git log) | 最新 commit が 26h 超 → **CRIT** (ダッシュ固着の疑い) |
+| `open_run` | オープン自動発注が走り entry が fill したか。最新 `logs/open_run_<date>/completion_recon.json` | `market_closed` abort=良性(OK) / 他 abort・entry 0 → **WARN** / 96h 超 → WARN |
+
+- source of truth は **primary repo** (`C:\Repos\...`)。`C:\tmp\qts-main-run` の
+  `logs`/`results_csv`/`data_cache` は primary への junction なので `--repo-root` だけ見れば良い。
+- durable: `logs/self_monitor_YYYYMMDD.json` (全 check の合否)。
+- exit code: 0=OK / 2=WARN / 3=CRIT。
+- 「全 OK」も 1 通送る = **dead-man's-switch** (通知が来ない=監視自体が死んでいる、が分かる)。
+  静かにしたいなら `--only`... ではなく `--no-notify` で JSON だけ出せる。
+
+疎通 (実データ, ntfy なし):
+```
+python scripts/self_monitor_check.py --repo-root C:\Repos\quant_trading_system_0510to0906 --dry-run
+```
+検証済 (2026-07-12): daily/signals(44)/publish/open_run すべて OK。
+
+---
+
+## #2a exit E2E 検証
+
+**`scripts/exit_verify.py`** + `exit_verify.ps1`
+
+`paper_exit_check` が生成する `exit_orders_YYYYMMDD.json` (planned exits + position
+snapshot) を single source に、「本日 exit 予定 vs 実 fill」を突合する。
+
+1. **expected**: position snapshot から time-based 満期 (`holding_days >= max_holding_days`,
+   S2=2/S3=3/S5=6/S6=3) を **独立再計算** = paper_exit_check の漏れ検知。
+2. **planned**: `exits[]` = paper_exit_check が実際に planned/submit した exit。
+3. **fill**: 各 planned close の Alpaca order status を GET 照合 (`--no-alpaca` なら JSON 記録値)。
+   resting protection (stop/limit/trailing) は fill 待ちが正常なので close 判定から除外。
+4. **reconcile** → `due_not_planned` / `closes_rejected` / `closes_unfilled_nonpending` /
+   `closes_pending`(市場休場の成行=良性) を分類。
+
+- durable: `logs/exit_verify_YYYYMMDD.json`。月曜以降の建玉で time-exit が実発火するのを日次で追える。
+- WARN 通知は「満期漏れ」「close reject/未 fill」があるときだけ。
+- exit code: 0=乖離なし / 2=discrepancy。
+
+### ⚠ 初回実行で検出した実バグ (要別対応)
+
+2026-07-12 の実データで `exit_verify` が **system3 の 6 建玉 (AEHR/AIP/FORM/MXL/UCTT/VECO)**
+を「満期(4d>=3d)だが未計画」と検出。根因は **端株 (qty<1) が exit 計画から丸ごと落ちる**:
+
+- `PositionSnapshot.abs_qty = int(abs(qty))` → qty 0.18 などは **0 に切り捨て** →
+  `build_exit_orders_from_positions` の `if abs_qty <= 0: continue` で **全 exit 種別(time/protect)
+  から silent に除外**。equity 連動サイジングは端株を日常的に作るので、多数の建玉が
+  **time-exit で決済できない** = まさに silent exit 失敗。
+- 制約: Alpaca は端株 (notional/fractional) を **market DAY のみ**受け付け、stop/limit/trailing
+  不可。→ 端株の time-exit は market close、protective は別扱い、という設計が要る。
+- 本 branch では **修正せず検出に留める** (core 発注ロジック変更 + Alpaca 端株制約の設計は別タスク)。
+
+---
+
+## #2b drawdown サーキットブレーカ (配線)
+
+判定関数 `portfolio_guard.evaluate_drawdown_flatten` は既存。今回 **自動 flatten を配線**:
+
+- **`common/drawdown_breaker.py`** (共有): peak 解決 (`alpaca_equity_history.json` + 現 equity の最大)、
+  `assess()` (誤発火ガード込み判定)、`flatten_all_paper()` (close_all_positions)。
+- **`scripts/drawdown_circuit_breaker.py`** (standalone CLI): 状態確認 / 手動 / スケジュール可能。
+- **`open_auto_run.py` の entry 前に配線**: config 有効 & 閾値超え & 全ガード通過なら
+  全 flatten して **新規建てを中止** (ドローダウン中に建てない安全弁)。
+
+**既定は完全 no-op** (`config.risk.portfolio.drawdown_flatten_pct = 0.0`)。有効化は user が
+config に閾値を入れたときだけ。**保守的な提案値 = 0.15 (15%)**。
+
+### 誤発火防止ガード (`assess`)
+| ガード | 挙動 |
+|--------|------|
+| config 無効 (threshold<=0) | `armed=False` で即 no-op (最優先, 既定) |
+| equity / peak 欠損・非正 | flatten しない (`no_equity`/`no_peak`) |
+| 履歴点数 < `--min-history-points`(既定5) | 薄い履歴で peak 不確か → flatten しない |
+| 絶対ドローダウン額 < `--min-abs-drawdown-usd`(既定0=無効) | 小口の flatten を抑止 |
+| 本日 flatten 済 (DONE marker) | 冪等 skip |
+| `--confirm` 未指定 | dry-run 等価 (WOULD FIRE 通知のみ) |
+| flatten 実行前 | `assert_paper_env` (live 口座なら中止) |
+
+新高値 (現 equity=peak) では drawdown=0 で絶対に発火しない。
+
+dry-run 検証 (2026-07-12, `--no-alpaca --equity` で疑似):
+- config=0 → `disabled` no-op (exit 0)
+- 閾値0.15 & 履歴2点 → `breached_but_guarded:thin_history(2<5)` = flatten せず (exit 0)
+- 閾値0.15 & `--min-history-points 1` & equity 80k(peak 106k, dd 24.7%) → `WOULD FLATTEN` (exit 11, 未執行)
+- equity 200k(新高値) → `within_threshold` (exit 0)
+
+exit code: 0=無為 / 10=flatten実行 / 11=WOULD(dry-run) / 2=エラー。
+
+---
+
+## スケジュール
+
+**`scripts/register_safety_tasks.ps1`** (登録専用・checkは走らせない・冪等)。既存
+`QuantTrading_OpenAutoRun` と同じ principal (Interactive/Limited)・hidden 実行:
+
+- `QuantTrading_SelfMonitor` : 07:15 JST daily → `self_monitor_check.ps1`
+- `QuantTrading_ExitVerify`  : 07:20 JST daily → `exit_verify.ps1`
+
+06:00 デイリーと前夜 22:35/23:35 open-run の **後** に 1 パスで全サイクルを検査。
+`-WorktreeRoot` 既定は production `C:\tmp\qts-main-run` (branch merge 後に有効)。
+merge 前の暫定は `-WorktreeRoot C:\tmp\qts-safety-nets`。
+
+> このスクリプトは **まだ未登録**。レビュー後にユーザーが 1 回実行する
+> (`push は確認後` 方針に合わせ、ライブ通知を送るタスクを勝手に常駐させない)。
+
+---
+
+## 安全性まとめ
+- 全スクリプト paper 前提。self_monitor / exit_verify は **read-only** (発注・cancel 一切なし)。
+- circuit breaker のみ flatten するが、`config 有効 + 閾値超え + 全ガード通過 + --confirm`
+  の 4 条件が揃うときだけ。既定は無効。live 口座は `assert_paper_env` で拒否。
+- ntfy は全経路 NtfyPublisher (UTF-8-safe)。

--- a/scripts/drawdown_circuit_breaker.py
+++ b/scripts/drawdown_circuit_breaker.py
@@ -1,0 +1,297 @@
+"""drawdown サーキットブレーカ — equity ドローダウン閾値超えで全ポジション flatten (paper)。
+
+``common/drawdown_breaker.py`` の純判定を実運用に配線する薄い CLI。**default は無効**
+(config ``risk.portfolio.drawdown_flatten_pct`` が 0 の間は何も起きない)。有効化は
+user が config に閾値を入れたときだけ。実 flatten は ``--confirm`` を明示したときだけ
+(無指定は dry-run と等価 = 誤爆防止)。
+
+判定入力:
+    - equity      : Alpaca paper 口座の現 equity (fetch_account_equity, read-only)。
+    - peak_equity : results_csv/alpaca_equity_history.json の履歴 + 現 equity の最大値。
+    - threshold   : --threshold-pct 明示 > config drawdown_flatten_pct。
+
+誤発火防止 (common.drawdown_breaker.assess):
+    - config 無効 (threshold<=0) → armed=False で即 no-op。
+    - equity / peak が欠損 → flatten しない。
+    - 履歴点数 < --min-history-points → 薄い履歴で peak が不確か → flatten しない。
+    - 絶対ドローダウン額 < --min-abs-drawdown-usd → flatten しない (0=ガード無効)。
+    - 本日すでに flatten 済 (logs/drawdown_breaker_<date>.done) → 冪等 skip。
+
+安全:
+    - flatten 実行前に必ず assert_paper_env (live 口座禁止)。
+    - Alpaca ネイティブ close_all_positions(cancel_orders=True) で決済。
+
+Usage:
+    # 疎通/状態確認 (発注しない。閾値未設定なら "disabled" と表示)
+    python scripts/drawdown_circuit_breaker.py --dry-run
+    # 閾値を明示して dry-run 検証 (config を汚さず発火条件を試す)
+    python scripts/drawdown_circuit_breaker.py --threshold-pct 0.15 --dry-run
+    # 本番 (config で有効化済み前提。閾値超え & 全ガード通過なら paper で全決済)
+    python scripts/drawdown_circuit_breaker.py --confirm
+
+Exit codes:
+    0  = 何もしない (無効 / 閾値内 / ガードで抑止 / 既に実行済)
+    10 = flatten を実行した
+    11 = 閾値超えだが dry-run のため未実行 (WOULD flatten)
+    2  = 実行時エラー (flatten 中の例外など)
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.drawdown_breaker import (  # noqa: E402
+    DEFAULT_MIN_ABS_DRAWDOWN_USD,
+    DEFAULT_MIN_HISTORY_POINTS,
+    assess,
+    flatten_all_paper,
+    load_equity_history,
+    resolve_peak_equity,
+)
+from common.portfolio_guard import load_guard_config  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _today_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _ntfy(title: str, body: str, *, urgent: bool = False) -> None:
+    """UTF-8-safe な NtfyPublisher で通知。失敗しても無視 (通知は best-effort)。"""
+    try:
+        from common.publishers.ntfy import NtfyPublisher
+
+        pub = NtfyPublisher()
+        if not pub.is_configured():
+            print("[ntfy] NTFY_TOPIC 未設定のため通知スキップ")
+            return
+        tags = "rotating_light,warning" if urgent else "shield"
+        res = pub.send_text(title, body, tags=tags, priority=(5 if urgent else None))
+        print(f"[ntfy] 送信 ok={getattr(res, 'ok', '?')}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ntfy] 送信失敗 (無視): {exc}")
+
+
+def _resolve_threshold(args: argparse.Namespace) -> tuple[float, str]:
+    if args.threshold_pct is not None:
+        return float(args.threshold_pct), "cli"
+    cfg = load_guard_config()
+    return float(cfg.get("drawdown_flatten_pct", 0.0) or 0.0), "config"
+
+
+def _resolve_equity(args: argparse.Namespace) -> float | None:
+    if args.equity is not None:
+        return float(args.equity)
+    if args.no_alpaca:
+        return None
+    try:
+        from common.alpaca_trading import fetch_account_equity
+
+        return fetch_account_equity()
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] equity 取得失敗 (offline 扱い): {exc}")
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--date", default=None, help="対象日 YYYY-MM-DD (default: today UTC)"
+    )
+    parser.add_argument(
+        "--threshold-pct",
+        type=float,
+        default=None,
+        help="peak drawdown 閾値 (0.15=15%%)。未指定は config risk.portfolio.drawdown_flatten_pct。",
+    )
+    parser.add_argument(
+        "--min-history-points",
+        type=int,
+        default=DEFAULT_MIN_HISTORY_POINTS,
+        help=f"equity 履歴がこの点数未満なら flatten しない (default {DEFAULT_MIN_HISTORY_POINTS})",
+    )
+    parser.add_argument(
+        "--min-abs-drawdown-usd",
+        type=float,
+        default=DEFAULT_MIN_ABS_DRAWDOWN_USD,
+        help="絶対ドローダウン額がこの USD 未満なら flatten しない (0=無効)",
+    )
+    parser.add_argument(
+        "--results-dir",
+        default=str(ROOT / "results_csv"),
+        help="alpaca_equity_history.json を探す dir",
+    )
+    parser.add_argument(
+        "--equity", type=float, default=None, help="現 equity を明示 (test/offline)"
+    )
+    parser.add_argument(
+        "--no-alpaca",
+        action="store_true",
+        help="Alpaca を叩かない (equity は --equity 必須)",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="実際に flatten する (無指定は dry-run と等価: 誤爆防止)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="本日 DONE marker があっても再判定する (冪等ロックを無視)",
+    )
+    parser.add_argument("--output-json", default=None, help="判定結果 JSON の出力先")
+    parser.add_argument(
+        "--log-dir",
+        default=str(ROOT / "logs"),
+        help="durable ログ / DONE marker の dir",
+    )
+    args = parser.parse_args(argv)
+
+    date_str = args.date or _today_str()
+    compact = date_str.replace("-", "")
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    done_marker = log_dir / f"drawdown_breaker_{compact}.done"
+    out_path = (
+        Path(args.output_json)
+        if args.output_json
+        else log_dir / f"drawdown_breaker_{compact}.json"
+    )
+
+    threshold, th_source = _resolve_threshold(args)
+    equity = _resolve_equity(args)
+    history = load_equity_history(Path(args.results_dir) / "alpaca_equity_history.json")
+    peak, n_points = resolve_peak_equity(history, equity)
+
+    a = assess(
+        equity,
+        peak,
+        threshold,
+        n_history_points=n_points,
+        min_history_points=args.min_history_points,
+        min_abs_drawdown_usd=args.min_abs_drawdown_usd,
+    )
+
+    print(
+        f"[breaker] armed={a.armed} breached={a.breached} would_flatten={a.would_flatten} "
+        f"equity={a.equity} peak={a.peak_equity} dd={a.drawdown_pct:.2%} "
+        f"threshold={a.threshold_pct:.2%}({th_source}) hist_points={n_points} "
+        f"reason={a.reason}"
+    )
+
+    record: dict[str, Any] = {
+        "version": "1.0",
+        "date": date_str,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "threshold_source": th_source,
+        "confirm": bool(args.confirm),
+        "assessment": a.to_dict(),
+        "action": "none",
+    }
+
+    # 冪等: 本日すでに flatten 済なら再実行しない
+    if a.would_flatten and args.confirm and done_marker.exists() and not args.force:
+        print(
+            f"[breaker] 本日 flatten 済 ({done_marker.name}) -> skip (--force で上書き)"
+        )
+        record["action"] = "skip_already_flattened"
+        _write(out_path, record)
+        return 0
+
+    if not a.armed:
+        # 無効 = 既定。静かに 0。dry-run 状態確認としては上の print で十分。
+        record["action"] = "disabled"
+        _write(out_path, record)
+        return 0
+
+    if not a.would_flatten:
+        # 閾値内 or ガードで抑止。armed だが発火せず。診断のため JSON は残す。
+        record["action"] = "no_breach" if not a.breached else "guarded"
+        _write(out_path, record)
+        return 0
+
+    # ここに来たら armed & breached & 全ガード通過 = 発火条件成立。
+    body = (
+        f"peak drawdown {a.drawdown_pct:.2%} >= 閾値 {a.threshold_pct:.2%} "
+        f"(equity ${a.equity:,.0f} / peak ${a.peak_equity:,.0f})"
+    )
+
+    if not args.confirm:
+        print(f"[breaker] WOULD FLATTEN (dry-run, --confirm 未指定): {body}")
+        record["action"] = "would_flatten_dry_run"
+        _write(out_path, record)
+        _ntfy(
+            f"DrawdownBreaker WOULD FIRE {date_str}",
+            "サーキットブレーカ発火条件成立 (dry-run のため未執行)。\n" + body,
+            urgent=True,
+        )
+        return 11
+
+    # --confirm: 実 flatten。paper 断言 → close_all_positions。
+    try:
+        from common import broker_alpaca as ba
+        from common.alpaca_trading import assert_paper_env
+
+        assert_paper_env()  # live なら例外
+        client = ba.get_client(paper=True)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[SAFETY ABORT] paper 断言/クライアント取得失敗、flatten 中止: {exc}")
+        record["action"] = "abort_not_paper"
+        record["error"] = str(exc)
+        _write(out_path, record)
+        _ntfy(
+            f"DrawdownBreaker ABORT {date_str}",
+            f"flatten を中止 (paper 断言失敗): {exc}",
+            urgent=True,
+        )
+        return 2
+
+    print(f"[breaker] FLATTEN 実行 (paper): {body}")
+    result = flatten_all_paper(client)
+    record["action"] = "flattened"
+    record["flatten_result"] = {
+        "ok": result.get("ok"),
+        "failed": result.get("failed"),
+        "order_ids": result.get("order_ids"),
+        "error": result.get("error"),
+    }
+    _write(out_path, record)
+    _write(
+        log_dir / f"drawdown_flatten_{compact}.json",
+        {"date": date_str, "assessment": a.to_dict(), "flatten": result},
+    )
+    done_marker.write_text(datetime.now(timezone.utc).isoformat(), encoding="utf-8")
+    _ntfy(
+        f"DrawdownBreaker FIRED {date_str}",
+        (
+            "サーキットブレーカ発火: 全ポジションを flatten (paper)。\n"
+            f"{body}\n"
+            f"close ok={result.get('ok')} failed={result.get('failed')}"
+        ),
+        urgent=True,
+    )
+    failed = int(result.get("failed") or 0)
+    return 10 if failed == 0 else 2
+
+
+def _write(path: Path, obj: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(obj, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"[write] {path}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] JSON 書き出し失敗 (無視): {exc}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/exit_verify.ps1
+++ b/scripts/exit_verify.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Task Scheduler wrapper for the daily exit E2E verifier.
+
+.DESCRIPTION
+    Thin launcher for scripts/exit_verify.py. Reconciles the day's planned exits
+    (exit_orders_<date>.json) against actual Alpaca fills (read-only GET) and flags
+    any close that did not fill or any time-based exit that should have fired but was
+    not planned. Sends ntfy only on discrepancy. Never places/cancels orders.
+
+    Kept in PowerShell (Python owns all Japanese to avoid cp932):
+      - Load the PRIMARY repo .env (Alpaca creds + NTFY_TOPIC).
+      - Force UTF-8 for the child python.
+      - Tee a launch log; propagate the Python exit code.
+
+.NOTES
+    Exit codes propagate from exit_verify.py (0 ok / 2 discrepancy / 1 no input).
+    Keep this file ASCII-only.
+#>
+param(
+    [string]$Date = "",
+    [switch]$DryRun = $false,
+    [switch]$NoAlpaca = $false,
+    [switch]$NoNotify = $false,
+    [string]$PrimaryRoot = "C:\Repos\quant_trading_system_0510to0906"
+)
+
+$ErrorActionPreference = "Continue"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$WorktreeRoot = Split-Path -Parent $ScriptDir
+$LogDir = Join-Path $WorktreeRoot "logs"
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+$Stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$LaunchLog = Join-Path $LogDir "exit_verify_launch_$Stamp.log"
+
+function Write-Launch {
+    param([string]$Message)
+    $line = "[{0}] {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $Message
+    Write-Host $line
+    Add-Content -Path $LaunchLog -Value $line -Encoding UTF8
+}
+
+Write-Launch "=== exit_verify.ps1 launch ==="
+Write-Launch "WorktreeRoot: $WorktreeRoot"
+Write-Launch "PrimaryRoot : $PrimaryRoot"
+
+# --- load PRIMARY .env (creds + NTFY_TOPIC) ------------------------------
+$EnvFile = Join-Path $PrimaryRoot ".env"
+if (Test-Path $EnvFile) {
+    Write-Launch "loading .env: $EnvFile"
+    Get-Content $EnvFile | ForEach-Object {
+        $line = $_
+        if ($line -match '^\s*#') { return }
+        if ($line -match '^\s*([^#=\s]+)\s*=\s*(.*)$') {
+            $k = $matches[1].Trim()
+            $v = $matches[2].Trim()
+            if ($v.Length -ge 2) {
+                if (($v.StartsWith('"') -and $v.EndsWith('"')) -or
+                    ($v.StartsWith("'") -and $v.EndsWith("'"))) {
+                    $v = $v.Substring(1, $v.Length - 2)
+                }
+            }
+            try { Set-Item -Path "Env:$k" -Value $v -ErrorAction Stop } catch {}
+        }
+    }
+}
+else {
+    Write-Launch "WARN: primary .env not found at $EnvFile"
+}
+
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8"
+# Read the child python's UTF-8 stdout as UTF-8 so the launch log is not mojibake.
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+# results_csv / logs are junction targets to the primary repo, so point at PrimaryRoot.
+$py = Join-Path $WorktreeRoot "scripts\exit_verify.py"
+$pyArgs = @(
+    $py,
+    "--results-dir", (Join-Path $PrimaryRoot "results_csv"),
+    "--log-dir", (Join-Path $PrimaryRoot "logs")
+)
+if ($Date) { $pyArgs += @("--date", $Date) }
+if ($DryRun) { $pyArgs += "--dry-run" }
+if ($NoAlpaca) { $pyArgs += "--no-alpaca" }
+if ($NoNotify) { $pyArgs += "--no-notify" }
+
+Set-Location $WorktreeRoot
+Write-Launch ("python " + ($pyArgs -join " "))
+
+& python @pyArgs 2>&1 | ForEach-Object { Write-Launch $_ }
+$code = $LASTEXITCODE
+Write-Launch "=== exit_verify.py exit=$code ==="
+
+exit $code

--- a/scripts/exit_verify.py
+++ b/scripts/exit_verify.py
@@ -1,0 +1,336 @@
+"""exit E2E 検証 — 「本日 exit 予定」vs「実 fill」を突合し durable ログ + 異常時 ntfy。
+
+exit 側 (SYSTEM_TRADE_RULES の max_holding_days S2=2/S3=3/S5=6/S6=3・利確・ATR ストップ)
+が **実際に paper で発火して決済したか** を観測・検証する。paper_exit_check が生成した
+``exit_orders_YYYYMMDD.json`` (planned exits + position snapshot) を single source にし、
+
+    1. [expected] position snapshot から time-based 満期 (holding_days >= max_holding_days)
+                  を **独立再計算** = 「本日 exit すべき」建玉 (paper_exit_check の漏れ検知)。
+    2. [planned]  exit_orders.json の exits[] = paper_exit_check が実際に planned/submit した exit。
+    3. [fill]     各 planned close の Alpaca order status を照合 (--no-alpaca なら JSON 記録値)。
+    4. [reconcile] close 未 fill / 満期なのに未計画 / reject を discrepancy として抽出。
+
+**read-only**: Alpaca へは GET のみ (order status / positions)。発注・cancel は一切しない。
+月曜以降の建玉で time-exit が実発火するのを、この durable ログ (logs/exit_verify_<date>.json)
+で日次に追える。異常 (close 未 fill / 満期漏れ) があれば ntfy WARN。
+
+Usage:
+    python scripts/exit_verify.py --date 2026-07-13            # 当日を検証 (Alpaca 照合あり)
+    python scripts/exit_verify.py --date 2026-07-13 --no-alpaca # JSON 記録値だけで検証
+    python scripts/exit_verify.py --date 2026-07-13 --dry-run   # ntfy を送らず本文表示
+
+Exit codes: 0=乖離なし, 2=discrepancy あり (WARN), 1=入力 (exit_orders JSON) が無い。
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.alpaca_trading import compute_holding_days  # noqa: E402
+from common.trade_management import SYSTEM_TRADE_RULES  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# fill とみなす Alpaca order status
+_FILLED = {"filled", "partially_filled"}
+# まだ約定待ち (成行は市場休場中 accepted のまま。失敗ではない)
+_PENDING = {
+    "new",
+    "accepted",
+    "pending_new",
+    "held",
+    "accepted_for_bidding",
+    "pending_replace",
+    "calculated",
+    "partially_filled",
+}
+_DEAD = {"canceled", "cancelled", "rejected", "expired", "done_for_day", "replaced"}
+# position を実際に閉じる exit reason (resting protection は fill 待ちが正常なので除外)
+_CLOSE_REASONS = {"time_based", "spy_breakout", "flatten_all"}
+
+
+def _today_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _norm_status(raw: Any) -> str:
+    return str(raw or "").lower().split(".")[-1].strip()
+
+
+def _is_close(row: dict[str, Any]) -> bool:
+    reason = str(row.get("reason") or "").lower()
+    if reason in _CLOSE_REASONS:
+        return True
+    # reason が protect_* でない market は close 扱い
+    return str(row.get("order_type")) == "market" and not reason.startswith("protect")
+
+
+def _expected_time_exits(
+    positions: list[dict[str, Any]], today: str
+) -> list[dict[str, Any]]:
+    """position snapshot から time-based 満期の建玉を独立再計算 (paper_exit_check の漏れ検知)。"""
+    due: list[dict[str, Any]] = []
+    for p in positions or []:
+        system = str(p.get("system") or "").lower()
+        rule = SYSTEM_TRADE_RULES.get(system)
+        max_hold = int(getattr(rule, "max_holding_days", 0) or 0) if rule else 0
+        if max_hold <= 0:
+            continue  # S1/S4/S7 は time-exit 無し
+        hd = compute_holding_days(p.get("entry_date"), today)
+        if hd is None:
+            continue
+        if hd >= max_hold:
+            due.append(
+                {
+                    "symbol": str(p.get("symbol") or "").upper(),
+                    "system": system,
+                    "holding_days": hd,
+                    "max_holding_days": max_hold,
+                    "entry_date": p.get("entry_date"),
+                }
+            )
+    return due
+
+
+def _live_status_map(order_ids: list[str]) -> dict[str, str]:
+    """Alpaca から order_id -> status を GET (read-only)。失敗時は空 map。"""
+    ids = [o for o in order_ids if o]
+    if not ids:
+        return {}
+    try:
+        from common import broker_alpaca as ba
+        from common.broker_alpaca import get_orders_status_map
+
+        client = ba.get_client(paper=True)
+        raw = get_orders_status_map(client, ids)
+        return {k: _norm_status(v) for k, v in raw.items()}
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] Alpaca order status 取得失敗 (JSON 記録値で継続): {exc}")
+        return {}
+
+
+def verify(
+    exit_orders: dict[str, Any], today: str, status_map: dict[str, str]
+) -> dict[str, Any]:
+    """planned exits と実 fill を突合し検証 dict を返す (pure、I/O は status_map に外出し)。"""
+    exits = exit_orders.get("exits") or []
+    positions = exit_orders.get("positions") or []
+
+    expected = _expected_time_exits(positions, today)
+
+    planned_rows: list[dict[str, Any]] = []
+    planned_close_symbols: set[str] = set()
+    closes_not_filled: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+
+    for e in exits:
+        sym = str(e.get("symbol") or "").upper()
+        oid = e.get("order_id")
+        is_close = _is_close(e)
+        # status: live 優先、無ければ JSON 記録値
+        st = status_map.get(str(oid)) if oid else None
+        if not st:
+            st = _norm_status(e.get("status"))
+        submitted = bool(oid) and not e.get("dry_run", True) and not e.get("error")
+        filled = st in _FILLED
+        row = {
+            "symbol": sym,
+            "system": e.get("system"),
+            "reason": e.get("reason"),
+            "order_type": e.get("order_type"),
+            "is_close": is_close,
+            "order_id": oid,
+            "submitted": submitted,
+            "status": st or None,
+            "filled": filled,
+            "dry_run": bool(e.get("dry_run", True)),
+            "error": e.get("error"),
+        }
+        planned_rows.append(row)
+        if is_close:
+            planned_close_symbols.add(sym)
+            if submitted and not filled:
+                if st in _DEAD:
+                    rejected.append(row)
+                elif st not in _PENDING:
+                    closes_not_filled.append(row)
+                else:
+                    closes_not_filled.append(
+                        row
+                    )  # pending も「まだ閉じてない」として記録
+
+    # 満期なのに planned に居ない建玉 = paper_exit_check の漏れ
+    due_not_planned = [e for e in expected if e["symbol"] not in planned_close_symbols]
+
+    # discrepancy = WARN 対象 (pending は info、rejected/漏れ が本命)
+    hard_closes_unfilled = [
+        r for r in closes_not_filled if (r["status"] or "") not in _PENDING
+    ]
+    discrepancies = {
+        "due_not_planned": due_not_planned,
+        "closes_rejected": rejected,
+        "closes_unfilled_nonpending": hard_closes_unfilled,
+        "closes_pending": [
+            r for r in closes_not_filled if (r["status"] or "") in _PENDING
+        ],
+    }
+    n_warn = len(due_not_planned) + len(rejected) + len(hard_closes_unfilled)
+
+    filled_closes = [r for r in planned_rows if r["is_close"] and r["filled"]]
+    return {
+        "date": today,
+        "mode": exit_orders.get("mode"),
+        "n_positions": len(positions),
+        "n_planned_exits": len(exits),
+        "n_planned_closes": len(planned_close_symbols),
+        "n_filled_closes": len(filled_closes),
+        "n_expected_time_exits": len(expected),
+        "expected_time_exits": expected,
+        "planned": planned_rows,
+        "discrepancies": discrepancies,
+        "n_warn": n_warn,
+    }
+
+
+def _summary_lines(v: dict[str, Any]) -> list[str]:
+    lines = [
+        f"positions={v['n_positions']} planned_closes={v['n_planned_closes']} "
+        f"filled_closes={v['n_filled_closes']} expected_time_exits={v['n_expected_time_exits']}",
+    ]
+    d = v["discrepancies"]
+    if d["due_not_planned"]:
+        syms = ", ".join(
+            f"{e['symbol']}({e['system']} {e['holding_days']}/{e['max_holding_days']}d)"
+            for e in d["due_not_planned"]
+        )
+        lines.append(f"[WARN] 満期だが未計画: {syms}")
+    if d["closes_rejected"]:
+        lines.append(
+            f"[WARN] close reject: {', '.join(r['symbol'] for r in d['closes_rejected'])}"
+        )
+    if d["closes_unfilled_nonpending"]:
+        lines.append(
+            f"[WARN] close 未 fill: {', '.join(r['symbol']+'('+str(r['status'])+')' for r in d['closes_unfilled_nonpending'])}"
+        )
+    if d["closes_pending"]:
+        lines.append(
+            f"[..] close pending(市場休場等): {', '.join(r['symbol'] for r in d['closes_pending'])}"
+        )
+    if v["n_warn"] == 0:
+        lines.append("[OK] 乖離なし (planned close は fill 済 / 満期漏れなし)")
+    return lines
+
+
+def _notify(date_str: str, v: dict[str, Any], dry_run: bool) -> None:
+    n_warn = v["n_warn"]
+    head = (
+        f"ExitVerify {date_str}: WARN ({n_warn})"
+        if n_warn
+        else f"ExitVerify {date_str}: OK"
+    )
+    body = head + "\n" + "\n".join(_summary_lines(v))
+    if dry_run:
+        print("--- ntfy (dry-run) ---")
+        print(body)
+        return
+    try:
+        from common.publishers.ntfy import NtfyPublisher
+
+        pub = NtfyPublisher()
+        if not pub.is_configured():
+            print("[ntfy] NTFY_TOPIC 未設定のため送信スキップ")
+            return
+        tags = "warning" if n_warn else "heavy_check_mark"
+        res = pub.send_text(head, body, tags=tags, priority=(5 if n_warn else None))
+        print(f"[ntfy] 送信 ok={getattr(res, 'ok', '?')}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ntfy] 送信失敗: {exc}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--date", default=None, help="対象日 YYYY-MM-DD (default: today UTC)"
+    )
+    parser.add_argument(
+        "--exit-orders-json",
+        default=None,
+        help="exit_orders JSON path (default: results_csv/exit_orders_<date>.json)",
+    )
+    parser.add_argument("--results-dir", default=str(ROOT / "results_csv"))
+    parser.add_argument("--log-dir", default=str(ROOT / "logs"))
+    parser.add_argument("--output-json", default=None, help="検証結果 JSON の出力先")
+    parser.add_argument(
+        "--no-alpaca", action="store_true", help="Alpaca を叩かず JSON 記録値だけで検証"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="ntfy を送らず本文表示")
+    parser.add_argument(
+        "--no-notify", action="store_true", help="ntfy 送信を完全に無効化"
+    )
+    args = parser.parse_args(argv)
+
+    date_str = args.date or _today_str()
+    compact = date_str.replace("-", "")
+    results_dir = Path(args.results_dir)
+    exit_path = (
+        Path(args.exit_orders_json)
+        if args.exit_orders_json
+        else results_dir / f"exit_orders_{compact}.json"
+    )
+    if not exit_path.exists():
+        print(f"[error] exit_orders JSON が無い: {exit_path}")
+        return 1
+    try:
+        exit_orders = json.loads(exit_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[error] exit_orders JSON を読めない: {exc}")
+        return 1
+
+    order_ids = [
+        str(e.get("order_id"))
+        for e in (exit_orders.get("exits") or [])
+        if e.get("order_id") and not e.get("dry_run", True)
+    ]
+    status_map = {} if args.no_alpaca else _live_status_map(order_ids)
+
+    v = verify(exit_orders, date_str, status_map)
+    for ln in _summary_lines(v):
+        print(ln)
+
+    record = {
+        "version": "1.0",
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "exit_orders_source": str(exit_path),
+        "alpaca_checked": not args.no_alpaca,
+        **v,
+    }
+    out_path = (
+        Path(args.output_json)
+        if args.output_json
+        else Path(args.log_dir) / f"exit_verify_{compact}.json"
+    )
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+        print(f"[write] {out_path}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] JSON 書き出し失敗 (無視): {exc}")
+
+    if not args.no_notify:
+        _notify(date_str, v, dry_run=args.dry_run)
+
+    return 2 if v["n_warn"] > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/register_safety_tasks.ps1
+++ b/scripts/register_safety_tasks.ps1
@@ -1,0 +1,103 @@
+<#
+.SYNOPSIS
+    Register the daily safety-net scheduled tasks (self-monitor + exit-verify).
+
+.DESCRIPTION
+    Creates two Windows Task Scheduler tasks, hidden, matching the existing
+    QuantTrading_OpenAutoRun principal (Interactive logon, Limited run level):
+
+      QuantTrading_SelfMonitor : 07:15 JST daily  -> scripts/self_monitor_check.ps1
+                                 (did the 06:00 daily run? signals abundant?
+                                  Vercel published? did last night's open-run fill?)
+      QuantTrading_ExitVerify  : 07:20 JST daily  -> scripts/exit_verify.ps1
+                                 (did planned exits actually fill? any due exit missed?)
+
+    Both are READ-ONLY (no order placement). They send ONE ntfy summary; urgent only
+    on anomaly. Times are chosen AFTER the 06:00 daily (main-follow) and AFTER the
+    prior evening's 22:35/23:35 open-run, so a single morning pass covers the whole cycle.
+
+    This script does NOT run any check itself; it only registers the schedule. Review,
+    then run it once. Re-running is idempotent (unregister + re-register).
+
+.PARAMETER WorktreeRoot
+    Folder holding scripts/self_monitor_check.ps1 & exit_verify.ps1. Default is the
+    production run dir C:\tmp\qts-main-run -- the safety-net branch must be merged into
+    whatever that worktree tracks (git pull) first. For interim use before merging,
+    pass the safety-nets worktree: -WorktreeRoot C:\tmp\qts-safety-nets.
+
+.PARAMETER PrimaryRoot
+    Primary repo (.env + junction target). Passed through to the launchers.
+
+.PARAMETER Unregister
+    Remove the two tasks instead of creating them.
+
+.EXAMPLE
+    # register (after reviewing / merging)
+    powershell -NoProfile -ExecutionPolicy Bypass -File scripts\register_safety_tasks.ps1
+    # interim (run from the safety-nets worktree before merge)
+    ... -File scripts\register_safety_tasks.ps1 -WorktreeRoot C:\tmp\qts-safety-nets
+    # remove
+    ... -File scripts\register_safety_tasks.ps1 -Unregister
+#>
+param(
+    [string]$WorktreeRoot = "C:\tmp\qts-main-run",
+    [string]$PrimaryRoot = "C:\Repos\quant_trading_system_0510to0906",
+    [switch]$Unregister = $false
+)
+
+$ErrorActionPreference = "Stop"
+
+$SelfMonitorTask = "QuantTrading_SelfMonitor"
+$ExitVerifyTask = "QuantTrading_ExitVerify"
+
+function Remove-TaskIfExists {
+    param([string]$Name)
+    $existing = Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskName $Name -Confirm:$false
+        Write-Host "removed: $Name"
+    }
+}
+
+if ($Unregister) {
+    Remove-TaskIfExists -Name $SelfMonitorTask
+    Remove-TaskIfExists -Name $ExitVerifyTask
+    Write-Host "done (unregister)."
+    return
+}
+
+$SelfMonitorPs1 = Join-Path $WorktreeRoot "scripts\self_monitor_check.ps1"
+$ExitVerifyPs1 = Join-Path $WorktreeRoot "scripts\exit_verify.ps1"
+foreach ($p in @($SelfMonitorPs1, $ExitVerifyPs1)) {
+    if (-not (Test-Path $p)) {
+        throw "launcher not found: $p  (merge the safety-nets branch into $WorktreeRoot, or pass -WorktreeRoot C:\tmp\qts-safety-nets)"
+    }
+}
+
+# principal: match QuantTrading_OpenAutoRun (Interactive, Limited).
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 15) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+
+function Register-SafetyTask {
+    param([string]$Name, [string]$Ps1, [string]$At)
+    $action = New-ScheduledTaskAction -Execute "powershell.exe" `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$Ps1`" -PrimaryRoot `"$PrimaryRoot`"" `
+        -WorkingDirectory $WorktreeRoot
+    $trigger = New-ScheduledTaskTrigger -Daily -At $At
+    Remove-TaskIfExists -Name $Name
+    Register-ScheduledTask -TaskName $Name -Action $action -Trigger $trigger `
+        -Principal $principal -Settings $settings `
+        -Description "QuantTrading safety net (read-only, paper). Registered $(Get-Date -Format 'yyyy-MM-dd')." | Out-Null
+    Write-Host "registered: $Name at $At daily -> $Ps1"
+}
+
+# 07:15 / 07:20 JST: after 06:00 daily and after the prior evening's open-run.
+Register-SafetyTask -Name $SelfMonitorTask -Ps1 $SelfMonitorPs1 -At "07:15"
+Register-SafetyTask -Name $ExitVerifyTask -Ps1 $ExitVerifyPs1 -At "07:20"
+
+Write-Host ""
+Write-Host "done. verify with: Get-ScheduledTask -TaskName 'QuantTrading_SelfMonitor','QuantTrading_ExitVerify'"
+Write-Host "first-run smoke test (no ntfy):"
+Write-Host "  powershell -File `"$SelfMonitorPs1`" -DryRun"
+Write-Host "  powershell -File `"$ExitVerifyPs1`" -Date <YYYY-MM-DD> -DryRun"

--- a/scripts/self_monitor_check.ps1
+++ b/scripts/self_monitor_check.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Task Scheduler wrapper for the daily self-monitoring silent-failure guard.
+
+.DESCRIPTION
+    Thin launcher for scripts/self_monitor_check.py. Runs read-only checks over the
+    primary repo's results_csv / logs / monitor-webapp branch and sends ONE summary
+    ntfy (urgent if any WARN/CRIT). Never places orders; never touches Alpaca.
+
+    Kept in PowerShell (everything else is Python so Japanese never hits cp932):
+      - Load the PRIMARY repo .env (NTFY_TOPIC) so the summary can be pushed.
+      - Force UTF-8 for the child python to avoid cp932 decode errors.
+      - Tee a launch log; propagate the Python exit code.
+
+.NOTES
+    Exit codes propagate from self_monitor_check.py (0 ok / 2 warn / 3 crit).
+    Keep this file ASCII-only; the Python side owns all Japanese output.
+#>
+param(
+    [string]$Date = "",
+    [switch]$DryRun = $false,
+    [switch]$NoNotify = $false,
+    [int]$MinSignals = 10,
+    [string]$PrimaryRoot = "C:\Repos\quant_trading_system_0510to0906"
+)
+
+$ErrorActionPreference = "Continue"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$WorktreeRoot = Split-Path -Parent $ScriptDir
+$LogDir = Join-Path $WorktreeRoot "logs"
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+$Stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$LaunchLog = Join-Path $LogDir "self_monitor_launch_$Stamp.log"
+
+function Write-Launch {
+    param([string]$Message)
+    $line = "[{0}] {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $Message
+    Write-Host $line
+    Add-Content -Path $LaunchLog -Value $line -Encoding UTF8
+}
+
+Write-Launch "=== self_monitor_check.ps1 launch ==="
+Write-Launch "WorktreeRoot: $WorktreeRoot"
+Write-Launch "PrimaryRoot : $PrimaryRoot"
+
+# --- load PRIMARY .env (NTFY_TOPIC) into this process env ----------------
+$EnvFile = Join-Path $PrimaryRoot ".env"
+if (Test-Path $EnvFile) {
+    Write-Launch "loading .env: $EnvFile"
+    Get-Content $EnvFile | ForEach-Object {
+        $line = $_
+        if ($line -match '^\s*#') { return }
+        if ($line -match '^\s*([^#=\s]+)\s*=\s*(.*)$') {
+            $k = $matches[1].Trim()
+            $v = $matches[2].Trim()
+            if ($v.Length -ge 2) {
+                if (($v.StartsWith('"') -and $v.EndsWith('"')) -or
+                    ($v.StartsWith("'") -and $v.EndsWith("'"))) {
+                    $v = $v.Substring(1, $v.Length - 2)
+                }
+            }
+            try { Set-Item -Path "Env:$k" -Value $v -ErrorAction Stop } catch {}
+        }
+    }
+}
+else {
+    Write-Launch "WARN: primary .env not found at $EnvFile (NTFY may be missing)"
+}
+
+# --- force UTF-8 for the child python ------------------------------------
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8"
+# Read the child python's UTF-8 stdout as UTF-8 so the launch log is not mojibake.
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+# --- build python args ---------------------------------------------------
+$py = Join-Path $WorktreeRoot "scripts\self_monitor_check.py"
+$pyArgs = @($py, "--repo-root", $PrimaryRoot, "--min-signals", "$MinSignals")
+if ($Date) { $pyArgs += @("--date", $Date) }
+if ($DryRun) { $pyArgs += "--dry-run" }
+if ($NoNotify) { $pyArgs += "--no-notify" }
+
+Set-Location $WorktreeRoot
+Write-Launch ("python " + ($pyArgs -join " "))
+
+& python @pyArgs 2>&1 | ForEach-Object { Write-Launch $_ }
+$code = $LASTEXITCODE
+Write-Launch "=== self_monitor_check.py exit=$code ==="
+
+exit $code

--- a/scripts/self_monitor_check.py
+++ b/scripts/self_monitor_check.py
@@ -1,0 +1,613 @@
+"""自己監視アラート — daily / open-run / publish の silent-failure を日次で検知し ntfy 1 通に集約。
+
+過去に踏んだ「0 シグナル」「ダッシュボード日付固着 (07-07)」の *silent* 失敗を、毎朝 1 回
+まとめて検査する dead-man's-switch。各チェックの合否を **1 通のサマリ ntfy** にして送る
+(NtfyPublisher = UTF-8-safe。素の str POST の latin-1 死を回避)。異常があれば urgent(5)。
+
+検査項目 (source of truth は primary repo。C:\\tmp\\qts-main-run の logs/results_csv/data_cache
+は primary への junction なので --repo-root だけ見れば良い):
+
+    1. [daily]     06:00 デイリー (main 追従) が走ったか。
+                   today_signals_YYYYMMDD.json / pipeline_YYYYMMDD.json の当日更新有無・mtime。
+                   最新ファイルが古い (mtime age > --max-age-hours) → CRIT。
+    1b.[pipeline]  daily_pipeline_*.log を解析し cache step が exit=0 で完走したか +
+                   pipeline が『完了』まで到達したか (途中 stall = silent hang を検出)。
+                   --auto-latest cache の本番実証に使う (走行 worktree 側の log を見る)。
+    1c.[data_fresh] full_backup 参照銘柄 (SPY) の最新日を NYSE 最新取引日と突合。
+                   full_backup は日次 fetch の着地点なので、その絶対 staleness を見れば
+                   freshness_guard の盲点 (rolling/full_backup 同時凍結を fresh と誤判定)
+                   も含め cache 凍結を検出できる (>4 営業日遅れ → CRIT)。rolling の前進は
+                   universe scoped な freshness_guard の担当 (下記 check_data_advance 参照)。
+    2. [signals]   シグナルが潤沢か。portfolio.total_signals が 0 → CRIT、
+                   閾値 (--min-signals) 未満 → WARN (データ鮮度異常の疑い)。
+    3. [publish]   Vercel publish が成功したか。monitor-webapp ブランチに当日 commit があるか
+                   (git log)。古ければ dashboard 固着の疑い → CRIT。
+    4. [open_run]  オープン自動発注 run が走り entry が fill したか。
+                   最新 logs/open_run_<date>/completion_recon.json + paper_orders_*.json。
+                   abort(market_closed) は良性、それ以外の abort / entry 0 は WARN。
+
+Exit codes: 0=全 OK, 2=WARN あり, 3=CRIT あり。
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+PRIMARY_ROOT_DEFAULT = r"C:\Repos\quant_trading_system_0510to0906"
+
+# status の重大度順 (worst を集約するのに使う)
+_SEVERITY = {"ok": 0, "info": 0, "skip": 1, "warn": 2, "crit": 3}
+_MARK = {"ok": "OK", "info": "..", "skip": "--", "warn": "WARN", "crit": "CRIT"}
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str  # ok / info / skip / warn / crit
+    detail: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def line(self) -> str:
+        return f"[{_MARK.get(self.status, '??')}] {self.name}: {self.detail}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "data": self.data,
+        }
+
+
+# --------------------------------------------------------------------------
+# small utils
+# --------------------------------------------------------------------------
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _mtime_age_hours(path: Path) -> float | None:
+    try:
+        mt = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        return (_now() - mt).total_seconds() / 3600.0
+    except Exception:
+        return None
+
+
+def _latest_dated_json(
+    results_dir: Path, prefix: str
+) -> tuple[Path | None, int | None]:
+    """prefix_YYYYMMDD.json のうち日付が最大のものと、その日付 (int) を返す。"""
+    best: tuple[int, Path] | None = None
+    for f in results_dir.glob(f"{prefix}_*.json"):
+        digits = "".join(ch for ch in f.stem[len(prefix) :] if ch.isdigit())[:8]
+        if len(digits) != 8:
+            continue
+        n = int(digits)
+        if best is None or n > best[0]:
+            best = (n, f)
+    if best is None:
+        return None, None
+    return best[1], best[0]
+
+
+def _load_json(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------
+# checks
+# --------------------------------------------------------------------------
+def check_daily(results_dir: Path, max_age_hours: float) -> CheckResult:
+    """today_signals / pipeline の最新ファイルの鮮度で 06:00 デイリーの実行を判定。"""
+    sig_path, sig_date = _latest_dated_json(results_dir, "today_signals")
+    pipe_path, pipe_date = _latest_dated_json(results_dir, "pipeline")
+    if sig_path is None:
+        return CheckResult(
+            "daily", "crit", "today_signals_*.json が 1 つも無い (デイリー未実行の疑い)"
+        )
+    age = _mtime_age_hours(sig_path)
+    data = {
+        "today_signals": sig_path.name,
+        "today_signals_date": sig_date,
+        "mtime_age_hours": round(age, 1) if age is not None else None,
+        "pipeline": pipe_path.name if pipe_path else None,
+        "pipeline_date": pipe_date,
+    }
+    if age is None:
+        return CheckResult(
+            "daily", "warn", f"{sig_path.name} の mtime を取得できない", data
+        )
+    if age > max_age_hours:
+        return CheckResult(
+            "daily",
+            "crit",
+            f"最新 {sig_path.name} が {age:.1f}h 前 (> {max_age_hours:.0f}h): "
+            "06:00 デイリーが走っていない疑い",
+            data,
+        )
+    return CheckResult(
+        "daily",
+        "ok",
+        f"{sig_path.name} を {age:.1f}h 前に生成 (date={sig_date})",
+        data,
+    )
+
+
+def check_signals(results_dir: Path, min_signals: int) -> CheckResult:
+    """最新 today_signals の総シグナル数で潤沢さを判定 (0=CRIT / 薄=WARN)。"""
+    sig_path, sig_date = _latest_dated_json(results_dir, "today_signals")
+    sig = _load_json(sig_path)
+    if sig is None:
+        return CheckResult(
+            "signals", "crit", "today_signals JSON を読めない (0 signals 事故の疑い)"
+        )
+    portfolio = sig.get("portfolio", {}) or {}
+    total = portfolio.get("total_signals")
+    if total is None:
+        # 明示フィールドが無ければ systems から数える
+        total = 0
+        for blk in (sig.get("systems") or {}).values():
+            if isinstance(blk, dict):
+                total += len(blk.get("signals") or [])
+    data = {
+        "date": sig.get("date"),
+        "total_signals": total,
+        "universe_target": portfolio.get("universe_target"),
+        "min_signals": min_signals,
+    }
+    if total <= 0:
+        return CheckResult(
+            "signals",
+            "crit",
+            f"total_signals={total} (0 シグナル: データ鮮度異常)",
+            data,
+        )
+    if total < min_signals:
+        return CheckResult(
+            "signals",
+            "warn",
+            f"total_signals={total} < 閾値{min_signals}: 薄い (データ鮮度異常の疑い)",
+            data,
+        )
+    return CheckResult(
+        "signals", "ok", f"total_signals={total} (>= {min_signals})", data
+    )
+
+
+def check_publish(
+    repo_root: Path, branch: str, max_age_hours: float, data_dir: Path
+) -> CheckResult:
+    """monitor-webapp ブランチの最新 commit 時刻で Vercel publish の当日実行を判定。"""
+    committed_iso: str | None = None
+    subject: str | None = None
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "log", "-1", "--format=%cI\x1f%s", branch],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            committed_iso, _, subject = proc.stdout.strip().partition("\x1f")
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "publish", "warn", f"git log 取得失敗: {exc}", {"branch": branch}
+        )
+
+    # 副: dashboard data dir の最新ファイル日付も参考に
+    dash_path, dash_date = _latest_dated_json(data_dir, "today_signals")
+    data = {
+        "branch": branch,
+        "last_commit_iso": committed_iso,
+        "last_commit_subject": subject,
+        "dashboard_data_date": dash_date,
+    }
+    if not committed_iso:
+        return CheckResult(
+            "publish", "warn", f"{branch} の commit を取得できない", data
+        )
+    try:
+        ct = datetime.fromisoformat(committed_iso)
+        age = (datetime.now(tz=ct.tzinfo) - ct).total_seconds() / 3600.0
+        data["last_commit_age_hours"] = round(age, 1)
+    except Exception:
+        return CheckResult(
+            "publish", "warn", f"commit 時刻を解釈できない: {committed_iso}", data
+        )
+    if age > max_age_hours:
+        return CheckResult(
+            "publish",
+            "crit",
+            f"{branch} 最新 commit が {age:.1f}h 前 (> {max_age_hours:.0f}h): "
+            "Vercel publish 停止/ダッシュ固着の疑い",
+            data,
+        )
+    return CheckResult(
+        "publish", "ok", f"{branch} を {age:.1f}h 前に更新 ('{subject}')", data
+    )
+
+
+def check_open_run(
+    logs_dir: Path, results_dir: Path, max_age_hours: float
+) -> CheckResult:
+    """最新 open_run_<date> の completion_recon で自動発注 run の実行/約定を判定。"""
+    dirs = sorted(logs_dir.glob("open_run_*"), reverse=True)
+    dirs = [d for d in dirs if d.is_dir()]
+    if not dirs:
+        return CheckResult("open_run", "info", "open_run_* ディレクトリがまだ無い")
+    newest = dirs[0]
+    recon = _load_json(newest / "completion_recon.json") or {}
+    done = (newest / "DONE.lock").exists()
+    age = _mtime_age_hours(newest / "completion_recon.json") or _mtime_age_hours(newest)
+    run_date = recon.get("date") or newest.name.replace("open_run_", "")
+    abort = recon.get("abort")
+    mode = recon.get("mode")
+    submitted = recon.get("entry_submitted")
+    data = {
+        "dir": newest.name,
+        "run_date": run_date,
+        "mode": mode,
+        "abort": abort,
+        "done_lock": done,
+        "entry_submitted": submitted,
+        "entry_status": recon.get("entry_status"),
+        "final_positions": recon.get("final_positions"),
+        "age_hours": round(age, 1) if age is not None else None,
+    }
+
+    # 良性 abort (市場休場) は OK 扱い
+    if abort == "market_closed":
+        return CheckResult(
+            "open_run", "ok", f"{run_date}: market closed で正常 skip", data
+        )
+    if abort == "drawdown_flatten":
+        return CheckResult(
+            "open_run",
+            "warn",
+            f"{run_date}: drawdown breaker 発火で flatten/中止",
+            data,
+        )
+    if abort:
+        return CheckResult("open_run", "warn", f"{run_date}: ABORT ({abort})", data)
+
+    # abort 無し = entry まで到達したはず
+    if age is not None and age > max_age_hours:
+        return CheckResult(
+            "open_run",
+            "warn",
+            f"最新 open_run が {age:.1f}h 前 (> {max_age_hours:.0f}h): ランナー停止の疑い",
+            data,
+        )
+    if mode == "dry_run":
+        return CheckResult("open_run", "info", f"{run_date}: dry_run (発注なし)", data)
+    try:
+        n_sub = int(submitted or 0)
+    except (TypeError, ValueError):
+        n_sub = 0
+    if n_sub <= 0:
+        return CheckResult(
+            "open_run",
+            "warn",
+            f"{run_date}: 実 run だが entry_submitted={submitted}",
+            data,
+        )
+    return CheckResult(
+        "open_run",
+        "ok",
+        f"{run_date}: entry_submitted={n_sub} status={recon.get('entry_status')} done={done}",
+        data,
+    )
+
+
+def check_pipeline_run(daily_log_dir: Path, max_age_hours: float) -> CheckResult:
+    """最新 daily_pipeline_*.log を解析し、cache step の exit と pipeline 完走を判定。
+
+    07-19 の --auto-latest 初本番実証で必要な (a) cache step が exit=0 で完走したか +
+    pipeline が『完了』まで到達したか (途中 stall=07-18 の silent hang を検出) を見る。
+    daily_pipeline のログは走行 worktree (既定 C:\\tmp\\qts-daily-main\\logs) 側に出る。
+    """
+    if not daily_log_dir.exists():
+        return CheckResult("pipeline", "skip", f"daily log dir 不在: {daily_log_dir}")
+    logs = [p for p in daily_log_dir.glob("daily_pipeline_*.log")]
+    if not logs:
+        return CheckResult(
+            "pipeline", "crit", "daily_pipeline_*.log が無い (デイリー未実行の疑い)"
+        )
+    newest = max(logs, key=lambda p: p.stat().st_mtime)
+    age = _mtime_age_hours(newest)
+    try:
+        text = newest.read_text(encoding="utf-8-sig", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "pipeline", "warn", f"log 読取失敗: {exc}", {"log": newest.name}
+        )
+    m_cache = re.search(r"\[cache\]\s*終了\s*\(exit=(-?\d+)\)", text)
+    cache_exit = int(m_cache.group(1)) if m_cache else None
+    completed = "Daily Pipeline 完了" in text
+    steps = re.findall(r"-----\s*\[([^\]]+)\]\s*(?:開始|終了)", text)
+    last_step = steps[-1] if steps else None
+    data = {
+        "log": newest.name,
+        "age_hours": round(age, 1) if age is not None else None,
+        "cache_exit": cache_exit,
+        "completed": completed,
+        "last_step": last_step,
+    }
+    if age is not None and age > max_age_hours:
+        return CheckResult(
+            "pipeline",
+            "crit",
+            f"🔴 最新 daily_pipeline log が {age:.1f}h 前 (> {max_age_hours:.0f}h): "
+            "06:00 デイリーが走っていない疑い",
+            data,
+        )
+    if not completed:
+        return CheckResult(
+            "pipeline",
+            "crit",
+            f"🔴 {newest.name} が『完了』未到達 (stall at [{last_step}]) "
+            "= silent hang の疑い",
+            data,
+        )
+    if cache_exit is None:
+        return CheckResult(
+            "pipeline", "warn", "pipeline 完了だが cache exit を検出できず", data
+        )
+    if cache_exit != 0:
+        return CheckResult(
+            "pipeline",
+            "warn",
+            f"pipeline 完了だが cache exit={cache_exit} "
+            "(--auto-latest 未完走 / 旧コード or fetch 失敗の疑い)",
+            data,
+        )
+    return CheckResult(
+        "pipeline",
+        "ok",
+        "🟢 --auto-latest cache 完走 (exit=0) + pipeline 完了",
+        data,
+    )
+
+
+def _csv_last_date(path: Path) -> str | None:
+    """CSV の最終行 (= 最新日) から YYYY-MM-DD を末尾読みで安価に取得。
+
+    full_backup は Date が第1列、rolling は index,Date,... と列順が異なるため、
+    列位置ではなく日付パターンで拾う (どちらの schema でも正しく取れる)。
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            fh.seek(max(0, size - 4096))
+            tail = fh.read().decode("utf-8", errors="replace").strip().splitlines()
+        if not tail:
+            return None
+        m = re.search(r"\d{4}-\d{2}-\d{2}", tail[-1])
+        return m.group(0) if m else tail[-1].split(",")[0].strip()
+    except Exception:
+        return None
+
+
+def check_data_advance(data_cache_dir: Path, ref: str = "SPY") -> CheckResult:
+    """full_backup 参照銘柄 (SPY) の最新日を NYSE 最新取引日と突合 (frozen cache 検出)。
+
+    ``full_backup`` は日次 fetch の着地点で、SPY を含む全銘柄が必ずここへ更新される。
+    その絶対 staleness (full_backup vs 実市場 = NYSE 最新取引日) を見れば、freshness_guard
+    の盲点 (rolling/full_backup 同時凍結を『fresh』と誤判定) も含めて cache 停滞を検出できる
+    ── full_backup が凍結すれば必ずここで拾える。
+
+    rolling の前進 (rolling vs full_backup) は universe scoped な freshness_guard
+    (check_rolling_freshness.py) の担当。ここでは **敢えて rolling を読まない**:
+    SPY は non-universe ETF で rolling へは再構築されず毎日 stale drift するため、
+    rolling/SPY.csv を参照すると恒常的な誤 WARN 表示になっていた (2026-07-19 の是正)。
+    full_backup 基準なら SPY を含む非 universe 参照銘柄でも正しく前進を確認できる。
+    """
+    fb = data_cache_dir / "full_backup" / f"{ref}.csv"
+    fb_date = _csv_last_date(fb)
+    data: dict[str, Any] = {"ref": ref, "full_backup_last": fb_date}
+    if fb_date is None:
+        return CheckResult(
+            "data_fresh", "skip", f"full_backup/{ref}.csv を読めない", data
+        )
+    try:
+        import pandas as pd
+
+        from common.utils_spy import get_latest_nyse_trading_day
+
+        now = pd.Timestamp.now(tz="America/New_York").tz_localize(None).normalize()
+        latest_nyse = pd.Timestamp(get_latest_nyse_trading_day(now)).normalize()
+        fb_ts = pd.Timestamp(fb_date).normalize()
+        lag = max(0, int(pd.bdate_range(fb_ts, latest_nyse).size) - 1)
+        data["latest_nyse"] = str(latest_nyse.date())
+        data["lag_business_days"] = lag
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "data_fresh",
+            "info",
+            f"full_backup {ref}={fb_date} (NYSE 突合不可: {exc})",
+            data,
+        )
+    tail = f"full_backup {ref}={fb_date} / 市場最新={latest_nyse.date()}"
+    if lag <= 1:
+        return CheckResult(
+            "data_fresh", "ok", f"データ前進 OK ({tail}, lag {lag} 営業日)", data
+        )
+    if lag <= 4:
+        return CheckResult(
+            "data_fresh",
+            "warn",
+            f"full_backup が市場より {lag} 営業日遅れ (cache 停滞疑い) — {tail}",
+            data,
+        )
+    return CheckResult(
+        "data_fresh",
+        "crit",
+        f"🔴 full_backup が市場より {lag} 営業日遅れ (cache 凍結) — {tail}",
+        data,
+    )
+
+
+# --------------------------------------------------------------------------
+# aggregate + notify
+# --------------------------------------------------------------------------
+def _aggregate(results: list[CheckResult]) -> str:
+    worst = "ok"
+    for r in results:
+        if _SEVERITY.get(r.status, 0) > _SEVERITY.get(worst, 0):
+            worst = r.status
+    return worst
+
+
+def _notify(
+    date_str: str, results: list[CheckResult], worst: str, dry_run: bool
+) -> bool:
+    n_bad = sum(1 for r in results if r.status in ("warn", "crit"))
+    n_ok = sum(1 for r in results if r.status in ("ok", "info"))
+    if worst == "crit":
+        head = f"SelfMonitor {date_str}: CRIT ({n_bad} issue)"
+    elif worst == "warn":
+        head = f"SelfMonitor {date_str}: WARN ({n_bad} issue)"
+    else:
+        head = f"SelfMonitor {date_str}: OK ({n_ok}/{len(results)})"
+    body = head + "\n" + "\n".join(r.line() for r in results)
+    urgent = worst in ("warn", "crit")
+
+    if dry_run:
+        print("--- ntfy (dry-run) ---")
+        print(body)
+        return True
+    try:
+        from common.publishers.ntfy import NtfyPublisher
+
+        pub = NtfyPublisher()
+        if not pub.is_configured():
+            print("[ntfy] NTFY_TOPIC 未設定のため送信スキップ")
+            return False
+        tags = "rotating_light,warning" if urgent else "white_check_mark"
+        res = pub.send_text(head, body, tags=tags, priority=(5 if urgent else None))
+        print(f"[ntfy] 送信 ok={getattr(res, 'ok', '?')}")
+        return bool(getattr(res, "ok", False))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ntfy] 送信失敗: {exc}")
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--date", default=None, help="対象日 YYYY-MM-DD (表示用。default: today local)"
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=os.getenv("QTS_REPO_ROOT", PRIMARY_ROOT_DEFAULT),
+        help="results_csv/logs を持つ primary repo (junction 元)",
+    )
+    parser.add_argument(
+        "--min-signals",
+        type=int,
+        default=10,
+        help="これ未満なら薄シグナル WARN (default 10)",
+    )
+    parser.add_argument(
+        "--max-age-hours",
+        type=float,
+        default=26.0,
+        help="daily / publish の鮮度上限 h (これ超で CRIT。default 26)",
+    )
+    parser.add_argument(
+        "--openrun-max-age-hours",
+        type=float,
+        default=96.0,
+        help="open_run の鮮度上限 h (週末を跨ぐので既定 96)",
+    )
+    parser.add_argument(
+        "--monitor-branch",
+        default="claude/monitor-webapp",
+        help="Vercel publish 先ブランチ",
+    )
+    parser.add_argument(
+        "--daily-log-dir",
+        default=os.getenv("QTS_DAILY_LOG_DIR", r"C:\tmp\qts-daily-main\logs"),
+        help="daily_pipeline_*.log の出力先 (走行 worktree 側。cache exit 判定に使う)",
+    )
+    parser.add_argument("--output-json", default=None, help="判定サマリ JSON の出力先")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="ntfy を送らず本文を表示"
+    )
+    parser.add_argument(
+        "--no-notify", action="store_true", help="ntfy 送信を完全に無効化"
+    )
+    args = parser.parse_args(argv)
+
+    date_str = args.date or datetime.now().strftime("%Y-%m-%d")
+    repo = Path(args.repo_root)
+    results_dir = repo / "results_csv"
+    logs_dir = repo / "logs"
+    data_dir = repo / "apps" / "dashboards" / "alpaca-next" / "data"
+    daily_log_dir = Path(args.daily_log_dir)
+    data_cache_dir = repo / "data_cache"
+
+    results = [
+        check_daily(results_dir, args.max_age_hours),
+        check_pipeline_run(daily_log_dir, args.max_age_hours),
+        check_data_advance(data_cache_dir),
+        check_signals(results_dir, args.min_signals),
+        check_publish(repo, args.monitor_branch, args.max_age_hours, data_dir),
+        check_open_run(logs_dir, results_dir, args.openrun_max_age_hours),
+    ]
+    worst = _aggregate(results)
+
+    for r in results:
+        print(r.line())
+    print(f"=> worst={worst.upper()}")
+
+    record = {
+        "version": "1.1",
+        "date": date_str,
+        "generated_at": _now().isoformat(timespec="seconds"),
+        "repo_root": str(repo),
+        "worst": worst,
+        "checks": [r.to_dict() for r in results],
+    }
+    out_path = (
+        Path(args.output_json)
+        if args.output_json
+        else logs_dir / f"self_monitor_{date_str.replace('-', '')}.json"
+    )
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+        print(f"[write] {out_path}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] JSON 書き出し失敗 (無視): {exc}")
+
+    if not args.no_notify:
+        _notify(date_str, results, worst, dry_run=args.dry_run)
+
+    return {"ok": 0, "info": 0, "skip": 0, "warn": 2, "crit": 3}.get(worst, 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_drawdown_breaker.py
+++ b/tests/test_drawdown_breaker.py
@@ -1,0 +1,130 @@
+"""drawdown サーキットブレーカ (common/drawdown_breaker) の判定 + 誤発火ガード検証。
+
+config 無効 (threshold<=0) が最優先で no-op、履歴が薄い/equity 欠損では絶対に
+would_flatten=True にしないことを固定化する (paper-only 安全弁の要)。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from common.drawdown_breaker import (  # noqa: E402
+    assess,
+    load_equity_history,
+    resolve_peak_equity,
+)
+
+
+# --- disabled by default (最重要) -----------------------------------------
+def test_disabled_when_threshold_zero():
+    a = assess(80_000, 100_000, 0.0, n_history_points=20)
+    assert a.armed is False
+    assert a.would_flatten is False
+    assert a.reason == "disabled(threshold<=0)"
+
+
+def test_disabled_when_threshold_none():
+    a = assess(80_000, 100_000, None, n_history_points=20)
+    assert a.armed is False
+    assert a.would_flatten is False
+
+
+# --- fire path -------------------------------------------------------------
+def test_would_flatten_when_breached_and_healthy():
+    a = assess(80_000, 100_000, 0.15, n_history_points=20)
+    assert a.armed is True
+    assert a.breached is True
+    assert a.would_flatten is True
+    assert a.drawdown_pct == 0.20
+
+
+def test_within_threshold_no_flatten():
+    a = assess(90_000, 100_000, 0.15, n_history_points=20)
+    assert a.breached is False
+    assert a.would_flatten is False
+    assert a.reason == "within_threshold"
+
+
+# --- misfire guards --------------------------------------------------------
+def test_thin_history_blocks_flatten():
+    a = assess(80_000, 100_000, 0.15, n_history_points=3, min_history_points=5)
+    assert a.breached is True  # 生判定は breach
+    assert a.would_flatten is False  # だがガードで抑止
+    assert any("thin_history" in g for g in a.guard_blocks)
+
+
+def test_no_equity_blocks_flatten():
+    a = assess(None, 100_000, 0.15, n_history_points=20)
+    assert a.would_flatten is False
+    assert "no_equity" in a.guard_blocks
+
+
+def test_no_peak_blocks_flatten():
+    a = assess(80_000, 0, 0.15, n_history_points=20)
+    assert a.would_flatten is False
+    assert "no_peak" in a.guard_blocks
+
+
+def test_abs_usd_guard_blocks_small_drawdown():
+    # 20% だが絶対額は $200 → min_abs_drawdown_usd=$1000 で抑止
+    a = assess(800, 1000, 0.15, n_history_points=20, min_abs_drawdown_usd=1000)
+    assert a.breached is True
+    assert a.would_flatten is False
+    assert any("below_abs_usd" in g for g in a.guard_blocks)
+
+
+def test_abs_usd_guard_allows_large_drawdown():
+    a = assess(80_000, 100_000, 0.15, n_history_points=20, min_abs_drawdown_usd=1000)
+    assert a.would_flatten is True  # $20k > $1k ガード通過
+
+
+# --- peak resolution -------------------------------------------------------
+def test_resolve_peak_uses_history_and_current():
+    hist = [
+        {"t": "2026-07-07", "equity": 100_000},
+        {"t": "2026-07-10", "equity": 106_000},
+    ]
+    peak, n = resolve_peak_equity(hist, 90_000)
+    assert peak == 106_000  # 履歴の最大 (現 equity 90k は下回る)
+    assert n == 2  # 現 equity を足す前の履歴点数
+
+
+def test_resolve_peak_current_is_new_high():
+    hist = [{"t": "2026-07-07", "equity": 100_000}]
+    peak, n = resolve_peak_equity(hist, 120_000)
+    assert peak == 120_000  # 新高値は current から
+    assert n == 1
+
+
+def test_resolve_peak_ignores_garbage_rows():
+    hist = [{"t": "x", "equity": "bad"}, {"equity": 0}, {"equity": 105_000}]
+    peak, n = resolve_peak_equity(hist, None)
+    assert peak == 105_000
+    assert n == 1  # 有効点は 105k のみ
+
+
+def test_new_high_never_flattens_end_to_end():
+    # 現 equity が新高値 → drawdown 0 → armed でも flatten しない
+    hist = [{"t": "a", "equity": 100_000}]
+    peak, n = resolve_peak_equity(hist, 130_000)
+    a = assess(130_000, peak, 0.15, n_history_points=n, min_history_points=1)
+    assert a.would_flatten is False
+
+
+def test_load_equity_history_missing_file(tmp_path: Path):
+    assert load_equity_history(tmp_path / "nope.json") == []
+
+
+def test_load_equity_history_reads_list(tmp_path: Path):
+    p = tmp_path / "hist.json"
+    p.write_text(
+        json.dumps([{"t": "a", "equity": 1}, "junk", {"t": "b"}]), encoding="utf-8"
+    )
+    out = load_equity_history(p)
+    assert out == [{"t": "a", "equity": 1}, {"t": "b"}]  # dict 以外は除去

--- a/tests/test_exit_verify.py
+++ b/tests/test_exit_verify.py
@@ -1,0 +1,167 @@
+"""exit E2E 検証 (scripts/exit_verify.verify) の突合ロジック検証。
+
+- time-based 満期の独立再計算 (positions snapshot から holding_days>=max)。
+- planned close の fill/pending/reject 分類。
+- 満期なのに未計画 (paper_exit_check 漏れ) の検知。
+status_map を注入できる純関数なので Alpaca 無しで検証できる。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.exit_verify import _expected_time_exits, verify  # noqa: E402
+
+
+def _pos(symbol, system, entry_date, side="long", qty=1.0):
+    return {
+        "symbol": symbol,
+        "system": system,
+        "entry_date": entry_date,
+        "side": side,
+        "qty": qty,
+    }
+
+
+def _exit(
+    symbol, system, reason, order_type, order_id=None, dry_run=False, status=None
+):
+    return {
+        "symbol": symbol,
+        "system": system,
+        "reason": reason,
+        "order_type": order_type,
+        "order_id": order_id,
+        "dry_run": dry_run,
+        "status": status,
+    }
+
+
+# --- expected time exits recompute ----------------------------------------
+def test_expected_time_exits_by_rule():
+    # S3 max 3d: 07-08 entry, today 07-12 -> 4d -> due。S1 は time-exit 無し。
+    positions = [
+        _pos("AAA", "system3", "2026-07-08"),
+        _pos("BBB", "system3", "2026-07-11"),  # 1d -> not due
+        _pos("CCC", "system1", "2026-07-01"),  # S1: max_hold=0 -> never
+    ]
+    due = _expected_time_exits(positions, "2026-07-12")
+    syms = {d["symbol"] for d in due}
+    assert syms == {"AAA"}
+
+
+def test_expected_time_exits_boundary_equal():
+    # holding_days == max_holding_days は due (>=)
+    positions = [_pos("AAA", "system2", "2026-07-10")]  # 2d == max2 -> due
+    due = _expected_time_exits(positions, "2026-07-12")
+    assert len(due) == 1
+
+
+# --- reconcile: due but not planned ---------------------------------------
+def test_due_not_planned_flagged():
+    exit_orders = {
+        "mode": "dry_run",
+        "positions": [
+            _pos("AAA", "system3", "2026-07-08"),  # due
+            _pos("BBB", "system3", "2026-07-08"),  # due
+        ],
+        "exits": [
+            # AAA だけ計画、BBB は漏れ
+            _exit(
+                "AAA", "system3", "time_based", "market", order_id="o1", status="filled"
+            ),
+        ],
+    }
+    v = verify(exit_orders, "2026-07-12", status_map={})
+    assert v["n_expected_time_exits"] == 2
+    dnp = {d["symbol"] for d in v["discrepancies"]["due_not_planned"]}
+    assert dnp == {"BBB"}
+    assert v["n_warn"] >= 1
+
+
+def test_all_due_planned_and_filled_no_warn():
+    exit_orders = {
+        "mode": "submitted",
+        "positions": [_pos("AAA", "system3", "2026-07-08")],
+        "exits": [
+            _exit(
+                "AAA", "system3", "time_based", "market", order_id="o1", dry_run=False
+            )
+        ],
+    }
+    # live status_map が fill を返す
+    v = verify(exit_orders, "2026-07-12", status_map={"o1": "filled"})
+    assert v["n_filled_closes"] == 1
+    assert v["n_warn"] == 0
+
+
+# --- reconcile: close fill classification ---------------------------------
+def test_rejected_close_is_warn():
+    exit_orders = {
+        "positions": [],
+        "exits": [
+            _exit(
+                "AAA", "system2", "time_based", "market", order_id="o1", dry_run=False
+            )
+        ],
+    }
+    v = verify(exit_orders, "2026-07-12", status_map={"o1": "rejected"})
+    assert len(v["discrepancies"]["closes_rejected"]) == 1
+    assert v["n_warn"] >= 1
+
+
+def test_pending_close_is_info_not_warn():
+    # 市場休場中の成行は accepted のまま = pending (失敗ではない)
+    exit_orders = {
+        "positions": [],
+        "exits": [
+            _exit(
+                "AAA", "system2", "time_based", "market", order_id="o1", dry_run=False
+            )
+        ],
+    }
+    v = verify(exit_orders, "2026-07-12", status_map={"o1": "accepted"})
+    assert len(v["discrepancies"]["closes_pending"]) == 1
+    assert len(v["discrepancies"]["closes_unfilled_nonpending"]) == 0
+    # pending だけなら n_warn に数えない
+    assert v["n_warn"] == 0
+
+
+def test_protection_orders_not_counted_as_close():
+    # resting protection (stop/limit) は close ではない → 未 fill でも WARN しない
+    exit_orders = {
+        "positions": [],
+        "exits": [
+            _exit(
+                "AAA", "system5", "protect_stop", "stop", order_id="o1", dry_run=False
+            ),
+            _exit(
+                "AAA",
+                "system5",
+                "protect_target",
+                "limit",
+                order_id="o2",
+                dry_run=False,
+            ),
+        ],
+    }
+    v = verify(exit_orders, "2026-07-12", status_map={"o1": "new", "o2": "new"})
+    assert v["n_planned_closes"] == 0
+    assert v["n_warn"] == 0
+
+
+def test_fractional_gap_regression():
+    """qty<1 の満期建玉が exits に無いと due_not_planned で必ず立つ (07-12 実データの回帰)。"""
+    exit_orders = {
+        "positions": [
+            _pos("FRAC", "system3", "2026-07-08", qty=0.18),  # 4d due だが fractional
+        ],
+        "exits": [],  # 端株は exit builder が abs_qty=0 で skip → 未計画
+    }
+    v = verify(exit_orders, "2026-07-12", status_map={})
+    assert [d["symbol"] for d in v["discrepancies"]["due_not_planned"]] == ["FRAC"]

--- a/tests/test_self_monitor_check.py
+++ b/tests/test_self_monitor_check.py
@@ -1,0 +1,218 @@
+"""自己監視ガード (scripts/self_monitor_check) の各チェック検証。
+
+tmp fixture の results_csv / logs を組み立て、鮮度・シグナル数・open_run 状態の
+判定 (ok/warn/crit/info) が期待通りに出ることを固定化する。Alpaca / git / ntfy は不要。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+import time
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.self_monitor_check import (  # noqa: E402
+    check_daily,
+    check_data_advance,
+    check_open_run,
+    check_publish,
+    check_signals,
+)
+
+
+def _write(path: Path, obj) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _latest_nyse_or_skip():
+    """Resolve the real latest NYSE trading day; skip if the dep is unavailable."""
+    pd = pytest.importorskip("pandas")
+    try:
+        from common.utils_spy import get_latest_nyse_trading_day
+    except Exception:  # noqa: BLE001
+        pytest.skip("common.utils_spy unavailable")
+    now = pd.Timestamp.now(tz="America/New_York").tz_localize(None).normalize()
+    return pd, pd.Timestamp(get_latest_nyse_trading_day(now)).normalize()
+
+
+# --- daily freshness -------------------------------------------------------
+def test_daily_ok_when_fresh(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    _write(rd / "today_signals_20260712.json", {"date": "2026-07-12", "portfolio": {}})
+    r = check_daily(rd, max_age_hours=26)
+    assert r.status == "ok"
+
+
+def test_daily_crit_when_missing(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    rd.mkdir(parents=True)
+    r = check_daily(rd, max_age_hours=26)
+    assert r.status == "crit"
+
+
+def test_daily_crit_when_stale(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    f = rd / "today_signals_20260701.json"
+    _write(f, {"date": "2026-07-01"})
+    # mtime を 48h 前へ
+    old = time.time() - 48 * 3600
+    os.utime(f, (old, old))
+    r = check_daily(rd, max_age_hours=26)
+    assert r.status == "crit"
+
+
+# --- data_fresh (full_backup absolute staleness) ---------------------------
+def test_data_fresh_ok_ignores_stale_rolling_spy(tmp_path: Path):
+    """full_backup が新鮮なら、rolling/SPY.csv が古くても OK。
+
+    SPY は non-universe ETF で rolling へは同期されない (毎日 stale drift)。
+    verdict は full_backup 基準なので rolling SPY の陳腐化に釣られてはいけない
+    (2026-07-19 の恒久 fix: 火曜以降も再発しないことの固定化)。
+    """
+    _pd, latest = _latest_nyse_or_skip()
+    dc = tmp_path / "data_cache"
+    _write_text(dc / "full_backup" / "SPY.csv", f"Date,Close\n{latest.date()},700\n")
+    # rolling SPY は意図的に大幅 stale (半年前) にしておく
+    _write_text(dc / "rolling" / "SPY.csv", "index,Date,Close\n0,2026-01-02,600\n")
+    r = check_data_advance(dc)
+    assert r.status == "ok", r.detail
+    # honest display: 誤解を招く rolling 値を出さない
+    assert "rolling" not in r.detail
+    assert "rolling_last" not in r.data
+
+
+def test_data_fresh_crit_when_fullbackup_stale(tmp_path: Path):
+    """full_backup 自体が市場より大きく遅れていれば CRIT (cache 凍結を正しく検出)。"""
+    _latest_nyse_or_skip()
+    dc = tmp_path / "data_cache"
+    _write_text(dc / "full_backup" / "SPY.csv", "Date,Close\n2026-01-02,600\n")
+    r = check_data_advance(dc)
+    assert r.status == "crit", r.detail
+
+
+def test_data_fresh_skip_when_fullbackup_missing(tmp_path: Path):
+    dc = tmp_path / "data_cache"
+    (dc / "full_backup").mkdir(parents=True)
+    r = check_data_advance(dc)
+    assert r.status == "skip"
+
+
+# --- signals abundance -----------------------------------------------------
+def test_signals_ok(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    _write(
+        rd / "today_signals_20260712.json",
+        {"date": "2026-07-12", "portfolio": {"total_signals": 44}},
+    )
+    r = check_signals(rd, min_signals=10)
+    assert r.status == "ok"
+    assert r.data["total_signals"] == 44
+
+
+def test_signals_crit_when_zero(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    _write(
+        rd / "today_signals_20260712.json",
+        {"date": "2026-07-12", "portfolio": {"total_signals": 0}},
+    )
+    r = check_signals(rd, min_signals=10)
+    assert r.status == "crit"
+
+
+def test_signals_warn_when_thin(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    _write(
+        rd / "today_signals_20260712.json",
+        {"date": "2026-07-12", "portfolio": {"total_signals": 3}},
+    )
+    r = check_signals(rd, min_signals=10)
+    assert r.status == "warn"
+
+
+def test_signals_counts_from_systems_when_no_portfolio(tmp_path: Path):
+    rd = tmp_path / "results_csv"
+    _write(
+        rd / "today_signals_20260712.json",
+        {"date": "2026-07-12", "systems": {"system1": {"signals": [1, 2, 3]}}},
+    )
+    r = check_signals(rd, min_signals=2)
+    assert r.data["total_signals"] == 3
+    assert r.status == "ok"
+
+
+# --- open_run status -------------------------------------------------------
+def test_open_run_market_closed_is_ok(tmp_path: Path):
+    logs = tmp_path / "logs"
+    d = logs / "open_run_20260711"
+    _write(
+        d / "completion_recon.json", {"date": "2026-07-11", "abort": "market_closed"}
+    )
+    r = check_open_run(logs, tmp_path / "results_csv", max_age_hours=96)
+    assert r.status == "ok"
+
+
+def test_open_run_thin_signal_abort_is_warn(tmp_path: Path):
+    logs = tmp_path / "logs"
+    d = logs / "open_run_20260713"
+    _write(
+        d / "completion_recon.json",
+        {"date": "2026-07-13", "abort": "thin_signals:2<10"},
+    )
+    r = check_open_run(logs, tmp_path / "results_csv", max_age_hours=96)
+    assert r.status == "warn"
+
+
+def test_open_run_filled_is_ok(tmp_path: Path):
+    logs = tmp_path / "logs"
+    d = logs / "open_run_20260713"
+    _write(
+        d / "completion_recon.json",
+        {
+            "date": "2026-07-13",
+            "mode": "paper_submit",
+            "entry_submitted": 30,
+            "entry_status": "ok",
+        },
+    )
+    (d / "DONE.lock").write_text("x", encoding="utf-8")
+    r = check_open_run(logs, tmp_path / "results_csv", max_age_hours=96)
+    assert r.status == "ok"
+
+
+def test_open_run_zero_entries_is_warn(tmp_path: Path):
+    logs = tmp_path / "logs"
+    d = logs / "open_run_20260713"
+    _write(
+        d / "completion_recon.json",
+        {"date": "2026-07-13", "mode": "paper_submit", "entry_submitted": 0},
+    )
+    r = check_open_run(logs, tmp_path / "results_csv", max_age_hours=96)
+    assert r.status == "warn"
+
+
+def test_open_run_none_when_no_dirs(tmp_path: Path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    r = check_open_run(logs, tmp_path / "results_csv", max_age_hours=96)
+    assert r.status == "info"
+
+
+# --- publish (git 無しの tmp dir では warn へフォールバック) ----------------
+def test_publish_warn_when_not_a_git_repo(tmp_path: Path):
+    r = check_publish(
+        tmp_path, "claude/monitor-webapp", max_age_hours=26, data_dir=tmp_path
+    )
+    assert r.status == "warn"


### PR DESCRIPTION
## Why
The paper safety nets (SelfMonitor / ExitVerify / drawdown circuit breaker) and the **data_fresh durable fix** lived only on the week-old branch `claude/monitor-safety-nets-20260712`. Consolidating them onto main for durability so they aren't stranded on a stale branch.

## What (monitoring / read-only / off-by-default only)
- **`scripts/self_monitor_check.py`(.ps1)** — pipeline-completion + cache/`data_fresh` guard. The `data_fresh` check compares **SPY full_backup latest vs NYSE latest trading day** to catch a *total* cache freeze (rolling + full_backup both frozen) that the universe-scoped `freshness_guard` reads as fresh, and fixes the chronic **false WARN** from reading non-universe SPY's rolling cache (the 2026-07-12..14 freeze class). Complements the freshness-guard absolute-staleness check landed in #145 (different entry point, redundant coverage of a critical blind spot).
- **`scripts/exit_verify.py`(.ps1)** — E2E exit verification (read-only reconcile).
- **`common/drawdown_breaker.py` + `scripts/drawdown_circuit_breaker.py`** — drawdown circuit breaker. **OFF BY DEFAULT** (`risk.portfolio.drawdown_flatten_pct = 0.0`, already on main); inert unless explicitly enabled and `--confirm`. **No wiring into any live submit path on main.**
- `scripts/register_safety_tasks.ps1`, `docs/MONITOR_SAFETY_NETS_20260712.md`.

## Deliberately excluded
`scripts/open_auto_run.py`/`.ps1` (the live 22:35 paper-submit runner) **stays on its runner branch** `claude/open-auto-run`. Main must not carry an auto-submit path.

## Safety
paper-only; **no trading-behavior change** — monitors + an off-by-default tool + tests. Verified against **current** main (branch was 13 commits behind): **39 tests pass**, scripts import cleanly, black/isort/ruff clean.