### PR TITLE
fix(exec): 薄シグナル判定を cap 前候補数へ戻す + cap trim 理由の可観測化

### DIFF
--- a/common/signal_export.py
+++ b/common/signal_export.py
@@ -227,6 +227,7 @@ def build_signals_json(
     status: str = "ok",
     abort_reason: str | None = None,
     stage_metrics: dict[str, Any] | None = None,
+    portfolio_caps: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """``(final_df, per_system)`` を version 1.0 の JSON dict に変換する。
 
@@ -382,6 +383,11 @@ def build_signals_json(
                 if funnel_by_sys
                 else None
             ),
+            # portfolio cap の held/allow/trimmed。per-system funnel は生成側しか
+            # 語らないため、cand が健全なのに signals=0 の system があると理由が
+            # JSON に残らない (2026-07-21..27 は held_long=51 > max_long=40 で
+            # allow_long=0 → long 4 system が毎日 0 本)。cap 未適用なら None。
+            "caps": dict(portfolio_caps) if portfolio_caps else None,
         },
         "meta": {
             "cli_version": cli_version,
@@ -529,16 +535,21 @@ def run_headless(argv: list[str]) -> int:
     # compute_today_signals は実行中に GLOBAL_STAGE_METRICS を副作用で埋める。
     # ここで snapshot を取り出し funnel (Tgt/FIL/STU/TRD/Entry/Exit) を JSON に載せる。
     stage_metrics: dict[str, Any] | None = None
+    # portfolio cap の trim 報告も同じ side-channel で受け取り、
+    # 「cand は健全なのに signals=0」の理由を JSON に残す。
+    portfolio_caps: dict[str, Any] | None = None
     try:
         from common.stage_metrics import GLOBAL_STAGE_METRICS
 
         snapshots = GLOBAL_STAGE_METRICS.all_snapshots()
         if snapshots:
             stage_metrics = dict(snapshots)
+        portfolio_caps = GLOBAL_STAGE_METRICS.get_portfolio_caps()
     except (
         Exception
     ):  # noqa: BLE001 - funnel は best-effort。失敗しても signals は出す。
         stage_metrics = None
+        portfolio_caps = None
 
     payload = build_signals_json(
         final_df,
@@ -549,6 +560,7 @@ def run_headless(argv: list[str]) -> int:
         status=status,
         abort_reason=abort_reason,
         stage_metrics=stage_metrics,
+        portfolio_caps=portfolio_caps,
     )
 
     out_path = (

--- a/common/stage_metrics.py
+++ b/common/stage_metrics.py
@@ -99,6 +99,7 @@ class StageMetricsStore:
         self._events: deque[StageEvent] = deque()
         self._lock = Lock()
         self._universe_target: int | None = None
+        self._portfolio_caps: dict[str, object] | None = None
         self.stage_counts: dict[str, dict[str, int | None]] = {}
         self._display_order: list[str] = []
 
@@ -120,6 +121,7 @@ class StageMetricsStore:
             self._snapshots.clear()
             self._events.clear()
             self._universe_target = None
+            self._portfolio_caps = None
 
     def drain_events(self) -> list[StageEvent]:
         """Return and clear all queued stage events."""
@@ -251,6 +253,36 @@ class StageMetricsStore:
 
         with self._lock:
             return self._universe_target
+
+    def set_portfolio_caps(self, report: object | None) -> None:
+        """Persist the portfolio-cap trim report (``_apply_portfolio_caps``).
+
+        funnel の per-system 段 (Tgt/FIL/STU/cand) は「生成側」しか語らないため、
+        cand が健全なのに signals が 0 の system があっても理由が JSON に残らない。
+        実際 2026-07-21..27 は held_long=51 > max_long=40 で ``allow_long=0`` となり
+        long 4 system (1/3/4/5) が毎日 0 本に落ちていたが、その事実は
+        ``[PORTFOLIO_CAP]`` の INFO ログにしか出ておらず、ダッシュボードからは
+        「system2 だけシグナルが出る」ようにしか見えなかった。
+
+        universe_target と同じ side-channel で cap の held/allow/trimmed を運び、
+        signals JSON の ``portfolio.caps`` に載せて「0 の理由」を可観測にする。
+        """
+
+        if report is None:
+            with self._lock:
+                self._portfolio_caps = None
+            return
+        if not isinstance(report, dict):
+            return
+        snapshot = dict(report)
+        with self._lock:
+            self._portfolio_caps = snapshot
+
+    def get_portfolio_caps(self) -> dict[str, object] | None:
+        """Return the last portfolio-cap trim report if one was recorded."""
+
+        with self._lock:
+            return dict(self._portfolio_caps) if self._portfolio_caps else None
 
     # ------------------------------------------------------------------
     # display helpers for Streamlit UI

--- a/core/final_allocation.py
+++ b/core/final_allocation.py
@@ -1826,6 +1826,17 @@ def _apply_portfolio_caps(
         logger.info(
             "[PORTFOLIO_CAP] trimmed %s (held L%d/S%d)", trims, held_long, held_short
         )
+    # signals JSON へ「なぜその system が 0 本なのか」を運ぶ (観測性のみ。挙動は不変)。
+    # per-system funnel は生成側しか語らないため、cand が健全でも cap で 0 に落ちた
+    # 事実は [PORTFOLIO_CAP] の INFO ログにしか残らない。実際 2026-07-21..27 は
+    # held_long=51 > max_long=40 で allow_long=0 となり long 4 system が毎日 0 本
+    # だったが、ダッシュボード上は「system2 だけ出る」としか見えなかった。
+    try:  # best-effort: 観測性のために allocation を壊さない
+        from common.stage_metrics import GLOBAL_STAGE_METRICS
+
+        GLOBAL_STAGE_METRICS.set_portfolio_caps(report)
+    except Exception:  # noqa: BLE001
+        pass
     return trimmed_df, report
 
 

--- a/scripts/open_auto_run.py
+++ b/scripts/open_auto_run.py
@@ -29,6 +29,19 @@
     実行できる。よって薄シグナルは entry 専用ゲートに降格した。
     切り戻しは --thin-aborts-run / env OPEN_RUN_THIN_ABORTS_RUN=1。
 
+    判定基準の修正 (2026-07-27):
+    ゲートの本来の目的は「データがまだ来ていない状態で発注しない」こと
+    (design_open_auto_run_20260708.md L15: 06:00 は Polygon 403 / EODHD 401 で
+    今日 1 件しか出ない)。しかし判定に使っていたのは ``systems[*].signals`` =
+    **portfolio cap 適用後**の本数で、これは
+    ``allow_total = max_total_positions(70) - held_total`` で上から抑えられた残枠。
+    結果、建玉が 61 まで積み上がると残枠 9 < 閾値 10 が固定化し、
+    2026-07-22..27 の 5 営業日連続で entry が SKIP された
+    (候補数は 44-48 件で健全なまま = データ欠測ではない)。しかも entry が止まると
+    建玉が減らないので残枠も戻らず、cap の最後の 9 枠が構造的に使えない。
+    よって判定を **cap 前の候補数** (funnel.candidate_count 合計) に戻した。
+    データ欠測時は候補数自体が 0-2 件になるため、本来の保護は維持される。
+
 一回限りランナーが踏んだ 2 バグを恒久修正:
     - subprocess の cp932 UnicodeDecodeError -> encoding="utf-8", errors="replace" +
       子プロセスへ PYTHONUTF8=1 / PYTHONIOENCODING=utf-8 を伝播。
@@ -184,6 +197,50 @@ class Runner:
         self.record["signals_json_date"] = (data or {}).get("date")
         return total
 
+    def _count_candidates(self) -> int | None:
+        """portfolio cap 適用**前**の候補数 (= シグナル生成の健全性) を返す。
+
+        薄シグナルゲートの本来の目的は「データがまだ来ていない状態で発注しない」こと
+        (`logs/design_open_auto_run_20260708.md` L15: 06:00 は Polygon 403 / EODHD 401
+        で今日 1 件しか出ない)。ところが判定に使っていた `_count_signals()` は
+        ``systems[*].signals`` = **portfolio cap 適用後**の本数で、
+        `core/final_allocation.py::_apply_portfolio_caps` が
+        ``allow_total = max_total_positions - held_total`` で上から抑えた残数でしかない。
+
+        そのため建玉が積み上がると「データは健全なのに本数が閾値未満」になり、
+        entry が毎日止まる (2026-07-22..27 の実測: 候補 44-48 件は健全なまま、
+        cap 後だけが 39 -> 8/9 に落ちて `thin_signals:9<10` で 5 営業日連続 SKIP)。
+
+        判定を cap 前の候補数に戻すことで、本来の意図 (データ欠測の検出) を保ったまま
+        cap 由来の誤発火だけを消す。``funnel.candidate_count`` が無い旧 JSON では
+        ``n_candidates_input`` にフォールバックし、どちらも無ければ None を返して
+        呼び出し側が従来どおり cap 後の本数で判定する (後方互換)。
+        """
+        if not self.signals_json.exists():
+            return None
+        try:
+            data = json.loads(self.signals_json.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        systems = ((data or {}).get("systems") or {}).values()
+        total = 0
+        seen = False
+        for blk in systems:
+            if not isinstance(blk, dict):
+                continue
+            funnel = blk.get("funnel")
+            raw = funnel.get("candidate_count") if isinstance(funnel, dict) else None
+            if raw is None:
+                raw = blk.get("n_candidates_input")
+            if raw is None:
+                continue
+            try:
+                total += int(raw)
+            except (TypeError, ValueError):
+                continue
+            seen = True
+        return total if seen else None
+
     # -- stages ------------------------------------------------------------
     def gate(self) -> bool:
         # paper 断言 (最優先。live なら即 abort)
@@ -233,16 +290,37 @@ class Runner:
             if code != 0:
                 self.log(f"[signals] WARN exit={code} (JSON があれば継続)")
 
-        n = self._count_signals()
-        self.record["signal_count"] = n
+        n_out = (
+            self._count_signals()
+        )  # portfolio cap 適用**後** = 実際に submit する本数
+        self.record["signal_count"] = n_out
+        # 薄シグナル判定は **cap 前の候補数** (データ健全性) で行う。cap 後の本数は
+        # portfolio cap の残枠 (max_total_positions - held_total) に上から抑えられる
+        # ため、建玉が積み上がると健全なデータでも閾値未満になり entry が恒久停止する。
+        n_raw = self._count_candidates()
+        self.record["candidate_count"] = n_raw
+        n = n_out if n_raw is None else n_raw
+        gate_basis = "signals(post-cap)" if n_raw is None else "candidates(pre-cap)"
+        self.record["thin_gate_basis"] = gate_basis
         self.log(
-            f"[gate] signal_count={n} (threshold={self.args.min_signals}) "
+            f"[gate] signal_count={n_out} candidate_count={n_raw} "
+            f"-> 判定={n} basis={gate_basis} (threshold={self.args.min_signals}) "
             f"signals_date={self.record.get('signals_json_date')}"
         )
         thin = n < self.args.min_signals
         self.entry_allowed = not thin
         self.record["entry_allowed"] = self.entry_allowed
         if not thin:
+            # データは健全だが cap 適用後に 1 件も残らなかった場合、submit しても no-op。
+            # 「entry を通したのに 0 件」を黙って通さず、明示的に SKIP として記録する。
+            if n_out == 0:
+                self.entry_allowed = False
+                self.record["entry_allowed"] = False
+                self.record["entry_skip_reason"] = "no_submittable_signals_after_caps"
+                self.log(
+                    "[gate] 候補は健全 (>= 閾値) だが portfolio cap 適用後に 0 件 -> "
+                    "entry SKIP (submit するものが無い)。exit は継続する"
+                )
             return True
 
         # 薄シグナルは **entry 専用ゲート**。手仕舞い (exit) を新規シグナルの本数で

--- a/tests/test_open_auto_run_thin_gate_precap.py
+++ b/tests/test_open_auto_run_thin_gate_precap.py
@@ -1,0 +1,280 @@
+"""薄シグナルゲートを cap 前の候補数で判定する回帰テスト (2026-07-27)。
+
+背景
+----
+薄シグナルゲートの目的は「データがまだ来ていない状態で発注しない」こと
+(`logs/design_open_auto_run_20260708.md` L15: 06:00 は Polygon 403 / EODHD 401 で
+今日 1 件しか出ない)。ところが判定に使っていた ``systems[*].signals`` は
+**portfolio cap 適用後**の本数で、``core/final_allocation.py::_apply_portfolio_caps``
+が ``allow_total = max_total_positions(70) - held_total`` で上から抑えた残枠でしかない。
+
+実測 (logs/open_run_*/): 建玉が 61 (L51/S10) まで積み上がった結果 残枠が 9 に固定され、
+候補数は 44-48 件で健全なままなのに ``thin_signals:9<10`` で 2026-07-22..27 の
+**5 営業日連続** entry が SKIP された。さらに entry が止まると建玉が減らないため
+残枠も戻らず、cap の最後の 9 枠が構造的に使えない (自己強化ループ)。
+
+ここで固定する契約:
+  1. cap で絞られただけ (候補は健全) なら entry を通す = 本バグの回帰。
+  2. 本物のデータ欠測 (候補自体が薄い) では従来どおり entry を止める = 保護の維持。
+  3. funnel が無い旧 JSON では cap 後の本数にフォールバックする = 後方互換。
+  4. 候補は健全でも cap 後 0 件なら、専用理由で SKIP する (黙って 0 件 submit しない)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module():
+    path = ROOT / "scripts" / "open_auto_run.py"
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    spec = importlib.util.spec_from_file_location("open_auto_run_precap_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+oar = _load_module()
+
+
+def _write_signals(root: Path, date_compact: str, systems: dict) -> None:
+    """systems ブロックをそのまま書き出す (funnel 有無を試験ごとに変えるため)。"""
+    results = root / "results_csv"
+    results.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "date": f"{date_compact[:4]}-{date_compact[4:6]}-{date_compact[6:8]}",
+        "systems": systems,
+    }
+    (results / f"today_signals_{date_compact}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _sys_block(n_out: int, candidate_count: int | None, *, legacy_key: bool = False):
+    """cap 後 n_out 本 / cap 前 candidate_count 件の system ブロックを作る。"""
+    blk: dict = {"signals": [{"symbol": f"S{i}"} for i in range(n_out)]}
+    if candidate_count is not None:
+        if legacy_key:
+            blk["n_candidates_input"] = candidate_count
+        else:
+            blk["funnel"] = {"candidate_count": candidate_count}
+    return blk
+
+
+def _args(**kw):
+    base = dict(
+        date=None,
+        min_signals=10,
+        poll_timeout=1.0,
+        dry_run=False,
+        skip_signals=True,
+        allow_closed=True,
+        force=True,
+        flatten_all=False,
+        no_publish=True,
+        primary_root=".",
+        thin_aborts_run=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+
+@pytest.fixture()
+def runner(tmp_path, monkeypatch):
+    monkeypatch.setattr(oar, "ROOT", tmp_path)
+
+    def _make(systems: dict, **overrides):
+        date = "2026-07-27"
+        _write_signals(tmp_path, date.replace("-", ""), systems)
+
+        r = oar.Runner(_args(date=date, **overrides))
+        rec = _Recorder()
+
+        monkeypatch.setattr(r, "_assert_paper", lambda: None)
+        monkeypatch.setattr(r, "_ntfy_warn", lambda *a, **k: None)
+        monkeypatch.setattr(r, "equity", lambda: 100_000.0)
+        monkeypatch.setattr(r, "wait_exit_fills", lambda ids: None)
+        monkeypatch.setattr(r, "record_stage", lambda: None)
+        monkeypatch.setattr(r, "publish", lambda: None)
+        monkeypatch.setattr(r, "notify", lambda eq: None)
+        monkeypatch.setattr(r, "gate", lambda: True)
+
+        def _exit_stage():
+            rec.calls.append("exit")
+            r.record["exit_count"] = 24
+            return []
+
+        def _entry_stage(eq):
+            rec.calls.append("entry")
+
+        monkeypatch.setattr(r, "exit_stage", _exit_stage)
+        monkeypatch.setattr(r, "entry_stage", _entry_stage)
+        return r, rec
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# 1) 本丸: cap で絞られただけなら entry を通す
+# ---------------------------------------------------------------------------
+
+
+def test_cap_limited_but_healthy_candidates_allows_entry(runner):
+    """2026-07-27 実測の再現: 候補 47 件 / cap 後 9 本 -> entry は通すべき。
+
+    sys1/3/4/5 は long cap (held_long=51 > max_long=40) で全滅し、
+    残った sys2 の 9 本は allow_total = 70 - 61 = 9 の残枠そのもの。
+    データは健全なので新規 entry を止める理由が無い。
+    """
+    systems = {
+        "sys1": _sys_block(0, 10),
+        "sys2": _sys_block(9, 10),
+        "sys3": _sys_block(0, 10),
+        "sys4": _sys_block(0, 10),
+        "sys5": _sys_block(0, 7),
+        "sys6": _sys_block(0, 0),
+        "sys7": _sys_block(0, 0),
+    }
+    r, rec = runner(systems)
+
+    code = r.main()
+
+    assert r.record["candidate_count"] == 47
+    assert r.record["signal_count"] == 9, "cap 後の本数は観測値として残すこと"
+    assert r.entry_allowed is True, (
+        "候補 47 件は健全。cap 後 9 本という残枠を理由に entry を止めるのは、"
+        "07-22..27 に 5 営業日 entry を殺したバグそのもの"
+    )
+    assert "entry" in rec.calls
+    assert rec.calls == ["exit", "entry"], "exit->entry の順序契約は維持"
+    assert code == 0
+    assert r.record.get("entry_skip_reason") is None
+
+
+# ---------------------------------------------------------------------------
+# 2) 保護の維持: 本物のデータ欠測では止める
+# ---------------------------------------------------------------------------
+
+
+def test_genuine_data_outage_still_blocks_entry(runner):
+    """2026-07-07 実測の再現: 候補 2 件 / cap 後 1 本 = Polygon 403 の薄データ。"""
+    systems = {
+        "sys1": _sys_block(1, 2),
+        "sys2": _sys_block(0, 0),
+    }
+    r, rec = runner(systems)
+
+    code = r.main()
+
+    assert r.record["candidate_count"] == 2
+    assert (
+        r.entry_allowed is False
+    ), "候補自体が 2 件 = データがまだ来ていない。ゲート本来の目的なので止める"
+    assert r.record["entry_skip_reason"] == "thin_signals:2<10"
+    assert "entry" not in rec.calls
+    assert "exit" in rec.calls, "データ欠測でも exit は止めない (A1 契約)"
+    assert code == 0
+
+
+def test_zero_candidates_blocks_entry(runner):
+    """2026-07-09 実測の再現: 候補 0 件 (データ皆無) でも exit は通す。"""
+    r, rec = runner({"sys1": _sys_block(0, 0)})
+
+    r.main()
+
+    assert r.entry_allowed is False
+    assert r.record["entry_skip_reason"] == "thin_signals:0<10"
+    assert rec.calls == ["exit"]
+
+
+# ---------------------------------------------------------------------------
+# 3) 後方互換: funnel が無ければ cap 後の本数で判定 (従来挙動)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_funnel_falls_back_to_postcap_count(runner):
+    """旧 JSON (funnel も n_candidates_input も無い) では従来どおり cap 後で判定。"""
+    systems = {"sys1": _sys_block(9, None)}
+    r, rec = runner(systems)
+
+    r.main()
+
+    assert r.record["candidate_count"] is None
+    assert r.record["thin_gate_basis"] == "signals(post-cap)"
+    assert r.entry_allowed is False, "候補数が取れない旧 JSON では従来挙動を維持"
+    assert r.record["entry_skip_reason"] == "thin_signals:9<10"
+
+
+def test_legacy_n_candidates_input_is_used(runner):
+    """funnel が無くても n_candidates_input があればそれを候補数として使う。"""
+    systems = {"sys1": _sys_block(9, 40, legacy_key=True)}
+    r, rec = runner(systems)
+
+    r.main()
+
+    assert r.record["candidate_count"] == 40
+    assert r.record["thin_gate_basis"] == "candidates(pre-cap)"
+    assert r.entry_allowed is True
+
+
+# ---------------------------------------------------------------------------
+# 4) 候補は健全でも cap 後 0 件なら専用理由で SKIP
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_candidates_but_zero_after_caps_skips_with_reason(runner):
+    """cap が全部刈った場合、submit は no-op なので黙って通さず理由を残す。"""
+    systems = {
+        "sys1": _sys_block(0, 30),
+        "sys2": _sys_block(0, 10),
+    }
+    r, rec = runner(systems)
+
+    code = r.main()
+
+    assert r.record["candidate_count"] == 40
+    assert r.record["signal_count"] == 0
+    assert r.entry_allowed is False
+    assert r.record["entry_skip_reason"] == "no_submittable_signals_after_caps"
+    assert "entry" not in rec.calls
+    assert "exit" in rec.calls
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# 5) 潤沢シグナルの非退行
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_day_unchanged(runner):
+    """2026-07-21 実測の再現: 候補 44 / cap 後 39 -> 従来どおり entry を通す。"""
+    systems = {
+        "sys1": _sys_block(7, 10),
+        "sys2": _sys_block(10, 10),
+        "sys3": _sys_block(8, 10),
+        "sys4": _sys_block(10, 10),
+        "sys5": _sys_block(4, 4),
+    }
+    r, rec = runner(systems)
+
+    r.main()
+
+    assert r.record["candidate_count"] == 44
+    assert r.record["signal_count"] == 39
+    assert r.entry_allowed is True
+    assert rec.calls == ["exit", "entry"]

--- a/tests/test_portfolio_caps_observability_20260727.py
+++ b/tests/test_portfolio_caps_observability_20260727.py
@@ -1,0 +1,177 @@
+"""portfolio cap の trim 理由が signals JSON に載ることの回帰テスト (2026-07-27)。
+
+背景:
+    2026-07-21..27 の 5 営業日、long 4 system (1/3/4/5) の signals が毎日 0 本
+    だった。生成側の funnel は健全 (cand = 10/10/10/7) で、原因は
+    ``held_long=51 > max_long_positions=40`` により ``allow_long=0`` になっていた
+    こと。ところがこの事実は ``[PORTFOLIO_CAP]`` の INFO ログにしか出ておらず、
+    signals JSON / ダッシュボードからは「system2 だけシグナルが出る」としか
+    見えなかった (実ログ: logs/open_run_20260727/signals.log
+    ``[PORTFOLIO_CAP] trimmed {'long_count': 30, 'total': 1} (held L51/S10)``)。
+
+    本テストは cap の held/allow/trimmed が JSON の ``portfolio.caps`` に
+    載ることを固定し、同じ「理由の見えない 0」が再発しないようにする。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from common.signal_export import build_signals_json
+from common.stage_metrics import StageMetricsStore
+
+# 2026-07-27 の実測値 (logs/open_run_20260727/signals.log より)。
+REAL_0727_CAPS = {
+    "applied": True,
+    "held": {"long": 51, "short": 10, "total": 61},
+    "caps": {"max_total": 70, "max_long": 40, "max_short": 30},
+    "allow": {"long": 0, "short": 20, "total": 9},
+    "kept": {"long": 0, "short": 9, "total": 9},
+    "trimmed": {"long_count": 30, "total": 1},
+}
+
+
+def test_store_roundtrips_portfolio_caps() -> None:
+    store = StageMetricsStore()
+    assert store.get_portfolio_caps() is None
+
+    store.set_portfolio_caps(REAL_0727_CAPS)
+    got = store.get_portfolio_caps()
+    assert got is not None
+    assert got["held"] == {"long": 51, "short": 10, "total": 61}
+    assert got["allow"]["long"] == 0
+
+
+def test_store_returns_a_copy_not_a_live_reference() -> None:
+    """呼び出し側の変異が store 内部に伝播しないこと (観測値の汚染防止)。"""
+
+    store = StageMetricsStore()
+    store.set_portfolio_caps(REAL_0727_CAPS)
+
+    got = store.get_portfolio_caps()
+    assert got is not None
+    got["held"] = {"long": 999}
+
+    again = store.get_portfolio_caps()
+    assert again is not None
+    assert again["held"] == {"long": 51, "short": 10, "total": 61}
+
+
+def test_reset_clears_portfolio_caps() -> None:
+    store = StageMetricsStore()
+    store.set_portfolio_caps(REAL_0727_CAPS)
+    store.reset()
+    assert store.get_portfolio_caps() is None
+
+
+@pytest.mark.parametrize("bad", [None, "not-a-dict", 42, ["a"]])
+def test_non_dict_reports_do_not_crash(bad: object) -> None:
+    """観測性のための side-channel が allocation を壊さないこと。"""
+
+    store = StageMetricsStore()
+    store.set_portfolio_caps(bad)
+    assert store.get_portfolio_caps() is None
+
+
+def test_signals_json_carries_caps_so_zero_has_a_reason() -> None:
+    """cand が健全でも signals=0 の理由 (allow_long=0) が JSON から読めること。"""
+
+    payload = build_signals_json(
+        pd.DataFrame(),
+        {},
+        date_str="2026-07-27",
+        portfolio_caps=REAL_0727_CAPS,
+    )
+
+    caps = payload["portfolio"]["caps"]
+    assert caps is not None
+    # long が 0 本だった理由 = 既保有 51 が long cap 40 を超過 -> 新規枠 0。
+    assert caps["held"]["long"] == 51
+    assert caps["caps"]["max_long"] == 40
+    assert caps["allow"]["long"] == 0
+    assert caps["trimmed"]["long_count"] == 30
+    # 「ちょうど 9 本」= 総枠 70 - 既保有 61 の残枠であって signal 生成数ではない。
+    assert caps["allow"]["total"] == 9
+    assert caps["kept"]["total"] == 9
+
+
+def test_caps_absent_stays_none_and_does_not_break_schema() -> None:
+    """cap 未適用 (旧経路 / 呼ばれなかった) 場合も従来どおり成立すること。"""
+
+    payload = build_signals_json(pd.DataFrame(), {}, date_str="2026-07-27")
+
+    assert payload["portfolio"]["caps"] is None
+    # 既存キーは不変。
+    for key in ("total_signals", "total_notional_usd", "hedge", "universe_target"):
+        assert key in payload["portfolio"]
+
+
+def test_apply_portfolio_caps_publishes_to_the_global_store() -> None:
+    """allocation -> store の配線が実際に通ること (両端だけでなく結線を固定)。
+
+    2026-07-27 の本番ログ
+    ``[PORTFOLIO_CAP] trimmed {'long_count': 30, 'total': 1} (held L51/S10)``
+    を合成入力から再現し、long 4 system が 0 本になった理由が
+    ``allow.long == 0`` として観測できることを固定する。
+    """
+
+    from common.stage_metrics import GLOBAL_STAGE_METRICS
+    from core.final_allocation import _apply_portfolio_caps
+
+    GLOBAL_STAGE_METRICS.set_portfolio_caps(None)
+
+    final_df = pd.DataFrame(
+        [{"symbol": f"L{i}", "side": "long"} for i in range(30)]
+        + [{"symbol": f"S{i}", "side": "short"} for i in range(10)]
+    )
+
+    class _Pos:
+        def __init__(self, symbol: str) -> None:
+            self.symbol = symbol
+            self.qty = "1"
+            self.side = "long"
+
+    held = [_Pos(f"H{i}") for i in range(61)]
+    symbol_system_map: dict[str, list[str]] = {f"H{i}": ["system1"] for i in range(51)}
+    symbol_system_map.update({f"H{i}": ["system2"] for i in range(51, 61)})
+
+    trimmed_df, report = _apply_portfolio_caps(
+        final_df,
+        caps={
+            "max_total_positions": 70,
+            "max_long_positions": 40,
+            "max_short_positions": 30,
+        },
+        active_positions=held,
+        symbol_system_map=symbol_system_map,
+        long_systems=["system1", "system3", "system4", "system5"],
+        short_systems=["system2", "system6", "system7"],
+        equity=103684.01,
+    )
+
+    # 本番ログと同じ数字であること。
+    assert report["held"] == {"long": 51, "short": 10, "total": 61}
+    assert report["allow"]["long"] == 0  # 51 > 40 -> long は 1 本も通らない
+    assert report["allow"]["total"] == 9  # 70 - 61 = 9 (= 「毎日ちょうど 9 本」の正体)
+    assert report["trimmed"] == {"long_count": 30, "total": 1}
+    assert len(trimmed_df) == 9
+    assert set(trimmed_df["side"]) == {"short"}
+
+    # 配線: allocation が store に publish していること。
+    published = GLOBAL_STAGE_METRICS.get_portfolio_caps()
+    assert published is not None
+    assert published["allow"]["long"] == 0
+    assert published["trimmed"]["long_count"] == 30
+
+
+def test_caps_snapshot_is_detached_from_the_allocation_report() -> None:
+    """JSON 化後に report が書き換わっても payload が汚れないこと。"""
+
+    report = {"applied": True, "held": {"long": 51}}
+    payload = build_signals_json(
+        pd.DataFrame(), {}, date_str="2026-07-27", portfolio_caps=report
+    )
+    report["held"] = {"long": 0}
+
+    assert payload["portfolio"]["caps"]["held"] == {"long": 51}


### PR DESCRIPTION
## 何が起きていたか

`open_auto_run` の薄シグナルゲートが **2026-07-22..27 の 5 営業日連続で entry を SKIP** していた。データは健全だったのに止まっていた。

### 実測 (`logs/open_run_20260727/`)

```
[PORTFOLIO_CAP] trimmed {'long_count': 30, 'total': 1} (held L51/S10)
ENTRY SKIPPED: thin_signals:9<10
```

- `held_long=51 > max_long_positions=40` → `allow_long = 0`
  → long 4 system (1/3/4/5) は候補が健全 (cand=10/10/10/7) でも **毎日きっかり 0 本**
- `allow_total = 70 - 61 = 9`
  → sys2 の「毎日ちょうど 9 本」は **signal 生成数ではなく cap の残枠**
- その 9 が閾値 10 を 1 本下回り entry 停止 → 建玉が減らない → 残枠も戻らない **自己強化ループ**

## 修正 1: 判定を cap 前の候補数へ (`01803df`)

ゲートの目的は「データがまだ来ていない状態で発注しない」こと (`logs/design_open_auto_run_20260708.md` §3 は **候補数** < 閾値 で ABORT と規定)。実装が cap **後**の本数を見ていたのが drift。

| 日付 | 状況 | precap | postcap | before | after |
|---|---|---|---|---|---|
| 07-21 | healthy | 44 | 39 | PASS | PASS |
| 07-07 | Polygon 403 | 2 | 1 | SKIP | SKIP |
| 07-09 | no data | 0 | 0 | SKIP | SKIP |
| 07-22 | cap-limited | 45 | 8 | SKIP | **PASS** |
| 07-27 | cap-limited | 47 | 9 | SKIP | **PASS** |

データ欠測時の保護は維持。cap 後 0 件なら `no_submittable_signals_after_caps` で SKIP。
旧 JSON は `n_candidates_input` → cap 後本数へフォールバック。

**切り戻し**: `--thin-aborts-run` / `OPEN_RUN_THIN_ABORTS_RUN=1`

## 修正 2: cap trim 理由を signals JSON へ (`c2d71d5`)

同じ「0」でも意味が 3 種類あるのに JSON では区別できなかった:

1. **cap 由来** (sys1/3/4/5) — 候補は健全、`allow_long=0` で全 trim
2. **spec どおり** (sys6) — `docs/systems/システム6.txt` が「候補数 0 でも正常動作」と明記
3. **spec どおり** (sys7) — SPY が 50 日安値でない

`universe_target` と同じ side-channel で `held/allow/trimmed` を運び `portfolio.caps` に載せる。**観測性のみ、allocation の挙動は不変** (publish は best-effort)。

## テスト

- 新規 18 本 (thin-gate 7 + 可観測化 11)。うち 1 本は allocation → store の結線を実際に通し、本番ログの数字を合成入力から再現。
- 既存 `test_open_auto_run_thin_signals_exit.py` 8 本は不変で緑。
- 先在失敗 5 本 (`test_final_allocation_comprehensive.py` の `get_settings` mock 切れ) は **baseline と同一・増減なし**。
- black / ruff / isort clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)