### PR TITLE
fix(risk): enforce per-system standing cap + fail-closed reconcile (P1 position accumulation)

### DIFF
--- a/common/alpaca_trading.py
+++ b/common/alpaca_trading.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
@@ -25,6 +26,7 @@ from typing import Any
 import pandas as pd
 
 from common import broker_alpaca as ba
+from common.symbol_map import resolve_primary_system
 
 logger = logging.getLogger(__name__)
 
@@ -921,6 +923,209 @@ def fetch_open_order_state(client: Any) -> tuple[dict[str, set[str]], set[str]]:
     return open_sides, open_coids
 
 
+# =========================================================================
+# Per-system standing cap (P1 fix, 2026-07-21)
+# =========================================================================
+# 根因 (logs/audit_20260719/AUDIT_REPORT.md 🔴P1): 発注境界には per-symbol の
+# ``already_held`` しか無く、**別銘柄で同一 system の保有数が上限 (max_positions=10)
+# を超えて積み上がる**のを止められなかった。07-13 の 10 銘柄 + 07-14 の別 10 銘柄が
+# 両方通り system 別 20 に。finalize_allocation の slot cap は open_auto_run 経路
+# (JSON→paper_trading_submit) を通らないので効かない。ここが両経路共通の発注直前点=
+# **最終防波堤**。詳細 docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md。
+#
+# cap 値は新規でなく既存 spec の実効化:
+#   per-system=risk.max_positions(=10, docs/systems S1/S2 明記/他 global 既定)
+#   total     =risk.portfolio.max_total_positions(=70, PHASE5 §2.1)
+# per-run TOP_N=10 (1 run の候補生成数) とは別概念 (こちらは日跨ぎの同時保有残高)。
+
+
+@dataclass(slots=True)
+class HeldPositionCounts:
+    """standing cap 判定用の現保有集計。
+
+    per_system: system 帰属できた保有数 (coid → symbol_system_map)。
+    unmapped: system 帰属できない nonzero 保有 (delisted/orphan, 例 FOLD/CDTX)。
+    total: nonzero 保有総数 (unmapped 含む)。long_total/short_total は qty 符号で。
+    """
+
+    per_system: dict[str, int]
+    unmapped: int
+    total: int
+    long_total: int
+    short_total: int
+
+
+def _fetch_entry_coid_by_symbol(client: Any) -> dict[str, str]:
+    """直近 Alpaca orders から entry 由来 client_order_id を symbol 別に引く (read-only)。
+
+    exit 経路 ``_hydrate_from_alpaca_coids`` と同じ信頼できる帰属源。取得失敗は
+    握り潰して空 dict (best-effort。position fetch 自体は別で fail-closed 済)。
+    """
+    out: dict[str, str] = {}
+    try:
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
+
+        raw = client.get_orders(
+            filter=GetOrdersRequest(status=QueryOrderStatus.ALL, limit=500)
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("standing cap: 直近 orders 取得失敗、coid 帰属を skip: %s", exc)
+        return out
+    for o in raw or []:
+        try:
+            sym = str(getattr(o, "symbol", "") or "").upper()
+            coid = str(getattr(o, "client_order_id", "") or "")
+            if not sym or not coid:
+                continue
+            if parse_system_from_client_order_id(coid) is None:
+                continue  # entry 由来 (system... prefix) のみ
+            out.setdefault(sym, coid)  # 最初にヒット (新しい fill から返る想定)
+        except Exception:
+            continue
+    return out
+
+
+def count_held_positions_by_system(
+    client: Any,
+    *,
+    open_positions: dict[str, float],
+    symbol_system_map: Mapping[str, Any] | None = None,
+    coid_by_symbol: Mapping[str, str] | None = None,
+) -> HeldPositionCounts:
+    """現保有を system 別に集計する (standing cap の分母)。
+
+    ``open_positions`` は ``{symbol: signed_qty}`` (``_fetch_open_positions`` 由来)。
+    帰属優先順位 = entry order の client_order_id (``system{N}-…``) → symbol_system_map。
+    どちらでも帰属できない nonzero 保有は delisted/orphan として ``unmapped`` に積む
+    (total/side には算入するが per-system には入れない = docs の設計判断)。
+    """
+    ssm: dict[str, str] = {}
+    if symbol_system_map:
+        for k, v in symbol_system_map.items():
+            try:
+                sym = str(k).strip().upper()
+            except Exception:
+                continue
+            prim = resolve_primary_system(v)
+            if not prim:
+                try:
+                    prim = str(v).strip().lower() or None
+                except Exception:
+                    prim = None
+            if sym and prim:
+                ssm[sym] = str(prim).strip().lower()
+
+    coids: Mapping[str, str] = coid_by_symbol if coid_by_symbol is not None else {}
+    if coid_by_symbol is None and client is not None:
+        coids = _fetch_entry_coid_by_symbol(client)
+
+    per_system: dict[str, int] = {}
+    unmapped = total = long_total = short_total = 0
+    for sym_raw, qty_raw in (open_positions or {}).items():
+        try:
+            qty = float(qty_raw or 0.0)
+        except (TypeError, ValueError):
+            qty = 0.0
+        if qty == 0.0:
+            continue
+        sym = str(sym_raw).strip().upper()
+        total += 1
+        if qty >= 0:
+            long_total += 1
+        else:
+            short_total += 1
+
+        system = parse_system_from_client_order_id(coids.get(sym))
+        if not system:
+            system = ssm.get(sym)
+        if not system and sym == "SPY" and qty < 0:
+            system = "system7"  # SPY short = catastrophe hedge
+        if system:
+            key = str(system).strip().lower()
+            per_system[key] = per_system.get(key, 0) + 1
+        else:
+            unmapped += 1  # delisted/orphan (帰属不能)
+
+    return HeldPositionCounts(
+        per_system=per_system,
+        unmapped=unmapped,
+        total=total,
+        long_total=long_total,
+        short_total=short_total,
+    )
+
+
+def evaluate_standing_cap(
+    *,
+    system: str,
+    held_by_system: Mapping[str, int],
+    total_held: int,
+    batch_by_system: Mapping[str, int],
+    batch_total: int,
+    per_system_cap: int,
+    total_cap: int,
+) -> str | None:
+    """新規 1 件が standing cap に触れるなら skip 理由を返す (pure, なければ None)。
+
+    total_held / batch_total は delisted 含む口座全体。held_by_system は帰属済保有。
+    """
+    if total_cap > 0 and (total_held + batch_total) >= total_cap:
+        return (
+            f"standing_cap:portfolio_total_held={total_held}"
+            f"+batch={batch_total}>=cap={total_cap}"
+        )
+    key = (system or "").strip().lower()
+    if per_system_cap > 0 and key:
+        held = int(held_by_system.get(key, 0))
+        batch = int(batch_by_system.get(key, 0))
+        if (held + batch) >= per_system_cap:
+            return f"standing_cap:{key}_held={held}+batch={batch}>=cap={per_system_cap}"
+    return None
+
+
+def _resolve_standing_caps() -> tuple[bool, int, int]:
+    """(enforce, per_system_cap, total_cap) を config + env から解決する。
+
+    既定は docs 通り (per-system=risk.max_positions=10 / total=
+    risk.portfolio.max_total_positions=70)。新しいリスク値は入れない。
+    env で ops 上書き / 無効化可 (docs §4)。
+    """
+
+    def _flag(name: str, default: str = "1") -> bool:
+        return os.environ.get(name, default).strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
+
+    def _int_env(name: str, fallback: int) -> int:
+        try:
+            raw = os.environ.get(name)
+            return int(raw) if raw not in (None, "") else fallback
+        except (TypeError, ValueError):
+            return fallback
+
+    per_system = 10
+    total = 70
+    try:
+        from config.settings import get_settings
+
+        risk = get_settings().risk
+        per_system = int(getattr(risk, "max_positions", 10))
+        total = int(
+            getattr(getattr(risk, "portfolio", None), "max_total_positions", 70)
+        )
+    except Exception:
+        pass
+
+    enforce = _flag("SUBMIT_ENFORCE_STANDING_CAP", "1")
+    per_system = _int_env("SUBMIT_MAX_POSITIONS_PER_SYSTEM", per_system)
+    total = _int_env("SUBMIT_MAX_TOTAL_POSITIONS", total)
+    return enforce, max(0, per_system), max(0, total)
+
+
 def signals_json_to_orders(
     json_data: dict[str, Any],
     tier: str,
@@ -958,9 +1163,12 @@ def signals_json_to_orders(
         entry_date = str(json_data.get("date") or "")
     date_compact = entry_date.replace("-", "").replace(" ", "")[:8]
 
-    # dedup (sym, system) を先に確定してから予算配分する。件数 cap / max_positions は
-    # 上流 (final_allocation) で today_signals 生成時に既に効いているので、ここでは
-    # per-name/gross/net の dollar cap のみを予算の内側で適用する。
+    # dedup (sym, system) を先に確定してから予算配分する。dollar cap
+    # (per-name/gross/net) は予算の内側でここで適用する。
+    # NOTE (P1 fix 2026-07-21): **件数 cap / max_positions は上流 finalize_allocation
+    # で必ず効く、という旧前提は誤り** (audit 🔴P1)。open_auto_run 経路は finalize を
+    # 通らず JSON→ここへ直行するため、per-system の保有件数上限は下の実発注ループで
+    # standing cap として enforce する (最終防波堤)。
     deduped: list[dict[str, Any]] = []
     seen: set[tuple[str, str]] = set()
     for s in signals:
@@ -1057,6 +1265,35 @@ def signals_json_to_orders(
     # raise して fail-closed (silent {} で既保有に重ねて buy しない = P0#7 の設計)。
     open_positions = _fetch_open_positions(client)
 
+    # --- per-system standing cap の分母を一度だけ集計 (P1 fix 2026-07-21) ---
+    # already_held は同一銘柄しか止めない。別銘柄で system の保有数が上限を超えて
+    # 積み上がる (07-13 の 10 + 07-14 の別 10 = 20) のを、ここで held+batch を数えて
+    # 弾く。これが finalize を経ない open_auto_run 経路の最終防波堤。
+    enforce_cap, per_system_cap, total_cap = _resolve_standing_caps()
+    if enforce_cap:
+        try:
+            from common.symbol_map import load_symbol_system_map
+
+            ssm = load_symbol_system_map()
+        except Exception:
+            ssm = {}
+        held_counts = count_held_positions_by_system(
+            client, open_positions=open_positions, symbol_system_map=ssm
+        )
+        logger.info(
+            "standing cap 有効: per_system<=%d total<=%d (現保有 total=%d "
+            "unmapped/delisted=%d per_system=%s)",
+            per_system_cap,
+            total_cap,
+            held_counts.total,
+            held_counts.unmapped,
+            held_counts.per_system,
+        )
+    else:
+        held_counts = HeldPositionCounts({}, 0, 0, 0, 0)
+    batch_by_system: dict[str, int] = {}
+    batch_total = 0
+
     submitted: list[PreparedOrder] = []
     for po in prepared:
         # pre-generation で既に skip 判定済 (min_notional 未満 / 整数株サイズ不能)
@@ -1078,6 +1315,32 @@ def signals_json_to_orders(
             logger.info("skip (既保有 %s): %s qty=%s", po.side, po.symbol, held)
             submitted.append(po)
             continue
+
+        # (0.5) per-system standing cap + portfolio total cap (P1 fix 2026-07-21):
+        #     already_held を通っても、別銘柄で system の保有が max_positions を超える
+        #     新規はここで弾く。実 submit 成功時のみ batch を積むので、skip/失敗は
+        #     cap 予算を消費しない。既存ポジションには一切触れない (新規を止めるだけ)。
+        if enforce_cap:
+            cap_reason = evaluate_standing_cap(
+                system=po.system or "",
+                held_by_system=held_counts.per_system,
+                total_held=held_counts.total,
+                batch_by_system=batch_by_system,
+                batch_total=batch_total,
+                per_system_cap=per_system_cap,
+                total_cap=total_cap,
+            )
+            if cap_reason:
+                po.skip_reason = cap_reason
+                _audit_log({"event": "skip_standing_cap", **po.to_row()})
+                logger.info(
+                    "skip (standing cap): %s %s %s",
+                    po.symbol,
+                    po.system,
+                    cap_reason,
+                )
+                submitted.append(po)
+                continue
 
         # (1) 冪等性: 同一 client_order_id が既に open なら二重 submit しない
         if po.client_order_id and po.client_order_id in open_coids:
@@ -1154,6 +1417,11 @@ def signals_json_to_orders(
             open_sides.setdefault(po.symbol, set()).add(po.side)
             if po.client_order_id:
                 open_coids.add(po.client_order_id)
+            # standing cap: 実 submit 成功分のみ batch に計上 (skip/失敗は消費しない)
+            batch_total += 1
+            _sys_key = (po.system or "").strip().lower()
+            if _sys_key:
+                batch_by_system[_sys_key] = batch_by_system.get(_sys_key, 0) + 1
             submitted.append(po)
         except Exception as exc:  # noqa: BLE001
             po.error = str(exc)
@@ -2052,6 +2320,9 @@ __all__ = [
     "plan_order_execution",
     "get_asset_fractionable",
     "fetch_open_order_state",
+    "HeldPositionCounts",
+    "count_held_positions_by_system",
+    "evaluate_standing_cap",
     "EXEC_NOTIONAL",
     "EXEC_QTY",
     "EXEC_SKIP",

--- a/core/final_allocation.py
+++ b/core/final_allocation.py
@@ -343,6 +343,77 @@ def count_active_positions_by_system(
     return counts
 
 
+def count_positions_with_unmapped(
+    positions: Sequence[object] | None,
+    symbol_system_map: Mapping[str, Any] | None,
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Like :func:`count_active_positions_by_system` but also tallies positions
+    that cannot be attributed to any system (delisted/orphan, e.g. FOLD/CDTX).
+
+    P1 fix (2026-07-21): ``count_active_positions_by_system`` silently *skips*
+    unmapped symbols, so ``held_total`` was undercounted and the portfolio total
+    cap thought there was more room than there really was (audit 🔴P1 root-cause C).
+    Delisted/orphan positions consume real capital and portfolio slots, so they
+    must count toward the total/side held — even though they have no per-system
+    attribution. See docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md §3.3.
+
+    Returns ``(per_system, unmapped)`` where ``unmapped`` is
+    ``{"long": n, "short": m, "total": k}``.
+    """
+    per_system = count_active_positions_by_system(positions, symbol_system_map)
+
+    normalized: SymbolSystemMap = {}
+    if symbol_system_map:
+        for key, value in symbol_system_map.items():
+            try:
+                symbol = str(key).strip().upper()
+            except Exception:
+                continue
+            if not symbol:
+                continue
+            systems = coerce_system_list(value, ensure_all=False)
+            if systems:
+                normalized[symbol] = systems
+
+    unmapped = {"long": 0, "short": 0, "total": 0}
+    for pos in positions or []:
+        try:
+            symbol_raw = _get_position_attr(pos, "symbol")
+            if symbol_raw is None:
+                continue
+            sym = str(symbol_raw).strip().upper()
+            if not sym:
+                continue
+            qty_raw = _get_position_attr(pos, "qty")
+            try:
+                qty_val = float(qty_raw) if qty_raw is not None else 0.0
+            except (TypeError, ValueError):
+                qty_val = 0.0
+            if qty_val == 0.0:
+                continue
+
+            side_raw = _get_position_attr(pos, "side")
+            side = str(side_raw).strip().lower() if side_raw is not None else ""
+
+            primary_system = resolve_primary_system(normalized.get(sym))
+            if not primary_system and sym == "SPY" and side == "short":
+                primary_system = "system7"
+            if primary_system:
+                continue  # attributed → already in per_system
+
+            # unmapped (delisted/orphan): tally toward total/side by qty sign
+            unmapped["total"] += 1
+            if side == "short" or qty_val < 0:
+                unmapped["short"] += 1
+            else:
+                unmapped["long"] += 1
+        except Exception as exc:  # noqa: BLE001 - defensive
+            logger.warning("count_positions_with_unmapped: skip position: %s", exc)
+            continue
+
+    return per_system, unmapped
+
+
 def _normalize_allocations(
     weights: Mapping[str, float] | None,
     defaults: Mapping[str, float],
@@ -1665,14 +1736,21 @@ def _apply_portfolio_caps(
     if final_df is None or getattr(final_df, "empty", True):
         return final_df, report
 
-    active_by_system = count_active_positions_by_system(
+    # P1 fix (2026-07-21): delisted/orphan (system 帰属できない実保有) も held に算入。
+    # 従来 count_active_positions_by_system は unmapped を skip し held_total 過少 →
+    # total cap が余裕を過大評価していた (audit 🔴P1 root-cause C)。
+    active_by_system, unmapped = count_positions_with_unmapped(
         active_positions, symbol_system_map
     )
     long_set = {str(s).strip().lower() for s in long_systems}
     short_set = {str(s).strip().lower() for s in short_systems}
-    held_long = sum(v for k, v in active_by_system.items() if k in long_set)
-    held_short = sum(v for k, v in active_by_system.items() if k in short_set)
-    held_total = sum(active_by_system.values())
+    held_long = sum(v for k, v in active_by_system.items() if k in long_set) + int(
+        unmapped.get("long", 0)
+    )
+    held_short = sum(v for k, v in active_by_system.items() if k in short_set) + int(
+        unmapped.get("short", 0)
+    )
+    held_total = sum(active_by_system.values()) + int(unmapped.get("total", 0))
 
     max_total = int(caps.get("max_total_positions", 70))
     max_long = int(caps.get("max_long_positions", 40))
@@ -1730,6 +1808,7 @@ def _apply_portfolio_caps(
     report = {
         "applied": True,
         "held": {"long": held_long, "short": held_short, "total": held_total},
+        "held_unmapped": dict(unmapped),  # delisted/orphan の内訳 (観測性)
         "caps": {
             "max_total": max_total,
             "max_long": max_long,

--- a/docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md
+++ b/docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md
@@ -1,0 +1,134 @@
+# Position Management P1 — standing-cap enforcement + fail-closed reconcile
+
+**日付**: 2026-07-21
+**対象 branch**: `claude/position-mgmt-p1-20260721` (off `origin/main` = `0eb5765`)
+**前提 docs (先読済, source of truth)**:
+- [`docs/POSITION_MANAGEMENT_AUDIT_20260703.md`](./POSITION_MANAGEMENT_AUDIT_20260703.md) §2 (per-system `max_positions=10`) / §5.2
+- [`docs/POSITION_MANAGEMENT_PHASE5_20260707.md`](./POSITION_MANAGEMENT_PHASE5_20260707.md) §2 (`risk.portfolio.max_total_positions=70` 他 no-op デフォルトの導出)
+- `logs/audit_20260719/AUDIT_REPORT.md` 🔴P1 (ポジ74 の構造的根因)
+
+> **方針**: docs-first / paper 限定 / **ライブ発注しない** / **既存ポジションを勝手に閉じない**。
+> 本 doc は「既に確定している per-system `max_positions=10` と portfolio
+> `max_total_positions=70` を、これまで **enforcement 境界に無かった発注直前**でも
+> 効かせる」ための実装記録。**新しいリスク値は導入しない** — 既存 spec の実効化のみ。
+
+---
+
+## 1. 根因 (2026-07-19 監査で確定) と本 fix の対応
+
+ポジションが 74 まで積み上がった構造的根因は 3 つの複合:
+
+| # | 根因 | 本 fix |
+|---|---|---|
+| A | **reconcile が fail-open**。`_resolve_positions_for_allocation` は live position fetch 失敗時に silent に `None`/`[]` へ縮退し、`available_slots` が per-run cap only に落ちる (held 未反映)。しかも `_fetch_positions_and_symbol_map` は fetch 例外を内部で握り潰して `[]`(=flat 口座に見える) を返す **二重 silent-fail**。 | **Fix 1**: fail-closed 化 (§3.1) |
+| B | **submit 境界に count cap が無い**。`signals_json_to_orders` は per-symbol `already_held` のみで、**別銘柄で同一 system が上限を超えて積み上がる**のを止めない。07-13 の 10 銘柄 + 07-14 の別 10 銘柄が両方通り system 別 20 に。`finalize_allocation` の per-system slot cap は **open_auto_run 経路 (JSON→paper_trading_submit) を通らない**ので効かない。 | **Fix 2**: submit 境界に per-system standing cap + portfolio total cap (§3.2) |
+| C | **delisted/orphan が held に未算入**。FOLD/CDTX 等 API で close 不能な legacy orphan は `symbol_system_map` 非帰属で `count_active_positions_by_system` から skip され、`held_total` 過少 → total cap が「まだ余裕がある」と誤認。 | **Fix 3**: delisted/orphan を total/side held に算入 (§3.3) |
+
+exit 失火 (code 40310000, cancel-before-close) は別 issue (PR #144 系) で本 fix の対象外。
+本 fix は **これ以上積み増さない**歯止め (entry 側) であり、既存 74 を**閉じるものではない** (§5)。
+
+---
+
+## 2. cap 値の出所 (docs 根拠 / 新値でないことの明示)
+
+| cap | 値 | docs 根拠 | per-run TOP_N=10 との違い |
+|---|---:|---|---|
+| **per-system standing cap** | **10** | `RiskConfig.max_positions=10` (config.yaml `risk.max_positions`)。docs/systems: S1/S2 は「最大10」明記、S3-S6 は global 既定 10。AUDIT_20260703 §2 row1。 | **TOP_N=10 は「1 run で system あたり何件の候補を生成するか」**。standing cap=10 は **「口座に同時に何件保有し続けるか」**。前者は毎 run リセット、後者は日を跨いで累積する残高。07-13 に 10 生成→fill、07-14 に別 10 生成→fill で **保有 20** になったのは、TOP_N は守れていても standing cap が enforcement されていなかったから。 |
+| **portfolio total standing cap** | **70** | `risk.portfolio.max_total_positions=70` (PHASE5 §2.1、= long 4 + short 3 system × 10 の implicit 上限の明示化)。 | 同上。全 system 合算の同時保有上限。 |
+
+いずれも **既存の確定値**。本 fix はデフォルトで新たに締め付けず、**docs 通りの上限を発注直前でも守らせる**だけ。運用でより厳しくしたい場合は config / env で下げられる (§4)。
+
+---
+
+## 3. 実装
+
+### 3.1 Fix 1 — reconcile fail-closed (`scripts/run_all_systems_today.py`)
+
+- 新例外 `PositionReconcileError(RuntimeError)`。
+- `_fetch_positions_and_symbol_map`: **position fetch 例外を握り潰して `[]` を返すのをやめ**、`PositionReconcileError` を raise (「flat 口座」と「取得失敗」を区別)。`symbol_system_map` の読み込み失敗は従来通り寛容 (`{}`)。
+- `_resolve_positions_for_allocation`:
+  - env `ALLOCATION_RECONCILE_POSITIONS` off → `None` (従来の fail-open。意図的無効化)。
+  - creds 無し → `None` (test/CI/backtest 保護。口座に触れない)。
+  - **fetch 失敗** → env `ALLOCATION_RECONCILE_FAILCLOSED` (既定 `1`=有効) が truthy なら **`PositionReconcileError` を raise (fail-closed)**。opt-out (`0`) で従来の WARN+`None` (fail-open) に戻せる。
+- 呼び出し側 (allocation 段): `PositionReconcileError` を捕捉し、**その run は新規エントリを一切生成しない** (`final_df` 空 + `AllocationSummary(mode="reconcile_failed")`)。**既存ポジションには一切触れない** (read の失敗なので当然)。distinct log で silent 縮退でないことを可視化。
+
+> 思想は F2 audit fix (exit の broker 到達不能 → silent exit0 でなく distinct exit3+WARN) と同一。
+> 「現保有を確認できないなら新規は開かない」= 保守的 fail-closed。
+
+### 3.2 Fix 2 — submit 境界の standing cap (`common/alpaca_trading.py`)
+
+`signals_json_to_orders` の **実発注ループ (非 dry_run)** に、`already_held` の直後 (step 0.5) として追加:
+
+- ループ前に一度だけ現保有を集計: `count_held_positions_by_system(client, open_positions, symbol_system_map)`
+  - 帰属優先順位 = **entry order の client_order_id (`system{N}-…` prefix) → `symbol_system_map` フォールバック** (exit 経路 `_hydrate_from_alpaca_coids` と同じ信頼できる帰属源。static な `symbol_system_map.json` 単独より正確)。
+  - 帰属できた held → `per_system[sys]++`。帰属できない held (delisted/orphan) → `unmapped++`。
+  - `total` は nonzero 保有すべて (unmapped 含む)。`long_total`/`short_total` は qty 符号で。
+- 各新規注文について pure 判定 `evaluate_standing_cap(...)`:
+  - `total_held + batch_total >= total_cap` → skip `standing_cap:portfolio_total_…`。
+  - `held_by_system[sys] + batch_by_system[sys] >= per_system_cap` → skip `standing_cap:{sys}_…`。
+  - **batch カウンタは実 submit 成功時のみ increment** (skip/失敗は cap 予算を消費しない)。
+- skip は **silent drop せず** `skip_reason` 付き `PreparedOrder` として結果に残し、`_audit_log({"event":"skip_standing_cap"})` + `logger.info`。caller サマリ (paper_trading_submit) の skip 内訳に必ず出る (観測性、既存の skip 作法と一致)。
+- `already_held` (同一銘柄) は温存。standing cap は **別銘柄での system 積み増し**を止める直交ガード。
+- この境界は **open_auto_run (JSON→paper_trading_submit→signals_json_to_orders) と daily_pipeline の両方が通る**唯一の発注直前点。ゆえに finalize を経ない経路の**最終防波堤**になる。
+
+旧コメント「件数 cap / max_positions は上流 (final_allocation) で既に効いているので、ここでは per-name/gross/net の dollar cap のみ」= **P1 で否定された前提**。→ コメント是正 + 実効化。
+
+### 3.3 Fix 3 — delisted/orphan を held に算入 (`core/final_allocation.py`)
+
+- 新 helper `count_positions_with_unmapped(positions, symbol_system_map)` → `(per_system, unmapped)`。`unmapped = {"long":n, "short":m, "total":k}` (system 帰属できない nonzero 保有を side 別に集計)。
+- `_apply_portfolio_caps`: `held_total`/`held_long`/`held_short` に unmapped を**加算**。→ delisted が居ても total/side cap が過少にならない (allocation 経路 = daily_pipeline の finalize)。
+- submit 境界 (§3.2) の `total` も unmapped を含む (実 Alpaca 保有をそのまま数えるため自然に算入)。
+
+**設計判断 (docs 根拠)**: delisted/orphan は **total/side cap には算入**し、**per-system cap には算入しない**。
+- *算入する側*: 実在する保有として real capital / exposure / 建玉スロットを消費している。AUDIT_REPORT が指摘した「held_total 過少」の直接是正。「70 の dead 建玉があるのに更に 70 積む」を許さない = 正しいリスク管理。
+- *per-system に入れない側*: system 帰属が無い (それが delisted たる所以)。無理に特定 system へ寄せると別 system の枠を誤って潰す。
+- *副作用の可視化*: delisted が total cap を圧迫して新規が絞られ得るが、その skip は理由付きで surface される (silent でない)。delisted の恒久解消は別 human task (清算待ち)。
+
+---
+
+## 4. config / env (すべて既定は docs 通り = 挙動を勝手に締めない)
+
+| key | 既定 | 効果 |
+|---|---|---|
+| `SUBMIT_ENFORCE_STANDING_CAP` (env) | `1` (有効) | submit 境界 standing cap の on/off。`0` で従来挙動。 |
+| `SUBMIT_MAX_POSITIONS_PER_SYSTEM` (env) | `risk.max_positions`=10 | per-system cap の上書き。 |
+| `SUBMIT_MAX_TOTAL_POSITIONS` (env) | `risk.portfolio.max_total_positions`=70 | total cap の上書き。 |
+| `ALLOCATION_RECONCILE_FAILCLOSED` (env) | `1` (fail-closed) | reconcile fetch 失敗時に raise するか。`0` で従来の fail-open。 |
+
+新しい config キーは追加しない (既存 `risk.max_positions` / `risk.portfolio.max_total_positions` を読むだけ)。
+
+---
+
+## 5. 変更前後で「何がどう変わるか」
+
+### 現在の 74 建玉はどうなるか
+- **何も閉じない**。本 fix は entry 側の歯止めのみ。74 はそのまま (既存ポジションに触れないのは厳守事項)。
+- 74 の縮小は **exit の正常発火** (cancel-before-close, PR #144 系) と **時間経過での time-exit** に委ねる。本 fix は「exit が減らした分を翌日また積み増して 74 に戻す」ループを止める。
+
+### 次回以降の run
+- **daily_pipeline (finalize 経路)**: reconcile が fetch 成功すれば held が available_slots に反映 (従来通り)。fetch 失敗時は **fail-closed で新規0** (従来は per-run cap で新規を出していた)。
+- **open_auto_run (submit 境界経路)**: 各 system の保有が 10 に達していれば、その system の新規は **standing_cap で skip** (従来は別銘柄なら通って 20 まで積んだ)。total 70 (delisted 含む) 到達時も新規 skip。
+- **通常運用への影響**: exit が正常に効いて各 system の保有 < 10 の日は、これまで通り不足分だけ新規で埋まる (cap は「上限まで」。減った枠は普通に補充される)。**シグナルは潤沢が正常、絞るのは entry のみ**という運用方針と一致。
+
+### 月曜 22:35 runner (`QuantTrading_OpenAutoRun`, `C:\tmp\qts-main-run` = `claude/open-auto-run`) への影響
+- runner は working-tree を読む。**本 fix は origin/main 宛の PR まで**で、runner tree には**まだ入らない**。
+- runner に効かせるには `common/alpaca_trading.py` の変更を runner tree に反映する必要がある (= **arm は別判断**)。本 fix は **arm しない** — main マージ可否と合わせて指示を仰ぐ。
+
+---
+
+## 6. 変更 files
+
+- `scripts/run_all_systems_today.py` — `PositionReconcileError` + fail-closed reconcile + 呼び出し側ガード。
+- `common/alpaca_trading.py` — `HeldPositionCounts` / `count_held_positions_by_system` / `evaluate_standing_cap` / `_resolve_standing_caps` + `signals_json_to_orders` への配線 + 旧コメント是正。
+- `core/final_allocation.py` — `count_positions_with_unmapped` + `_apply_portfolio_caps` の delisted 算入。
+- `tests/test_position_standing_cap_20260721.py` — **新規** (fail-closed / per-system cap / total cap / delisted 算入 / pure decision)。
+- `tests/test_allocation_position_reconcile_20260707.py` — fetch 失敗 test を fail-open→**fail-closed** に更新 (意図した挙動変更) + opt-out test 追加。
+- `docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md` — 本 doc。
+
+## 7. rollback
+
+```powershell
+git revert <commit>   # または env で無効化 (挙動を即座に従来へ)
+$env:SUBMIT_ENFORCE_STANDING_CAP = "0"
+$env:ALLOCATION_RECONCILE_FAILCLOSED = "0"
+```

--- a/scripts/run_all_systems_today.py
+++ b/scripts/run_all_systems_today.py
@@ -2068,14 +2068,30 @@ def _subset_data(
     return out
 
 
+class PositionReconcileError(RuntimeError):
+    """現保有ポジションの取得に失敗したことを表す (fail-closed 用, P1 fix 2026-07-21)。
+
+    「口座が flat ([])」と「取得に失敗した」を区別できるようにするための例外。
+    従来は _fetch_positions_and_symbol_map が fetch 例外を握り潰して [] を返し、
+    呼び出し側が flat と誤認して per-run cap only で新規を出していた (silent 縮退)。
+    """
+
+
 def _fetch_positions_and_symbol_map() -> tuple[list[Any], dict[str, str]]:
-    """Fetch Alpaca positions and cached symbol-to-system mapping once."""
+    """Fetch Alpaca positions and cached symbol-to-system mapping once.
+
+    P1 fix (2026-07-21): position fetch の失敗は **握り潰さず raise** する。
+    silent [] は「flat 口座」と区別できず、held 未反映で新規を積み増す原因だった。
+    symbol_system_map の読み込み失敗は従来通り寛容 (``{}``)。
+    """
 
     try:
         client = ba.get_client(paper=True)
         positions = list(client.get_all_positions())
-    except Exception:
-        positions = []
+    except Exception as exc:  # noqa: BLE001
+        raise PositionReconcileError(
+            f"Alpaca 現保有ポジション取得に失敗: {exc}"
+        ) from exc
 
     try:
         symbol_system_map = load_symbol_system_map()
@@ -2094,12 +2110,17 @@ def _resolve_positions_for_allocation() -> tuple[list[Any] | None, Any | None]:
     従来は active_positions=None で突合が実質無効だった (fable5 audit item7/8) のを
     ここで配線し、finalize_allocation(positions=...) に渡して available_slots に反映する。
 
-    安全策 (fail-open = 従来挙動へ縮退):
+    fetch を試みない安全策 (fail-open = 従来挙動へ縮退。口座に触れない環境の保護):
     - env ``ALLOCATION_RECONCILE_POSITIONS`` が偽値 (0/false/no/off) なら突合無効。
     - APCA creds 未設定なら Alpaca に触れず None (test/CI/backtest 保護)。
-    - fetch 失敗時も None にフォールバック。allocation 段は best-effort で良い
-      (submit 段 signals_json_to_orders / signals_to_orders の held-check が
-       duplicate exposure の hard guard)。
+
+    P1 fix (2026-07-21) — **fetch 失敗は fail-CLOSED**:
+    - creds があり fetch を試みて失敗した場合、silent に None へ縮退すると held が
+      available_slots に反映されず per-run cap only になり、日跨ぎで積み増す原因になる
+      (audit 🔴P1 root-cause A)。既定 (``ALLOCATION_RECONCILE_FAILCLOSED`` truthy) では
+      ``PositionReconcileError`` を raise し、呼び出し側が「この run は新規を出さない」
+      判断をする (既存ポジションには触れない)。
+    - opt-out (``ALLOCATION_RECONCILE_FAILCLOSED=0``) で従来の WARN+None (fail-open)。
     """
     try:
         symbol_system_map: Any = load_symbol_system_map()
@@ -2114,10 +2135,23 @@ def _resolve_positions_for_allocation() -> tuple[list[Any] | None, Any | None]:
         # creds 無し = 口座に触れない環境。従来通り突合しない。
         return None, symbol_system_map
 
+    fail_closed = os.environ.get(
+        "ALLOCATION_RECONCILE_FAILCLOSED", "1"
+    ).strip().lower() not in ("0", "false", "no", "off")
     try:
         positions, fetched_map = _fetch_positions_and_symbol_map()
     except Exception as exc:  # noqa: BLE001
-        _log(f"⚠️ 現保有ポジション取得に失敗、突合なしで継続: {exc}", level="WARNING")
+        if fail_closed:
+            _log(
+                "🔒 現保有ポジション取得に失敗 → fail-closed。"
+                f"本 run は新規エントリを生成しません: {exc}",
+                level="ERROR",
+            )
+            raise PositionReconcileError(str(exc)) from exc
+        _log(
+            f"⚠️ 現保有ポジション取得に失敗、突合なしで継続 (fail-open opt-out): {exc}",
+            level="WARNING",
+        )
         return None, symbol_system_map
 
     if not symbol_system_map and fetched_map:
@@ -5477,6 +5511,27 @@ def compute_today_signals(  # noqa: C901  # type: ignore[reportGeneralTypeIssues
             market_data_dict=ctx.basic_data,
             signal_date=ctx.today,
             include_trade_management=True,
+        )
+    except PositionReconcileError as e:
+        # P1 fail-closed: 現保有を確認できないので新規は一切出さない。
+        # 既存ポジションには触れない (read 失敗であって write ではない)。
+        _log(
+            "🔒 現保有ポジション未確認 (fail-closed) → 本 run は新規エントリ 0 件。"
+            f" 既存ポジションは不変: {e}",
+            level="ERROR",
+        )
+        final_df = pd.DataFrame()
+        from core.final_allocation import (
+            AllocationSummary as _AS,  # local import to avoid cycle
+        )
+
+        allocation_summary = _AS(
+            mode="reconcile_failed",
+            long_allocations={},
+            short_allocations={},
+            active_positions={},
+            available_slots={},
+            final_counts={},
         )
     except Exception as e:
         _log(f"❌ finalize_allocation 失敗: {e}")

--- a/tests/test_allocation_position_reconcile_20260707.py
+++ b/tests/test_allocation_position_reconcile_20260707.py
@@ -55,17 +55,42 @@ def test_reconcile_fetches_when_enabled(monkeypatch):
     assert positions == fake_positions
 
 
-def test_reconcile_fetch_failure_falls_back_to_none(monkeypatch):
+def test_reconcile_fetch_failure_is_fail_closed(monkeypatch):
+    """P1 fix (2026-07-21): fetch 失敗は既定で **fail-closed** (raise)。
+
+    従来は None へ silent フォールバック (fail-open) で、held が available_slots に
+    反映されず per-run cap only で新規を積み増していた (audit 🔴P1 root-cause A)。
+    """
+    import pytest
+
     monkeypatch.setenv("ALLOCATION_RECONCILE_POSITIONS", "1")
     monkeypatch.setenv("APCA_API_KEY_ID", "k")
     monkeypatch.setenv("APCA_API_SECRET_KEY", "s")
+    monkeypatch.delenv(
+        "ALLOCATION_RECONCILE_FAILCLOSED", raising=False
+    )  # 既定=fail-closed
+
+    def _boom():
+        raise RuntimeError("alpaca down")
+
+    monkeypatch.setattr(rast, "_fetch_positions_and_symbol_map", _boom)
+    with pytest.raises(rast.PositionReconcileError):
+        rast._resolve_positions_for_allocation()
+
+
+def test_reconcile_fetch_failure_failopen_optout(monkeypatch):
+    """opt-out (ALLOCATION_RECONCILE_FAILCLOSED=0) で従来の fail-open (None) に戻せる。"""
+    monkeypatch.setenv("ALLOCATION_RECONCILE_POSITIONS", "1")
+    monkeypatch.setenv("APCA_API_KEY_ID", "k")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "s")
+    monkeypatch.setenv("ALLOCATION_RECONCILE_FAILCLOSED", "0")
 
     def _boom():
         raise RuntimeError("alpaca down")
 
     monkeypatch.setattr(rast, "_fetch_positions_and_symbol_map", _boom)
     positions, _ = rast._resolve_positions_for_allocation()
-    assert positions is None  # fetch 失敗は None にフォールバック (fail-open)
+    assert positions is None  # opt-out: fetch 失敗は None にフォールバック
 
 
 def test_held_positions_reduce_available_slots():

--- a/tests/test_position_standing_cap_20260721.py
+++ b/tests/test_position_standing_cap_20260721.py
@@ -1,0 +1,449 @@
+"""P1 fix (2026-07-21): position-management standing-cap の回帰テスト。
+
+対象 (docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md):
+  Fix 1 — reconcile fail-closed: 現保有 fetch 失敗を silent None 縮退でなく raise。
+  Fix 2 — submit 境界 per-system standing cap: system の保有が上限のとき新規を弾く。
+           (already_held は同一銘柄しか止めない → 別銘柄での積み増しを止める最終防波堤)
+  Fix 3 — delisted/orphan を held に算入: 帰属できない実保有を total/side に数える。
+
+既存の silent-fail 監視テスト (test_alpaca_positions_fetch_error_raises,
+test_paper_order_execution_fallback) と同じ作法: fake client + skip_reason 検証で
+「silent drop しない」ことを固定する。paper 限定・実発注なし (dry_run/fake client)。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from common.alpaca_trading import (  # noqa: E402
+    count_held_positions_by_system,
+    evaluate_standing_cap,
+    signals_json_to_orders,
+)
+import common.broker_alpaca as ba  # noqa: E402
+from core.final_allocation import (  # noqa: E402
+    _apply_portfolio_caps,
+    count_positions_with_unmapped,
+)
+
+
+# =========================================================================
+# fake Alpaca client (self-contained)
+# =========================================================================
+class _Asset:
+    def __init__(self, frac: bool) -> None:
+        self.fractionable = frac
+
+
+class _Order:
+    def __init__(self, oid="oid", status="accepted", symbol=None, side=None, coid=None):
+        self.id = oid
+        self.status = status
+        self.symbol = symbol
+        self.side = side
+        self.client_order_id = coid
+
+
+class _Pos:
+    def __init__(self, symbol, qty, side=None):
+        self.symbol = symbol
+        self.qty = qty
+        self.side = side or ("long" if float(qty) >= 0 else "short")
+
+
+class _Client:
+    """held-position / order / asset を注入できる最小 fake。"""
+
+    def __init__(self, *, positions=None, all_orders=None, frac=None):
+        self._positions = positions or []
+        self._orders = all_orders or []
+        self._frac = frac or {}
+        self.notional_submits: list = []
+
+    def get_all_positions(self):
+        return list(self._positions)
+
+    def get_orders(self, filter=None):  # noqa: A002 (mirror alpaca kw)
+        return list(self._orders)
+
+    def get_asset(self, sym):
+        return _Asset(self._frac.get(sym, True))
+
+    def submit_order(self, order_data=None):
+        self.notional_submits.append(order_data)
+        return _Order(oid=f"nid-{getattr(order_data, 'symbol', '?')}")
+
+
+@pytest.fixture
+def paper_env(monkeypatch):
+    monkeypatch.setenv("ALPACA_PAPER", "true")
+    monkeypatch.setenv("ALPACA_API_BASE_URL", "https://paper-api.alpaca.markets")
+    # 既定を明示 (他テストの env 汚染から隔離)
+    monkeypatch.delenv("SUBMIT_ENFORCE_STANDING_CAP", raising=False)
+    monkeypatch.delenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", raising=False)
+    monkeypatch.delenv("SUBMIT_MAX_TOTAL_POSITIONS", raising=False)
+    # standing-cap の held 集計を coid 経由に固定するため map は空にする
+    monkeypatch.setattr("common.symbol_map.load_symbol_system_map", lambda *a, **k: {})
+
+
+def _json(signals: list[dict], date="2026-07-02") -> dict:
+    """sys{N} JSON を組み立てる (_flatten_json_signals が system{N} に正規化)。"""
+    systems: dict = {}
+    for s in signals:
+        key = s["system"].replace("system", "sys")
+        systems.setdefault(key, {"signals": []})["signals"].append(
+            {
+                "symbol": s["symbol"],
+                "side": s["side"],
+                "entry_price": s.get("entry_price", 100.0),
+                "weight": s.get("weight", 1.0),
+            }
+        )
+    return {"date": date, "systems": systems}
+
+
+# =========================================================================
+# A. evaluate_standing_cap — pure decision
+# =========================================================================
+def test_eval_under_caps_returns_none():
+    assert (
+        evaluate_standing_cap(
+            system="system1",
+            held_by_system={"system1": 3},
+            total_held=3,
+            batch_by_system={"system1": 2},
+            batch_total=2,
+            per_system_cap=10,
+            total_cap=70,
+        )
+        is None
+    )
+
+
+def test_eval_per_system_cap_blocks_when_held_plus_batch_reaches_cap():
+    # held 8 + batch 2 = 10 >= cap 10 → 弾く
+    reason = evaluate_standing_cap(
+        system="system2",
+        held_by_system={"system2": 8},
+        total_held=8,
+        batch_by_system={"system2": 2},
+        batch_total=2,
+        per_system_cap=10,
+        total_cap=70,
+    )
+    assert reason and reason.startswith("standing_cap:system2_held=8+batch=2")
+
+
+def test_eval_total_cap_takes_precedence():
+    reason = evaluate_standing_cap(
+        system="system1",
+        held_by_system={"system1": 0},
+        total_held=70,
+        batch_by_system={},
+        batch_total=0,
+        per_system_cap=10,
+        total_cap=70,
+    )
+    assert reason and "portfolio_total_held=70" in reason
+
+
+def test_eval_cap_zero_disables_that_dimension():
+    # per_system_cap=0 → per-system 判定なし。total_cap=0 → total 判定なし。
+    assert (
+        evaluate_standing_cap(
+            system="system1",
+            held_by_system={"system1": 99},
+            total_held=99,
+            batch_by_system={},
+            batch_total=0,
+            per_system_cap=0,
+            total_cap=0,
+        )
+        is None
+    )
+
+
+# =========================================================================
+# B. count_held_positions_by_system — 帰属 + delisted
+# =========================================================================
+def test_count_held_attributes_via_coid():
+    client = _Client(
+        positions=[_Pos("AAA", 10), _Pos("BBB", -3)],
+        all_orders=[
+            _Order(symbol="AAA", coid="system1-AAA-20260713"),
+            _Order(symbol="BBB", coid="system2-BBB-20260713"),
+        ],
+    )
+    held = count_held_positions_by_system(
+        client, open_positions={"AAA": 10.0, "BBB": -3.0}, symbol_system_map={}
+    )
+    assert held.per_system == {"system1": 1, "system2": 1}
+    assert held.total == 2
+    assert held.long_total == 1 and held.short_total == 1
+    assert held.unmapped == 0
+
+
+def test_count_held_falls_back_to_symbol_system_map():
+    # coid が取れない (orders 空) → symbol_system_map で帰属
+    client = _Client(positions=[_Pos("CCC", 5)], all_orders=[])
+    held = count_held_positions_by_system(
+        client, open_positions={"CCC": 5.0}, symbol_system_map={"CCC": "system3"}
+    )
+    assert held.per_system == {"system3": 1}
+    assert held.unmapped == 0
+
+
+def test_count_held_delisted_orphan_is_unmapped_but_counts_total():
+    # FOLD/CDTX 相当: coid も map も無い → unmapped だが total/side には算入 (Fix 3)
+    client = _Client(positions=[_Pos("FOLD", 7), _Pos("CDTX", -2)], all_orders=[])
+    held = count_held_positions_by_system(
+        client,
+        open_positions={"FOLD": 7.0, "CDTX": -2.0},
+        symbol_system_map={},
+    )
+    assert held.per_system == {}
+    assert held.unmapped == 2
+    assert held.total == 2
+    assert held.long_total == 1 and held.short_total == 1
+
+
+def test_count_held_spy_short_attributes_to_system7():
+    client = _Client(positions=[_Pos("SPY", -4)], all_orders=[])
+    held = count_held_positions_by_system(
+        client, open_positions={"SPY": -4.0}, symbol_system_map={}
+    )
+    assert held.per_system == {"system7": 1}
+    assert held.unmapped == 0
+
+
+# =========================================================================
+# C. signals_json_to_orders — submit 境界の standing cap (end-to-end, fake client)
+# =========================================================================
+def test_per_system_cap_blocks_cross_day_accumulation(monkeypatch, paper_env):
+    """system1 を既に 2 保有 (別銘柄) → cap=2 で新規 system1 は全 skip。
+
+    これが 07-13 の 10 + 07-14 の別 10 = 20 を防ぐ核心 (already_held は別銘柄を
+    止められない)。既存ポジションには一切触れない (新規を弾くだけ)。
+    """
+    monkeypatch.setenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", "2")
+    client = _Client(
+        positions=[_Pos("HELD0", 10), _Pos("HELD1", 10)],  # 既存 system1 保有 2
+        all_orders=[
+            _Order(symbol="HELD0", coid="system1-HELD0-20260713"),
+            _Order(symbol="HELD1", coid="system1-HELD1-20260713"),
+        ],
+        frac={"NEWA": True, "NEWB": True},
+    )
+    orders = signals_json_to_orders(
+        _json(
+            [
+                {"symbol": "NEWA", "side": "buy", "system": "system1"},
+                {"symbol": "NEWB", "side": "buy", "system": "system1"},
+            ]
+        ),
+        tier="small",
+        dry_run=False,
+        client=client,
+        sizing_mode="fixed_tier",
+    )
+    assert len(orders) == 2
+    for o in orders:
+        assert o.order_id is None, f"{o.symbol} は発注されてはいけない"
+        assert o.skip_reason and o.skip_reason.startswith("standing_cap:system1")
+    assert client.notional_submits == []  # 実 submit 0
+
+
+def test_batch_cap_within_single_call(monkeypatch, paper_env):
+    """保有 0 でも 1 回の call 内で cap を超える分は弾く (batch カウント)。"""
+    monkeypatch.setenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", "2")
+    client = _Client(
+        positions=[],
+        all_orders=[],
+        frac={s: True for s in ("A0", "A1", "A2", "A3")},
+    )
+    orders = signals_json_to_orders(
+        _json(
+            [
+                {"symbol": "A0", "side": "buy", "system": "system1"},
+                {"symbol": "A1", "side": "buy", "system": "system1"},
+                {"symbol": "A2", "side": "buy", "system": "system1"},
+                {"symbol": "A3", "side": "buy", "system": "system1"},
+            ]
+        ),
+        tier="small",
+        dry_run=False,
+        client=client,
+        sizing_mode="fixed_tier",
+    )
+    submitted = [o for o in orders if o.order_id]
+    skipped = [o for o in orders if o.skip_reason and "standing_cap" in o.skip_reason]
+    assert len(submitted) == 2  # 先着 2 のみ
+    assert len(skipped) == 2  # 残りは理由付き skip (silent drop でない)
+
+
+def test_total_cap_blocks_across_systems(monkeypatch, paper_env):
+    """portfolio total cap は system 横断で効く (delisted 含む total 基準)。"""
+    monkeypatch.setenv("SUBMIT_MAX_TOTAL_POSITIONS", "1")
+    monkeypatch.setenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", "10")
+    client = _Client(
+        positions=[], all_orders=[], frac={s: True for s in ("X0", "Y0", "Z0")}
+    )
+    orders = signals_json_to_orders(
+        _json(
+            [
+                {"symbol": "X0", "side": "buy", "system": "system1"},
+                {"symbol": "Y0", "side": "buy", "system": "system3"},
+                {"symbol": "Z0", "side": "buy", "system": "system4"},
+            ]
+        ),
+        tier="small",
+        dry_run=False,
+        client=client,
+        sizing_mode="fixed_tier",
+    )
+    submitted = [o for o in orders if o.order_id]
+    blocked = [
+        o for o in orders if o.skip_reason and "portfolio_total" in o.skip_reason
+    ]
+    assert len(submitted) == 1
+    assert len(blocked) == 2
+
+
+def test_delisted_orphans_consume_total_cap(monkeypatch, paper_env):
+    """delisted 保有 (帰属不能) が total を圧迫し新規を弾く = Fix 3 が submit 境界で効く。"""
+    monkeypatch.setenv("SUBMIT_MAX_TOTAL_POSITIONS", "2")
+    monkeypatch.setenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", "10")
+    client = _Client(
+        positions=[_Pos("FOLD", 7), _Pos("CDTX", -2)],  # 帰属不能 orphan 2
+        all_orders=[],
+        frac={"NEWX": True},
+    )
+    orders = signals_json_to_orders(
+        _json([{"symbol": "NEWX", "side": "buy", "system": "system1"}]),
+        tier="small",
+        dry_run=False,
+        client=client,
+        sizing_mode="fixed_tier",
+    )
+    assert len(orders) == 1
+    assert orders[0].order_id is None
+    assert "portfolio_total" in orders[0].skip_reason  # total=2 (delisted) >= cap 2
+
+
+def test_enforce_flag_off_disables_cap(monkeypatch, paper_env):
+    """SUBMIT_ENFORCE_STANDING_CAP=0 で従来挙動 (cap 無し)。"""
+    monkeypatch.setenv("SUBMIT_ENFORCE_STANDING_CAP", "0")
+    monkeypatch.setenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", "1")
+    client = _Client(
+        positions=[], all_orders=[], frac={s: True for s in ("B0", "B1", "B2")}
+    )
+    orders = signals_json_to_orders(
+        _json(
+            [
+                {"symbol": "B0", "side": "buy", "system": "system1"},
+                {"symbol": "B1", "side": "buy", "system": "system1"},
+                {"symbol": "B2", "side": "buy", "system": "system1"},
+            ]
+        ),
+        tier="small",
+        dry_run=False,
+        client=client,
+        sizing_mode="fixed_tier",
+    )
+    # cap 無効 → standing_cap での skip は 0
+    assert not any("standing_cap" in (o.skip_reason or "") for o in orders)
+
+
+def test_no_silent_drop_capped_orders_have_skip_reason(monkeypatch, paper_env):
+    """cap で弾いた注文も terminal state (skip_reason) を必ず持つ。"""
+    monkeypatch.setenv("SUBMIT_MAX_POSITIONS_PER_SYSTEM", "1")
+    client = _Client(positions=[], all_orders=[], frac={"C0": True, "C1": True})
+    orders = signals_json_to_orders(
+        _json(
+            [
+                {"symbol": "C0", "side": "buy", "system": "system1"},
+                {"symbol": "C1", "side": "buy", "system": "system1"},
+            ]
+        ),
+        tier="small",
+        dry_run=False,
+        client=client,
+        sizing_mode="fixed_tier",
+    )
+    for o in orders:
+        assert bool(o.order_id) or bool(o.error) or bool(o.skip_reason)
+
+
+# =========================================================================
+# D. count_positions_with_unmapped + _apply_portfolio_caps の delisted 算入 (Fix 3)
+# =========================================================================
+def test_count_positions_with_unmapped_tally():
+    positions = [
+        _Pos("AAA", 10, "long"),  # mapped system1
+        _Pos("FOLD", 5, "long"),  # delisted long
+        _Pos("CDTX", -3, "short"),  # delisted short
+    ]
+    sym_map = {"AAA": "system1"}
+    per_system, unmapped = count_positions_with_unmapped(positions, sym_map)
+    assert per_system.get("system1") == 1
+    assert unmapped == {"long": 1, "short": 1, "total": 2}
+
+
+def test_apply_portfolio_caps_counts_delisted_in_total():
+    """delisted 2 (long) + max_total 5 → 新規は 3 までしか通らない (従来は 5 通していた)。"""
+    import pandas as pd
+
+    caps = {
+        "max_total_positions": 5,
+        "max_long_positions": 40,
+        "max_short_positions": 30,
+        "max_gross_exposure_pct": 1.0,
+        "max_net_exposure_pct": 1.0,
+    }
+    positions = [_Pos("FOLD", 5, "long"), _Pos("XDEAD", 4, "long")]  # 帰属不能 2
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": f"N{i}",
+                "system": "system1",
+                "side": "long",
+                "position_value": 100.0,
+            }
+            for i in range(5)
+        ]
+    )
+    out, report = _apply_portfolio_caps(
+        df,
+        caps=caps,
+        active_positions=positions,
+        symbol_system_map={},  # 帰属できない → unmapped
+        long_systems=["system1"],
+        short_systems=["system2"],
+        equity=100000.0,
+    )
+    assert report["held"]["total"] == 2  # delisted 2 が held に算入された
+    assert report["held_unmapped"] == {"long": 2, "short": 0, "total": 2}
+    assert len(out) == 3  # allow_total = 5 - 2 = 3
+
+
+# =========================================================================
+# E. reconcile fail-closed 補完 (fetch primitive が raise すること)
+# =========================================================================
+def test_fetch_positions_and_symbol_map_raises_on_client_failure(monkeypatch):
+    """P1 Fix 1: position fetch 失敗を silent [] でなく PositionReconcileError に。"""
+    import scripts.run_all_systems_today as rast
+
+    class _BadClient:
+        def get_all_positions(self):
+            raise RuntimeError("alpaca unreachable")
+
+    monkeypatch.setattr(ba, "get_client", lambda *a, **k: _BadClient())
+    with pytest.raises(rast.PositionReconcileError):
+        rast._fetch_positions_and_symbol_map()


### PR DESCRIPTION
## 何を直したか (audit 🔴P1: ポジ74 の構造的根因)

ポジションが 74 まで積み上がった 3 つの複合根因を、**既存 spec の実効化**として修正。
新しいリスク値は導入せず、既に確定している per-system `max_positions=10` と portfolio
`max_total_positions=70` を **これまで enforcement 境界に無かった発注直前でも守らせる**。

**paper 限定 / ライブ発注しない / 既存ポジションを勝手に閉じない**。

| Fix | 根因 | 対応 |
|---|---|---|
| **1. reconcile fail-closed** | live position fetch 失敗を silent `None`/`[]` に縮退 (しかも `_fetch_positions_and_symbol_map` が例外を握り潰し `[]`=flat に見せる二重 silent-fail) → held 未反映で per-run cap only | fetch 失敗を `PositionReconcileError` で raise。呼び出し側は **その run の新規を 0 件** に (既存ポジションは不変)。`ALLOCATION_RECONCILE_FAILCLOSED=0` で opt-out |
| **2. submit 境界 standing cap** | `signals_json_to_orders` は per-symbol `already_held` のみ。**別銘柄で同一 system が上限超過**しても止まらない (07-13 の10 + 07-14 の別10 = 20)。finalize の cap は open_auto_run 経路を通らない | 実発注ループに per-system(=10) + total(=70) cap を追加。held(coid→map 帰属) + batch(実 submit 分) が上限で新規を **skip_reason 付き**で弾く。両経路共通の**最終防波堤** |
| **3. delisted を held に算入** | FOLD/CDTX 等 orphan が `symbol_system_map` 非帰属で skip → `held_total` 過少 → total cap が余裕を過大評価 | `count_positions_with_unmapped` で unmapped を total/side に算入 |

`per-run TOP_N=10` (1 run の候補生成数) と `standing cap=10` (日跨ぎの同時保有残高) は**別概念**。

## 挙動がどう変わるか
- **現在の 74**: 何も閉じない (entry 側の歯止めのみ)。exit の正常発火 + time-exit で縮小に委ね、「減った分を翌日また積んで 74 に戻す」ループを止める。
- **daily_pipeline (finalize 経路)**: reconcile fetch 失敗時は fail-closed で新規0 (従来は per-run cap で新規を出していた)。
- **open_auto_run (submit 経路)**: system の保有が 10 到達で新規 skip / total 70 (delisted 含む) 到達で新規 skip。exit が効いて保有<10 の日は従来通り不足分を補充。
- **既定は docs 通り**で勝手に締めない。`SUBMIT_ENFORCE_STANDING_CAP` / `SUBMIT_MAX_POSITIONS_PER_SYSTEM` / `SUBMIT_MAX_TOTAL_POSITIONS` / `ALLOCATION_RECONCILE_FAILCLOSED` で ops 調整可。

## テスト
- `tests/test_position_standing_cap_20260721.py` 新規 **17 tests**: fail-closed / per-system cap (cross-day + batch) / total cap / delisted 算入 / pure decision / no-silent-drop。
- `tests/test_allocation_position_reconcile_20260707.py`: fetch 失敗 test を fail-open→**fail-closed** に更新 (意図した挙動変更) + opt-out test 追加。
- 影響範囲の回帰 218 passed、black/isort/ruff (pinned) clean。既存の6失敗は origin/main と同一の pre-existing (get_settings mock / 統計 test。main CI は success)。

## docs
`docs/POSITION_MANAGEMENT_P1_STANDING_CAP_20260721.md` (設計・cap 値の docs 根拠・挙動変更・rollback)。POSITION_MANAGEMENT_AUDIT / PHASE5 と矛盾なし。

## ⚠️ 月曜 22:35 runner への arm は別判断
本 PR は origin/main 宛まで。runner (`C:\tmp\qts-main-run` = `claude/open-auto-run`) は working-tree を読むため、**本 fix はまだ runner に入らない**。main マージ可否と合わせて指示待ち (**勝手に arm しない**)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)