### PR TITLE
land: System8 (FOMC drift) を main へ + 血統 (Bensdorp / 独自開発) の恒久区別

### DIFF
--- a/apps/app_integrated.py
+++ b/apps/app_integrated.py
@@ -201,7 +201,7 @@ def main() -> None:
             "📊 Real-time",
             "🤖 AI分析",
         ]
-        + [f"System{i}" for i in range(1, 8)]
+        + [f"System{i}" for i in range(1, 9)]
     )
 
     with tabs[0]:

--- a/apps/dashboards/alpaca-next/components/AlpacaSection.tsx
+++ b/apps/dashboards/alpaca-next/components/AlpacaSection.tsx
@@ -22,8 +22,10 @@ import {
   fmtQty,
   fmtSignedUsd,
   fmtUsd,
+  LINEAGE_LEGEND,
   pnlText,
   sysColor,
+  sysLineageTitle,
   sysShort,
 } from '@/lib/format';
 
@@ -391,6 +393,8 @@ function ExposureBlock({ snap }: { snap: AlpacaSnapshot }) {
       <div>
         <div className="text-[10px] text-muted mb-1">
           system 別配分（% of active gross・delisted 除外）
+          {/* 血統マーカーの意味をここで一度だけ示す。チップ本体は sysShort() が付ける。 */}
+          <span className="ml-1 text-muted/60">· {LINEAGE_LEGEND}</span>
         </div>
         <div className="space-y-1">
           {systems.map(([sys, s, pct]) => (
@@ -398,6 +402,7 @@ function ExposureBlock({ snap }: { snap: AlpacaSnapshot }) {
               <span
                 className="text-[10px] tabular-nums min-w-9 shrink-0 font-medium whitespace-nowrap pr-1"
                 style={{ color: sysColor(sys) }}
+                title={sysLineageTitle(sys)}
               >
                 {sysShort(sys)}
               </span>
@@ -753,6 +758,7 @@ function PositionsTable({ positions }: { positions: AlpacaPosition[] }) {
                         color: sysColor(p.system),
                         backgroundColor: `${sysColor(p.system)}22`,
                       }}
+                      title={sysLineageTitle(p.system)}
                     >
                       {sysShort(p.system)}
                     </span>

--- a/apps/dashboards/alpaca-next/components/PipelineSection.tsx
+++ b/apps/dashboards/alpaca-next/components/PipelineSection.tsx
@@ -1,10 +1,26 @@
+import { LINEAGE_LABEL, LINEAGE_LEGEND, sysLineage } from '@/lib/format';
 import type {
   PipelinePayload,
   SystemPipeline,
   SystemPipelinePhase,
 } from '@/lib/types';
 
-const SYSTEMS = ['sys1', 'sys2', 'sys3', 'sys4', 'sys5', 'sys6', 'sys7'];
+// sys8 は payload に無ければ描画されない (下の filter)。System8 は現状ライブの
+// 日次ループに未配線なので通常は出てこないが、配線された日に落ちないよう並べておく。
+const SYSTEMS = [
+  'sys1',
+  'sys2',
+  'sys3',
+  'sys4',
+  'sys5',
+  'sys6',
+  'sys7',
+  'sys8',
+];
+
+// pipeline payload の key は `sysN`、血統レジストリの key は `systemN`。
+const lineageOfSysKey = (key: string) =>
+  key.startsWith('sys') ? sysLineage('system' + key.slice(3)) : null;
 
 function fmtCount(v: number | null): string {
   return v == null ? '—' : v.toLocaleString();
@@ -73,11 +89,21 @@ function PhaseRow({ phase }: { phase: SystemPipelinePhase }) {
 function SystemPipelineAccordion({ sys }: { sys: SystemPipeline }) {
   const universe = universeOf(sys);
   const final = finalOf(sys);
+  const lineage = lineageOfSysKey(sys.system_id);
   return (
     <details className="rounded-lg bg-white/[0.03] border border-white/5">
       <summary className="cursor-pointer select-none list-none px-3 py-2 flex items-center justify-between gap-2">
         <span className="flex items-center gap-2 min-w-0">
           <span className="font-medium">{sys.system_id}</span>
+          {/* 血統が Bensdorp 系でないものだけ明示する (控えめだが混同させない)。 */}
+          {lineage === 'original' ? (
+            <span
+              className="text-[9px] px-1.5 py-0.5 rounded-full bg-lime-400/15 text-lime-300 shrink-0"
+              title={LINEAGE_LABEL.original}
+            >
+              独自
+            </span>
+          ) : null}
           <span className="text-[10px] text-muted tabular-nums truncate">
             {fmtCount(universe)} → {fmtCount(final)}
           </span>
@@ -118,6 +144,8 @@ export function PipelineSection({
           数値は<span className="text-cardfg"> 絞込透明性のための参考値</span>で、
           通過率は評価軸ではありません (厳しい gate ほど TRDlist/Entry は少数になる設計)。
         </p>
+        {/* 血統の凡例。System8 だけ設計思想が別系統なので、印の意味を必ず添える。 */}
+        <p className="text-[10px] text-muted mb-3 leading-snug">{LINEAGE_LEGEND}</p>
         {!payload ? (
           <div className="text-sm text-muted">
             No pipeline data yet. Run{' '}

--- a/apps/dashboards/alpaca-next/lib/format.ts
+++ b/apps/dashboards/alpaca-next/lib/format.ts
@@ -47,11 +47,67 @@ export const SYSTEM_COLOR: Record<string, string> = {
   system5: '#fbbf24',
   system6: '#fb7185',
   system7: '#94a3b8',
+  // System8 は血統が別 (独自開発の event-driven)。lime で 1-7 のどの色とも被らせない。
+  system8: '#a3e635',
   // 上場廃止 (INACTIVE / 非tradable) で API から close 不能なポジション。
   // muted terracotta で「取引不能・要注意」を示し、system 各色とも被らない。
   delisted: '#c08457',
   unknown: '#64748b',
 };
 
+/**
+ * system の血統 (lineage)。
+ *
+ * - `bensdorp`: Laurens Bensdorp の自動売買システム本に準拠した定型システム群 (System1-7)。
+ *   広いユニバースに指標フィルター + セットアップを当て上位 N を取る、
+ *   モメンタム / 平均回帰 × ロング / ショートの組み合わせ。
+ * - `original`: 当リポジトリ独自開発。Bensdorp 準拠ではない。現状 System8 のみ
+ *   (FOMC 声明日のオーバーナイト・ドリフト = イベントドリブン)。
+ *
+ * 正準定義は Python 側 `common/system_constants.py` の `SYSTEM_LINEAGE`。
+ * ここはその写しなので、増える時は両方を更新すること (docs/SYSTEM_LINEAGE.md)。
+ */
+export type Lineage = 'bensdorp' | 'original';
+
+export const SYSTEM_LINEAGE: Record<string, Lineage> = {
+  system1: 'bensdorp',
+  system2: 'bensdorp',
+  system3: 'bensdorp',
+  system4: 'bensdorp',
+  system5: 'bensdorp',
+  system6: 'bensdorp',
+  system7: 'bensdorp',
+  system8: 'original',
+};
+
+/** 独自開発 system に付ける控えめな印。Python 側 `LINEAGE_MARKER` と同じ字。 */
+export const LINEAGE_MARKER = '◆';
+
+export const LINEAGE_LABEL: Record<Lineage, string> = {
+  bensdorp: 'Bensdorp 準拠',
+  original: '独自開発 (event-driven)',
+};
+
+/** 凡例 1 行。マーカーを出す画面には必ずこれも出して意味不明にしない。 */
+export const LINEAGE_LEGEND = `${LINEAGE_MARKER} = ${LINEAGE_LABEL.original} / 無印 = ${LINEAGE_LABEL.bensdorp}`;
+
+export const sysLineage = (s: string): Lineage | null => SYSTEM_LINEAGE[s] ?? null;
+
+/** 独自開発なら marker、それ以外 (未知含む) は空文字。 */
+export const sysMarker = (s: string) =>
+  SYSTEM_LINEAGE[s] === 'original' ? LINEAGE_MARKER : '';
+
+/** チップ等の tooltip 文言。血統が分かる system のみ返す。 */
+export const sysLineageTitle = (s: string): string | undefined => {
+  const lin = sysLineage(s);
+  return lin ? `${s} — ${LINEAGE_LABEL[lin]}` : undefined;
+};
+
 export const sysColor = (s: string) => SYSTEM_COLOR[s] ?? '#64748b';
-export const sysShort = (s: string) => (s.startsWith('system') ? 'S' + s.slice(6) : s);
+
+/**
+ * チップ表示用の短縮名。独自開発 system には血統マーカーを付ける
+ * (例: `system8` → `S8◆`)。突合や JSON key には使わないこと。
+ */
+export const sysShort = (s: string) =>
+  s.startsWith('system') ? 'S' + s.slice(6) + sysMarker(s) : s;

--- a/apps/systems/app_system8.py
+++ b/apps/systems/app_system8.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+import time
+from typing import Any, cast
+
+import pandas as pd
+import streamlit as st
+
+from common.i18n import language_selector, load_translations_from_dir, tr
+from common.notifier import Notifier, get_notifiers_from_env, now_jst_str
+from common.performance_summary import summarize as summarize_perf
+from common.price_chart import save_price_chart
+from common.ui_components import (
+    run_backtest_app,
+    save_signal_and_trade_logs,
+    show_signal_trade_summary,
+)
+from common.ui_manager import UIManager
+import common.ui_patch  # noqa: F401
+from strategies import get_strategy
+
+# Load translations and (optionally) show language selector
+load_translations_from_dir(Path(__file__).parent / "translations")
+if not st.session_state.get("_integrated_ui", False):
+    language_selector()
+
+SYSTEM_NAME = "System8"
+DISPLAY_NAME = "システム8"
+
+
+def _strategy():
+    return get_strategy("system8")
+
+
+notifiers: list[Notifier] = get_notifiers_from_env()
+
+
+def run_tab(
+    single_mode: bool | None = None,
+    ui_manager: UIManager | None = None,
+) -> None:
+    """System8 タブを描画し、バックテストを実行する。
+
+    System8 は SPY オーバーナイト FOMC プレドリフト（イベント駆動・ロング専用）。
+    予定 FOMC 声明日の前営業日に引けで買い、声明日の寄りで手仕舞う 1 泊保有。
+    """
+    st.header(
+        tr(
+            "{display_name} バックテスト（FOMC オーバーナイト・ドリフト / SPYのみ）",
+            display_name=DISPLAY_NAME,
+        )
+    )
+    st.caption(
+        tr(
+            "予定 FOMC 声明日の前営業日 T-1 の引け（MOC）でロング、声明日 T の寄り"
+            "（MOO）で手仕舞い。等ノーショナル・ストップなし・往復2bp。"
+            "（出所: n0150_fomc_macro_event_drift_spy, GO_CANDIDATE）"
+        )
+    )
+
+    ui_base: UIManager = (
+        ui_manager.system(SYSTEM_NAME)
+        if ui_manager
+        else UIManager().system(SYSTEM_NAME)
+    )
+    fetch_phase = ui_base.phase("fetch", title=tr("データ取得"))
+    ind_phase = ui_base.phase("indicators", title=tr("カレンダー適用"))
+    cand_phase = ui_base.phase("candidates", title=tr("候補選定"))
+    notify_key = f"{SYSTEM_NAME}_notify_backtest"
+    run_start = time.time()
+    strategy = _strategy()
+    _rb = cast(
+        tuple[
+            pd.DataFrame | None,
+            pd.DataFrame | None,
+            dict[str, pd.DataFrame] | None,
+            float,
+            object | None,
+        ],
+        run_backtest_app(
+            strategy,
+            system_name=SYSTEM_NAME,
+            limit_symbols=1,
+            ui_manager=ui_base,
+        ),
+    )
+    elapsed = time.time() - run_start
+    results_df, _, data_dict, capital, candidates_by_date = _rb
+    fetch_phase.log_area.write(tr("データ取得完了"))
+    ind_phase.log_area.write(tr("FOMC カレンダー適用完了"))
+    cand_phase.log_area.write(tr("候補選定完了"))
+
+    if results_df is not None and candidates_by_date is not None:
+        summary_df = show_signal_trade_summary(
+            data_dict,
+            results_df,
+            SYSTEM_NAME,
+            display_name=DISPLAY_NAME,
+        )
+        with st.expander(tr("取引ログ・保存ファイル"), expanded=False):
+            save_signal_and_trade_logs(
+                summary_df,
+                results_df,
+                SYSTEM_NAME,
+                capital,
+            )
+        summary, df2 = summarize_perf(results_df, capital)
+        try:
+            _max_dd = float(df2["drawdown"].min())
+        except Exception:
+            _max_dd = float(getattr(summary, "max_drawdown", 0.0))
+        stats: dict[str, Any] = {
+            "総リターン": f"{summary.total_return:.2f}",
+            "最大DD": f"{_max_dd:.2f}",
+            "Sharpe": f"{summary.sharpe:.2f}",
+            "実施日時": now_jst_str(),
+            "銘柄数": len(data_dict) if data_dict else 0,
+            "開始資金": int(capital),
+            "処理時間": f"{elapsed:.2f}s",
+        }
+
+        try:
+            from common.ui_components import show_results
+
+            show_results(results_df, capital, SYSTEM_NAME, key_context="live")
+        except Exception:
+            pass
+
+        period: str = ""
+        if "entry_date" in results_df.columns and "exit_date" in results_df.columns:
+            start = pd.to_datetime(results_df["entry_date"]).min()
+            end = pd.to_datetime(results_df["exit_date"]).max()
+            period = f"{start:%Y-%m-%d}〜{end:%Y-%m-%d}"
+        ranking: list[str] = (
+            [str(s) for s in results_df["symbol"].head(10)]
+            if "symbol" in results_df.columns
+            else []
+        )
+        chart_url = None
+        if not results_df.empty and "symbol" in results_df.columns:
+            try:
+                top_sym = results_df.sort_values("pnl", ascending=False)["symbol"].iloc[
+                    0
+                ]
+                _, chart_url = save_price_chart(str(top_sym), trades=results_df)
+            except Exception:
+                chart_url = None
+        if st.session_state.get(notify_key, False):
+            sent = False
+            for n in notifiers:
+                try:
+                    _mention: str | None = (
+                        "channel" if getattr(n, "platform", None) == "slack" else None
+                    )
+                    if hasattr(n, "send_backtest_ex"):
+                        n.send_backtest_ex(
+                            SYSTEM_NAME.lower(),
+                            period,
+                            stats,
+                            ranking,
+                            image_url=chart_url,
+                            mention=_mention,
+                        )
+                    else:
+                        n.send_backtest(
+                            SYSTEM_NAME.lower(),
+                            period,
+                            stats,
+                            ranking,
+                        )
+                    sent = True
+                except Exception:
+                    continue
+            if sent:
+                st.success(tr("通知を送信しました"))
+            else:
+                st.warning(tr("通知の送信に失敗しました"))
+    else:
+        # Fallback view from session state
+        prev_res = st.session_state.get(f"{SYSTEM_NAME}_results_df")
+        prev_data = st.session_state.get(f"{SYSTEM_NAME}_prepared_dict")
+        prev_cap = st.session_state.get(f"{SYSTEM_NAME}_capital_saved")
+        if prev_res is not None:
+            _ = show_signal_trade_summary(
+                prev_data,
+                prev_res,
+                SYSTEM_NAME,
+                display_name=DISPLAY_NAME,
+            )
+            try:
+                from common.ui_components import show_results
+
+                show_results(
+                    prev_res,
+                    prev_cap or 0.0,
+                    SYSTEM_NAME,
+                    key_context="prev",
+                )
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "streamlit" not in sys.argv[0]:
+        run_tab()

--- a/common/alpaca_order.py
+++ b/common/alpaca_order.py
@@ -162,6 +162,8 @@ def submit_orders_df(
         "system2": "limit",
         "system6": "limit",
         "system7": "limit",
+        # System8: MOC エントリー / MOO エグジット。既定は市場成行扱い。
+        "system8": "market",
     }
     sys_map = (system_order_type or {}) | default_sys_map  # defaultを下敷き
 

--- a/common/notifier.py
+++ b/common/notifier.py
@@ -68,6 +68,7 @@ SYSTEM_POSITION: dict[str, str] = {
     "system5": "long",
     "system6": "short",
     "system7": "short",
+    "system8": "long",
 }
 
 COLOR_LONG = 0x2ECC71

--- a/common/system_constants.py
+++ b/common/system_constants.py
@@ -20,6 +20,7 @@ MIN_ROWS_SYSTEM4 = 200  # SMA200 + HV50 必要
 MIN_ROWS_SYSTEM5 = 150  # ADX7 + ATR ベース
 MIN_ROWS_SYSTEM6 = 100  # 比較的短期指標
 MIN_ROWS_SYSTEM7 = 150  # SPY専用、基本指標
+MIN_ROWS_SYSTEM8 = 150  # SPY専用、イベント駆動（指標不要）
 
 # === System1 (Long ROC200) 定数 ===
 SYSTEM1_ROC_PERIOD = 200
@@ -80,6 +81,15 @@ SYSTEM6_DOLLAR_VOLUME_PERIOD = 50
 # === System7 (SPY short catastrophe hedge) 定数 ===
 SYSTEM7_SYMBOL = "SPY"  # 固定シンボル
 SYSTEM7_MIN_ROWS = 150
+
+# === System8 (SPY overnight FOMC pre-drift) 定数 ===
+# イベント駆動（予定 FOMC 声明日の前営業日にロング, T 寄りで手仕舞い）。
+# 指標は使わず、data/events/fomc.csv の予定声明日から setup を決める。
+# 出所: 別リポジトリ n0150_fomc_macro_event_drift_spy (rules_frozen.md v03)。
+SYSTEM8_SYMBOL = "SPY"  # 固定シンボル（ロング専用）
+SYSTEM8_MIN_ROWS = 150
+# 往復コスト（bp）: Alpaca 手数料 $0 + SPY スプレッド ~0.5-1bp/片道 = 2bp RT。
+SYSTEM8_COST_BPS_ROUNDTRIP = 2.0
 
 # === エントリー対象から除外するヘッジ/インデックス銘柄 (systems 1-6) ===
 # docs/systems/INDEX.md: システム7 は「SPY 固定のヘッジ戦略（変更禁止）」、
@@ -166,6 +176,10 @@ SYSTEM7_REQUIRED_INDICATORS = [
     "max_70",  # Max_70 - 70日の最高価格
 ]
 
+# System8 はイベント駆動（FOMC カレンダー）で指標を必要としない。
+# setup は prepare_data が data/events/fomc.csv から付与する（OHLC のみ使用）。
+SYSTEM8_REQUIRED_INDICATORS: list[str] = []
+
 # === システム別設定マッピング ===
 SYSTEM_CONFIGS = {
     "system1": {
@@ -219,6 +233,13 @@ SYSTEM_CONFIGS = {
         "min_rows": MIN_ROWS_SYSTEM7,
         "required_indicators": SYSTEM7_REQUIRED_INDICATORS,
         "symbol": SYSTEM7_SYMBOL,
+    },
+    "system8": {
+        "min_rows": MIN_ROWS_SYSTEM8,
+        "required_indicators": SYSTEM8_REQUIRED_INDICATORS,
+        "symbol": SYSTEM8_SYMBOL,
+        # 往復コスト（bp）。EA/約定側で参照可能なメタ。
+        "cost_bps_roundtrip": SYSTEM8_COST_BPS_ROUNDTRIP,
     },
 }
 
@@ -352,6 +373,7 @@ __all__ = [
     "MIN_ROWS_SYSTEM5",
     "MIN_ROWS_SYSTEM6",
     "MIN_ROWS_SYSTEM7",
+    "MIN_ROWS_SYSTEM8",
     # システム別必須指標
     "SYSTEM1_REQUIRED_INDICATORS",
     "SYSTEM2_REQUIRED_INDICATORS",
@@ -360,8 +382,11 @@ __all__ = [
     "SYSTEM5_REQUIRED_INDICATORS",
     "SYSTEM6_REQUIRED_INDICATORS",
     "SYSTEM7_REQUIRED_INDICATORS",
+    "SYSTEM8_REQUIRED_INDICATORS",
     # ヘッジ/インデックス除外 (systems 1-6 エントリー universe)
     "SYSTEM7_SYMBOL",
+    "SYSTEM8_SYMBOL",
+    "SYSTEM8_COST_BPS_ROUNDTRIP",
     "HEDGE_INDEX_SYMBOLS",
     # 設定管理
     "SYSTEM_CONFIGS",

--- a/common/system_constants.py
+++ b/common/system_constants.py
@@ -180,16 +180,52 @@ SYSTEM7_REQUIRED_INDICATORS = [
 # setup は prepare_data が data/events/fomc.csv から付与する（OHLC のみ使用）。
 SYSTEM8_REQUIRED_INDICATORS: list[str] = []
 
+# === システムの血統 (lineage) ===
+# System1-7 と System8 は **出自も設計思想も別物** であり、後任が「同じ枠組みの 8 番目」と
+# 誤解しないよう、ここを血統の正準定義とする（表示・doc・ダッシュはすべてここを参照）。
+#
+#   - ``bensdorp``: Laurens Bensdorp の自動売買システム本に準拠した定型システム群。
+#     広いユニバースに指標フィルター + セットアップを当て、ランキング上位 N を取る
+#     モメンタム / 平均回帰 × ロング / ショートの組み合わせ（System7 の SPY ヘッジを含む）。
+#   - ``original``: 当リポジトリ独自開発。Bensdorp 準拠ではない。
+#     現状 System8 のみ（FOMC 声明日のオーバーナイト・ドリフト＝イベントドリブン）。
+#     指標クロスでも top-N ストックピッキングでもなく、イベントカレンダーが setup を決める。
+#
+# 詳細と背景は docs/SYSTEM_LINEAGE.md を参照。
+LINEAGE_BENSDORP = "bensdorp"
+LINEAGE_ORIGINAL = "original"
+
+SYSTEM_LINEAGE: dict[str, str] = {
+    "system1": LINEAGE_BENSDORP,
+    "system2": LINEAGE_BENSDORP,
+    "system3": LINEAGE_BENSDORP,
+    "system4": LINEAGE_BENSDORP,
+    "system5": LINEAGE_BENSDORP,
+    "system6": LINEAGE_BENSDORP,
+    "system7": LINEAGE_BENSDORP,
+    # System8 のみ独自開発。ここを bensdorp に書き換えてはいけない。
+    "system8": LINEAGE_ORIGINAL,
+}
+
+# 表示用の短いラベル（UI / 通知 / ダッシュのバッジ文言はここに揃える）。
+LINEAGE_LABELS: dict[str, str] = {
+    LINEAGE_BENSDORP: "Bensdorp 準拠",
+    LINEAGE_ORIGINAL: "独自開発 (event-driven)",
+}
+
+
 # === システム別設定マッピング ===
 SYSTEM_CONFIGS = {
     "system1": {
         "min_rows": MIN_ROWS_SYSTEM1,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM1_REQUIRED_INDICATORS,
         "min_price": SYSTEM1_MIN_PRICE,
         "min_dollar_volume": SYSTEM1_MIN_DOLLAR_VOLUME,
     },
     "system2": {
         "min_rows": MIN_ROWS_SYSTEM2,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM2_REQUIRED_INDICATORS,
         "min_price": SYSTEM2_MIN_PRICE,
         "min_dollar_volume": SYSTEM2_MIN_DOLLAR_VOLUME,
@@ -198,6 +234,7 @@ SYSTEM_CONFIGS = {
     },
     "system3": {
         "min_rows": MIN_ROWS_SYSTEM3,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM3_REQUIRED_INDICATORS,
         "min_price": SYSTEM3_MIN_PRICE,
         "min_avg_volume_50": SYSTEM3_MIN_AVG_VOLUME_50,
@@ -206,6 +243,7 @@ SYSTEM_CONFIGS = {
     },
     "system4": {
         "min_rows": MIN_ROWS_SYSTEM4,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM4_REQUIRED_INDICATORS,
         "min_price": SYSTEM4_MIN_PRICE,
         "min_dollar_volume": SYSTEM4_MIN_DOLLAR_VOLUME,
@@ -213,6 +251,7 @@ SYSTEM_CONFIGS = {
     },
     "system5": {
         "min_rows": MIN_ROWS_SYSTEM5,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM5_REQUIRED_INDICATORS,
         "min_price": SYSTEM5_MIN_PRICE,
         # audit-remediation 2026-07-03 (D3 Case A): 流動性 filter を新設。
@@ -224,6 +263,7 @@ SYSTEM_CONFIGS = {
     },
     "system6": {
         "min_rows": MIN_ROWS_SYSTEM6,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM6_REQUIRED_INDICATORS,
         "min_price": SYSTEM6_MIN_PRICE,
         "min_dollar_volume": SYSTEM6_MIN_DOLLAR_VOLUME,
@@ -231,11 +271,13 @@ SYSTEM_CONFIGS = {
     },
     "system7": {
         "min_rows": MIN_ROWS_SYSTEM7,
+        "lineage": LINEAGE_BENSDORP,
         "required_indicators": SYSTEM7_REQUIRED_INDICATORS,
         "symbol": SYSTEM7_SYMBOL,
     },
     "system8": {
         "min_rows": MIN_ROWS_SYSTEM8,
+        "lineage": LINEAGE_ORIGINAL,
         "required_indicators": SYSTEM8_REQUIRED_INDICATORS,
         "symbol": SYSTEM8_SYMBOL,
         # 往復コスト（bp）。EA/約定側で参照可能なメタ。
@@ -359,6 +401,26 @@ def get_system_config(system_name: str) -> dict:
     return SYSTEM_CONFIGS[system_name.lower()]
 
 
+def get_system_lineage(system_name: str) -> str:
+    """指定されたシステムの血統 (lineage) を返す。
+
+    System1-7 は ``"bensdorp"``（Laurens Bensdorp の本に準拠した定型システム群）、
+    System8 は ``"original"``（当リポジトリ独自開発の event-driven）。
+    表示・レポート・ダッシュはこの関数（または :data:`SYSTEM_LINEAGE`）を単一の
+    出所として使い、system 番号から血統を推測しないこと。
+
+    Args:
+        system_name: システム名（例: "system1", "System8"）
+
+    Returns:
+        ``"bensdorp"`` または ``"original"``
+
+    Raises:
+        KeyError: 未知のシステム名の場合
+    """
+    return SYSTEM_LINEAGE[system_name.lower()]
+
+
 __all__ = [
     # 基本定数
     "REQUIRED_COLUMNS",
@@ -388,6 +450,12 @@ __all__ = [
     "SYSTEM8_SYMBOL",
     "SYSTEM8_COST_BPS_ROUNDTRIP",
     "HEDGE_INDEX_SYMBOLS",
+    # 血統 (bensdorp 準拠 / 独自開発) — docs/SYSTEM_LINEAGE.md
+    "LINEAGE_BENSDORP",
+    "LINEAGE_ORIGINAL",
+    "SYSTEM_LINEAGE",
+    "LINEAGE_LABELS",
+    "get_system_lineage",
     # 設定管理
     "SYSTEM_CONFIGS",
     "get_system_config",

--- a/common/system_groups.py
+++ b/common/system_groups.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+# System8 は SPY オーバーナイト FOMC ドリフト（ロング方向）。System1/3/5 のような
+# 「普通株プールから top-N を選ぶ」ロング・ストックピッキングではなく、単一銘柄の
+# イベント駆動スリーブ。ここでの分類は *建玉方向（side）* の表示グルーピングに過ぎず、
+# 資金配分プール（long_allocations / short_allocations）への参加を意味しない
+# （System8 は配分ウェイト未登録＝資金は割り当てられない。config/settings.py 参照）。
 SYSTEM_SIDE_GROUPS: dict[str, tuple[str, ...]] = {
-    "long": ("system1", "system3", "system5"),
+    "long": ("system1", "system3", "system5", "system8"),
     "short": ("system2", "system4", "system6", "system7"),
 }
 
@@ -14,7 +19,7 @@ SYSTEM_SIDE_GROUPS: dict[str, tuple[str, ...]] = {
 GROUP_ORDER: tuple[str, ...] = tuple(SYSTEM_SIDE_GROUPS.keys())
 
 GROUP_DISPLAY_NAMES: dict[str, str] = {
-    "long": "Long (System1,3,5)",
+    "long": "Long (System1,3,5,8)",
     "short": "Short (System2,4,6,7)",
 }
 
@@ -27,6 +32,7 @@ SYSTEM_LABELS: dict[str, str] = {
     "system5": "System5",
     "system6": "System6",
     "system7": "System7",
+    "system8": "System8",
 }
 
 

--- a/common/system_groups.py
+++ b/common/system_groups.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from common.system_constants import LINEAGE_LABELS, LINEAGE_ORIGINAL, SYSTEM_LINEAGE
+
+# 血統マーカー: 独自開発（Bensdorp 準拠でない）system に付ける控えめな印。
+# 表示は控えめでよいが、Bensdorp 系（System1-7）と混同されないことを優先する。
+# ダッシュ側の同等定義は apps/dashboards/alpaca-next/lib/format.ts。
+LINEAGE_MARKER = "◆"
+
 # System8 は SPY オーバーナイト FOMC ドリフト（ロング方向）。System1/3/5 のような
 # 「普通株プールから top-N を選ぶ」ロング・ストックピッキングではなく、単一銘柄の
 # イベント駆動スリーブ。ここでの分類は *建玉方向（side）* の表示グルーピングに過ぎず、
@@ -19,11 +26,13 @@ SYSTEM_SIDE_GROUPS: dict[str, tuple[str, ...]] = {
 GROUP_ORDER: tuple[str, ...] = tuple(SYSTEM_SIDE_GROUPS.keys())
 
 GROUP_DISPLAY_NAMES: dict[str, str] = {
-    "long": "Long (System1,3,5,8)",
+    # System8 は建玉方向こそ long だが Bensdorp 系の long プール（1/3/5）とは別系統
+    # なので、同列に並べずマーカー付きで区別する。
+    "long": f"Long (System1,3,5 / System8{LINEAGE_MARKER})",
     "short": "Short (System2,4,6,7)",
 }
 
-# システムラベルの正規化対応表
+# システムラベルの正規化対応表（純粋な ID。血統マーカーは付けない）
 SYSTEM_LABELS: dict[str, str] = {
     "system1": "System1",
     "system2": "System2",
@@ -40,6 +49,27 @@ def _normalize_system_name(name: str) -> str:
     if not isinstance(name, str):
         return ""
     return name.strip().lower()
+
+
+def lineage_marker(system_name: str) -> str:
+    """独自開発 system なら血統マーカーを、Bensdorp 系/未知なら空文字を返す。"""
+    norm = _normalize_system_name(system_name)
+    return LINEAGE_MARKER if SYSTEM_LINEAGE.get(norm) == LINEAGE_ORIGINAL else ""
+
+
+def format_system_label(system_name: str) -> str:
+    """血統マーカー付きの表示ラベルを返す（例: ``"System8◆"`` / ``"System1"``）。
+
+    表示専用。JSON key や突合には :data:`SYSTEM_LABELS` / 生の system 名を使うこと。
+    """
+    norm = _normalize_system_name(system_name)
+    base = SYSTEM_LABELS.get(norm, _format_label(norm))
+    return f"{base}{lineage_marker(norm)}"
+
+
+def lineage_legend() -> str:
+    """マーカーの意味を 1 行で説明する凡例文字列。"""
+    return f"{LINEAGE_MARKER} = {LINEAGE_LABELS[LINEAGE_ORIGINAL]}"
 
 
 def _format_label(name: str) -> str:

--- a/common/system_setup_predicates.py
+++ b/common/system_setup_predicates.py
@@ -345,6 +345,16 @@ def system7_setup_predicate(row: pd.Series) -> bool:
         return False
 
 
+# --- System8 (Long overnight FOMC pre-drift) ---------------------------------
+# 条件: その日が予定 FOMC 声明日の前営業日 T-1（= prepare_data で付与された
+# ``setup`` 列が True）。カレンダー駆動のため指標条件は持たない。
+def system8_setup_predicate(row: pd.Series) -> bool:
+    try:
+        return bool(row.get("setup", False))
+    except Exception:
+        return False
+
+
 # --- System6 (Short momentum) ------------------------------------------------
 # 条件: return_6d > 0.20 and uptwodays == True
 def system6_setup_predicate(row: pd.Series) -> bool:
@@ -375,6 +385,8 @@ SETUP_PREDICATES: Mapping[str, Callable[..., bool]] = {
     "System6": system6_setup_predicate,
     "7": system7_setup_predicate,
     "System7": system7_setup_predicate,
+    "8": system8_setup_predicate,
+    "System8": system8_setup_predicate,
 }
 
 
@@ -395,6 +407,7 @@ __all__ = [
     "system5_setup_predicate",
     "system6_setup_predicate",
     "system7_setup_predicate",
+    "system8_setup_predicate",
     "get_system_setup_predicate",
     "SETUP_PREDICATES",
     "DEFAULT_ATR_PCT_THRESHOLD",

--- a/common/ui_components.py
+++ b/common/ui_components.py
@@ -783,7 +783,8 @@ def run_backtest_app(
         st.success(tr("cache cleared"))
 
     # シンボル選択処理（サイドバーで定義済みの変数を使用）
-    if system_name == "System7":
+    # System7（SPY ヘッジ）と System8（SPY FOMC ドリフト）はどちらも SPY 単一銘柄。
+    if system_name in ("System7", "System8"):
         symbols = ["SPY"]
     elif use_auto:
         if st.session_state.get(f"{system_name}_use_all_common", False):

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,6 +101,17 @@ strategies:
     single_mode: false
     # 当日抽出の上限（SPY 単一想定だが整合性のため設定）
     top_n_rank: 10
+  system8:
+    # System8: SPY オーバーナイト FOMC プレドリフト（イベント駆動・ロング専用）。
+    # 出所リポジトリ n0150_fomc_macro_event_drift_spy の凍結ルール v03。
+    # ストップなし・等ノーショナル・往復 2bp。指標は使わず data/events/fomc.csv 駆動。
+    cost_bps_roundtrip: 2.0  # 往復コスト（bp）
+    # 等ノーショナルの建玉割合（現在資本 × position_pct、[0,1] にクランプ＝無レバレッジ）。
+    # 単一銘柄・同時1ポジションのため既定は満額（1.0）。バックテスト/デモの検証用に調整可。
+    position_pct: 1.0
+    top_n_rank: 1  # SPY 単一・イベントごと最大1件
+    # 注: 実資金配分ウェイト（long_allocations / short_allocations）には *意図的に*
+    # 未登録。配分参加は repo オーナーの経営判断。docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md 参照。
 
 data:
   vendor: EODHD

--- a/core/system1.py
+++ b/core/system1.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System1（ロング ROC200 モメンタム）のエントリー・ランキング・フィルタロジック専門
 #
 # 前提条件：

--- a/core/system2.py
+++ b/core/system2.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System2（ショート RSI スパイク）のエントリー・ランキング・フィルタロジック専門
 #
 # 前提条件：

--- a/core/system3.py
+++ b/core/system3.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System3（ロング ミーン・リバージョン 3 日ドロップ）のロジック専門
 #
 # 前提条件：

--- a/core/system4.py
+++ b/core/system4.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System4（ロング トレンド ロー・ボラティリティ）のロジック専門
 #
 # 前提条件：

--- a/core/system5.py
+++ b/core/system5.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System5（ロング ミーン・リバージョン 高 ADX）のロジック専門
 #
 # 前提条件（audit-remediation 2026-07-03 D3 Case A で docs 完全準拠に是正）：

--- a/core/system6.py
+++ b/core/system6.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System6（ショート ミーン・リバージョン 高シックスデイサージ）のロジック専門
 #
 # 前提条件：

--- a/core/system7.py
+++ b/core/system7.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System7（SPY ショート カタストロフィー・ヘッジ）のロジック専門
 #
 # ⚠️ CRITICAL: System7 は SPY 固定のヘッジ専用。ロジック変更・他銘柄割当は禁止

--- a/core/system8.py
+++ b/core/system8.py
@@ -1,0 +1,391 @@
+# ============================================================================
+# 🧠 Context Note
+# このファイルは System8（SPY オーバーナイト FOMC ドリフト）のロジック専門
+#
+# ⚠️ CRITICAL: System8 は SPY 固定・ロング専用・イベントカレンダー駆動。
+#   指標クロスではなく「翌営業日が FOMC 声明日か」で setup を決める構造。
+#   ロジック変更・他銘柄割当・イベント種別追加（CPI/NFP/QQQ 等）は禁止。
+#
+# 前提条件（凍結ルール v03 — 出所リポジトリ n0150_fomc_macro_event_drift_spy）：
+#   - SPY のみ・ロングのみ・同時保有は1ポジション
+#   - イベント源: data/events/fomc.csv の「予定された FOMC 声明日」のみ（年8回）。
+#     臨時会合・電話会議・議事録公表日・非取引日開催は対象外（自動で除外）。
+#   - エントリー: 声明日 T の前営業日 T-1 の引け（MOC）でロング
+#   - エグジット: 声明日 T の寄り（MOO）で手仕舞い（14:00 ET 発表は持ち越さない）
+#   - サイジング: イベントごとに等ノーショナル・無レバレッジ・ナンピン/マーチン禁止
+#   - ストップ: なし（1泊のイベント保有。リスクはサイジングで制御）
+#   - コスト: 往復 2bp（Alpaca 手数料 $0 + SPY スプレッド ~0.5-1bp/片道）
+#
+# ロジック単位：
+#   prepare_data_vectorized_system8() → SPY データ + FOMC カレンダーから setup 付与
+#   generate_candidates_system8()     → T-1 setup 日を候補化（等ノーショナル用 payload）
+#
+# Copilot へ：
+#   → SPY 以外・イベント種別追加・レジームゲート等の「改良」は絶対に足すな（凍結 v03）
+#   → 声明日が非取引日なら当該イベントは丸ごと落とす（メイクアップ日なし）
+# ============================================================================
+
+"""System8 core logic (SPY overnight FOMC pre-drift)。
+
+System8 は SPY 専用のイベント駆動戦略のため、System1-6 の指標/セットアップ
+テンプレート（フィルター→ランキング）には当てはまらない。「今日が予定 FOMC 声明日
+の前営業日 (T-1) か」だけが setup 条件であり、実約定は T-1 の引け（MOC）と
+声明日 T の寄り（MOO）で完結する 1 泊のオーバーナイト保有。
+
+出所（別リポジトリ・監査証跡）:
+    strategies/n0150_fomc_macro_event_drift_spy/rules_frozen.md (v03, GO_CANDIDATE)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# === System8 configuration constants ===
+SYSTEM8_SYMBOL = "SPY"  # 固定シンボル（ロング専用）
+# 往復コスト（bp）。Alpaca 手数料 $0 + SPY スプレッド ~0.5-1bp/片道 = 2bp RT。
+SYSTEM8_COST_BPS_ROUNDTRIP = 2.0
+# 既定のイベントカレンダー（git 追跡の静的参照データ）。
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FOMC_CALENDAR_PATH = _PROJECT_ROOT / "data" / "events" / "fomc.csv"
+# 「予定された声明」として扱う event_type（臨時会合等は含めない）。
+_SCHEDULED_EVENT_TYPES = frozenset({"fomc"})
+
+
+def load_fomc_event_dates(
+    calendar_path: str | Path | None = None,
+) -> pd.DatetimeIndex:
+    """FOMC 予定声明日を正規化した DatetimeIndex で返す。
+
+    Args:
+        calendar_path: fomc.csv のパス。None なら DEFAULT_FOMC_CALENDAR_PATH。
+
+    Returns:
+        重複除去・昇順ソート済みの声明日 DatetimeIndex（tz-naive・normalize 済み）。
+        ファイル欠損や読み込み失敗時は空の DatetimeIndex。
+    """
+    path = (
+        Path(calendar_path) if calendar_path is not None else DEFAULT_FOMC_CALENDAR_PATH
+    )
+    if not path.exists():
+        logger.warning("System8: FOMC calendar not found at %s", path)
+        return pd.DatetimeIndex([])
+    try:
+        df = pd.read_csv(path)
+    except Exception as e:  # pragma: no cover - 防御
+        logger.warning("System8: failed to read FOMC calendar %s: %s", path, e)
+        return pd.DatetimeIndex([])
+    if "event_date" not in df.columns:
+        logger.warning("System8: FOMC calendar missing 'event_date' column")
+        return pd.DatetimeIndex([])
+    # event_type があれば予定声明のみに絞る（無ければ全行を声明扱い）。
+    if "event_type" in df.columns:
+        type_norm = df["event_type"].astype(str).str.strip().str.lower()
+        df = df[type_norm.isin(_SCHEDULED_EVENT_TYPES)]
+    dates = pd.to_datetime(df["event_date"], errors="coerce").dropna()
+    normalized = pd.DatetimeIndex(dates).normalize().unique().sort_values()
+    return normalized
+
+
+def _next_nyse_trading_day(ts: pd.Timestamp) -> pd.Timestamp:
+    """``ts`` の翌 NYSE 取引日を返す（見つからなければ NaT）。
+
+    実運用環境では repo 正準の ``common.utils_spy.resolve_signal_entry_date`` を使う
+    （System7 と同一のカレンダー基準）。当該モジュールは指標スタック（ta 等）を
+    import するため、それが利用できない環境では pandas_market_calendars に直接
+    フォールバックする（System8 をイベント計算に対して自己完結にするため）。
+    """
+    ts = pd.Timestamp(ts).normalize()
+    try:  # canonical path（本番環境）
+        from common.utils_spy import resolve_signal_entry_date
+
+        nxt = resolve_signal_entry_date(ts)
+        if nxt is not None and not pd.isna(nxt):
+            return pd.Timestamp(nxt).normalize()
+    except Exception as e:  # pragma: no cover - 指標スタック未整備時のみ
+        logger.debug("System8: utils_spy unavailable, using mcal fallback: %s", e)
+    try:  # fallback: 市場カレンダー直接
+        import pandas_market_calendars as mcal
+
+        nyse = mcal.get_calendar("NYSE")
+        sched = nyse.schedule(
+            start_date=ts + pd.Timedelta(days=1),
+            end_date=ts + pd.Timedelta(days=10),
+        )
+        valid = pd.to_datetime(sched.index).normalize()
+        future = valid[valid > ts]
+        if len(future) > 0:
+            return pd.Timestamp(future.min()).normalize()
+    except Exception as e:  # pragma: no cover - カレンダー未整備時
+        logger.debug("System8: mcal next-trading-day failed: %s", e)
+    return pd.NaT
+
+
+def _normalized_index(df_raw: pd.DataFrame) -> pd.DataFrame:
+    """入力 SPY DataFrame の index を tz-naive・normalize 済み日付に揃える。"""
+    if "Date" in df_raw.columns:
+        df = df_raw.copy()
+        df.index = pd.Index(pd.to_datetime(df["Date"]).dt.normalize())
+    else:
+        df = df_raw.copy()
+        df.index = pd.Index(pd.to_datetime(df.index).normalize())
+    return df
+
+
+def prepare_data_vectorized_system8(
+    raw_data_dict: dict[str, pd.DataFrame] | None,
+    *,
+    fomc_calendar_path: str | Path | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
+    log_callback: Callable[[str], None] | None = None,
+    skip_callback: Callable[[str], None] | None = None,
+    reuse_indicators: bool = True,
+    **kwargs: Any,
+) -> dict[str, pd.DataFrame]:
+    """SPY データに FOMC カレンダー由来の setup を付与して返す。
+
+    System8 は指標を必要とせず、OHLC と FOMC カレンダーのみで setup を決める。
+    付与カラム:
+      - ``fomc_event``: その日が予定 FOMC 声明日 T か（取引日として index に存在する場合）
+      - ``setup``: その日が声明日の前営業日 T-1 か（= エントリー実行日）
+      - ``fomc_event_date``: setup 日に対応する声明日 T（それ以外は NaT）
+
+    非取引日に落ちた声明日は SPY index に存在しないため、その T-1 も生成されず
+    イベントごと丸ごと除外される（凍結ルール「メイクアップ日なし」を満たす）。
+    """
+    prepared_dict: dict[str, pd.DataFrame] = {}
+    raw_data_dict = raw_data_dict or {}
+    try:
+        df_raw = raw_data_dict.get(SYSTEM8_SYMBOL)
+        if df_raw is None:
+            raise ValueError(f"{SYSTEM8_SYMBOL} data missing")
+        df = _normalized_index(df_raw)
+
+        event_dates = load_fomc_event_dates(fomc_calendar_path)
+
+        n = len(df)
+        setup = np.zeros(n, dtype=bool)
+        fomc_event = np.zeros(n, dtype=bool)
+        event_date_col: list[Any] = [pd.NaT] * n
+
+        if n > 0 and len(event_dates) > 0:
+            # index 上で FOMC 声明日に一致する行位置（= 取引日 T）。
+            event_mask = df.index.isin(event_dates)
+            fomc_event = np.asarray(event_mask, dtype=bool)
+            event_positions = np.flatnonzero(event_mask)
+            for pos in event_positions:
+                if pos - 1 < 0:
+                    # T-1 が履歴外（最初の行が声明日）→ エントリー不能につき除外。
+                    continue
+                setup[pos - 1] = True
+                event_date_col[pos - 1] = df.index[pos]
+
+            # 前方（ライブ/当日）エッジ: 最終行の翌 NYSE 取引日が予定 FOMC 声明日なら、
+            # その声明日 T はまだ価格 index に現れていない（未来の暦日）ため上の
+            # ヒストリカル判定では拾えない。最終行のみ市場カレンダーで T-1 を判定する。
+            # （声明日が非取引日なら翌取引日が T をスキップ→ setup にならず、イベントは
+            # 自然に除外される。）
+            last_pos = n - 1
+            if not setup[last_pos] and not fomc_event[last_pos]:
+                nxt = _next_nyse_trading_day(df.index[last_pos])
+                if nxt is not None and not pd.isna(nxt) and nxt in event_dates:
+                    setup[last_pos] = True
+                    event_date_col[last_pos] = nxt
+
+        df["fomc_event"] = fomc_event
+        df["setup"] = setup
+        df["fomc_event_date"] = pd.Series(event_date_col, index=df.index)
+
+        prepared_dict[SYSTEM8_SYMBOL] = df
+    except Exception as e:
+        logger.debug("System8: Failed to prepare data for %s: %s", SYSTEM8_SYMBOL, e)
+        if skip_callback:
+            try:
+                skip_callback(f"{SYSTEM8_SYMBOL} の処理をスキップしました: {e}")
+            except Exception:
+                pass
+
+    if log_callback:
+        try:
+            n_setup = (
+                int(prepared_dict[SYSTEM8_SYMBOL]["setup"].sum())
+                if SYSTEM8_SYMBOL in prepared_dict
+                else 0
+            )
+            log_callback(
+                f"SPY FOMC カレンダー適用完了（setup=T-1 引け, exit=T 寄り, "
+                f"setup 日数={n_setup}）"
+            )
+        except Exception:
+            pass
+    if progress_callback:
+        try:
+            progress_callback(1, 1)
+        except Exception:
+            pass
+
+    return prepared_dict
+
+
+def _build_setup_payload(
+    df: pd.DataFrame, setup_date: pd.Timestamp
+) -> dict[str, object]:
+    """setup 日（T-1）の候補 payload を作る。
+
+    entry_price は setup 日終値（MOC の proxy。シグナル生成時点で確定済みの既知値で
+    look-ahead ではない）。exit（T 寄り）は未来値のため backtest 側で参照する。
+    """
+    row = df.loc[setup_date]
+    event_date = row.get("fomc_event_date")
+    close_val = row.get("Close")
+    payload: dict[str, object] = {
+        "entry_date": setup_date,  # MOC 実行日（T-1）
+        "event_date": event_date,  # FOMC 声明日 T
+        "exit_date": event_date,  # MOO 実行日（= T）
+        "entry_price": (float(close_val) if pd.notna(close_val) else None),
+        "stop_price": None,  # ストップなし（1泊イベント保有）
+    }
+    return payload
+
+
+def generate_candidates_system8(
+    prepared_dict: dict[str, pd.DataFrame],
+    *,
+    top_n: int | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
+    log_callback: Callable[[str], None] | None = None,
+    batch_size: int | None = None,
+    latest_only: bool = False,
+    include_diagnostics: bool = False,
+    **kwargs: Any,
+) -> (
+    tuple[dict[pd.Timestamp, dict[str, dict[str, object]]], pd.DataFrame | None]
+    | tuple[
+        dict[pd.Timestamp, dict[str, dict[str, object]]],
+        pd.DataFrame | None,
+        dict[str, Any],
+    ]
+):
+    """System8 候補を生成する。
+
+    候補は「エントリー実行日（T-1）」でキーした dict-of-dicts
+    ``{Timestamp(setup_date): {"SPY": payload}}`` で返す（System1-7 と同じ器）。
+    System8 は SPY 単一・イベントごと最大1件のため top_n は実質無効。
+    """
+    diagnostics: dict[str, Any] = {
+        "ranking_source": None,
+        "setup_predicate_count": 0,
+        "ranked_top_n_count": 0,
+        "predicate_only_pass_count": 0,
+        "mismatch_flag": 0,
+    }
+
+    def _ret(
+        normalized: dict[pd.Timestamp, dict[str, dict[str, object]]],
+        merged: pd.DataFrame | None,
+    ):
+        if progress_callback:
+            try:
+                progress_callback(1, 1)
+            except Exception:
+                pass
+        if include_diagnostics:
+            return (normalized, merged, diagnostics)
+        return (normalized, merged)
+
+    df = prepared_dict.get(SYSTEM8_SYMBOL) if prepared_dict else None
+    if df is None or df.empty or "setup" not in df.columns:
+        return _ret({}, None)
+
+    # === Fast Path（当日シグナル抽出用）===
+    if latest_only:
+        last_date = df.index[-1]
+        try:
+            is_setup = bool(df.iloc[-1].get("setup", False))
+        except Exception:
+            is_setup = False
+        if not is_setup:
+            if log_callback:
+                try:
+                    log_callback(
+                        f"System8: latest_only 0 candidates. "
+                        f"date={pd.Timestamp(last_date).date()} setup=False"
+                    )
+                except Exception:
+                    pass
+            return _ret({}, None)
+        payload = _build_setup_payload(df, pd.Timestamp(last_date))
+        normalized = {pd.Timestamp(last_date): {SYSTEM8_SYMBOL: payload}}
+        diagnostics["ranking_source"] = "latest_only"
+        diagnostics["setup_predicate_count"] = 1
+        diagnostics["ranked_top_n_count"] = 1
+        df_fast = pd.DataFrame(
+            [{"symbol": SYSTEM8_SYMBOL, "date": pd.Timestamp(last_date), "rank": 1}]
+        )
+        if log_callback:
+            try:
+                log_callback("System8: latest_only fast-path -> 1 candidate")
+            except Exception:
+                pass
+        return _ret(normalized, df_fast)
+
+    # === Full Historical Path（backtest）===
+    try:
+        setup_days = df.index[df["setup"].to_numpy(dtype=bool)]
+    except Exception as e:
+        logger.debug("System8: Failed to select setup days: %s", e)
+        setup_days = pd.DatetimeIndex([])
+
+    normalized_full: dict[pd.Timestamp, dict[str, dict[str, object]]] = {}
+    for setup_date in setup_days:
+        ts = pd.Timestamp(setup_date)
+        payload = _build_setup_payload(df, ts)
+        # 声明日 T が index 外（=非取引日に落ちた）の場合は候補化しない。
+        event_date = payload.get("event_date")
+        if event_date is None or pd.isna(event_date):
+            continue
+        normalized_full[ts] = {SYSTEM8_SYMBOL: payload}
+
+    diagnostics["ranking_source"] = "full_scan"
+    diagnostics["setup_predicate_count"] = len(normalized_full)
+    diagnostics["ranked_top_n_count"] = 1 if normalized_full else 0
+
+    if log_callback:
+        try:
+            log_callback(
+                f"候補日数: {len(normalized_full)}（予定 FOMC 声明日の前営業日 T-1）"
+            )
+        except Exception:
+            pass
+    return _ret(normalized_full, None)
+
+
+def get_total_days_system8(data_dict: dict[str, pd.DataFrame]) -> int:
+    """データに含まれるユニーク日数（System7 と同じ集計）。"""
+    all_dates: set[Any] = set()
+    for df in data_dict.values():
+        if df is None or df.empty:
+            continue
+        if "Date" in df.columns:
+            dates = pd.to_datetime(df["Date"]).dt.normalize()
+        else:
+            dates = pd.to_datetime(df.index).normalize()
+        all_dates.update(dates)
+    return len(all_dates)
+
+
+__all__ = [
+    "SYSTEM8_SYMBOL",
+    "SYSTEM8_COST_BPS_ROUNDTRIP",
+    "DEFAULT_FOMC_CALENDAR_PATH",
+    "load_fomc_event_dates",
+    "prepare_data_vectorized_system8",
+    "generate_candidates_system8",
+    "get_total_days_system8",
+]

--- a/core/system8.py
+++ b/core/system8.py
@@ -1,5 +1,10 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: original (in-house) — **Bensdorp 準拠ではない**。当リポジトリ独自開発の
+#   イベントドリブン戦略 (FOMC 声明日のオーバーナイト・ドリフト)。System1-7 (bensdorp 系)
+#   とは設計思想が根本的に異なり、指標クロスでも top-N ストックピッキングでもない。
+#   出所は別リポジトリの研究成果 n0150_fomc_macro_event_drift_spy (凍結ルール v03)。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは System8（SPY オーバーナイト FOMC ドリフト）のロジック専門
 #
 # ⚠️ CRITICAL: System8 は SPY 固定・ロング専用・イベントカレンダー駆動。

--- a/data/events/fomc.csv
+++ b/data/events/fomc.csv
@@ -1,0 +1,177 @@
+event_date,event_time_utc,event_type,actual,forecast,previous,surprise_z,source,fetch_ts
+2006-01-31,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-03-28,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-05-10,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-06-29,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-08-08,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-09-20,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-10-25,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2006-12-12,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-01-31,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-03-21,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-05-09,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-06-28,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-08-07,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-09-18,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-10-31,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2007-12-11,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-01-30,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-03-18,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-04-30,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-06-25,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-08-05,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-09-16,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-10-29,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2008-12-16,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-01-28,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-03-18,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-04-29,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-06-24,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-08-12,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-09-23,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-11-04,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2009-12-16,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-01-27,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-03-16,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-04-28,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-06-23,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-08-10,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-09-21,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-11-03,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2010-12-14,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-01-26,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-03-15,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-04-27,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-06-22,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-08-09,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-09-21,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-11-02,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2011-12-13,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-01-25,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-03-13,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-04-25,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-06-20,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-08-01,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-09-13,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-10-24,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2012-12-12,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-01-30,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-03-20,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-05-01,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-06-19,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-07-31,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-09-18,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-10-30,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2013-12-18,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-01-29,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-03-19,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-04-30,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-06-18,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-07-30,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-09-17,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-10-29,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2014-12-17,19:15,fomc,,,,,federalreserve.gov fomchistorical archive (scheduled meetings; statement=last day),2026-07-15T15:58:42.638350+00:00
+2015-01-28,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-03-18,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-04-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-06-17,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-07-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-09-17,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-10-28,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2015-12-16,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-01-27,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-03-16,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-04-27,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-06-15,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-07-27,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-09-21,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-11-02,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2016-12-14,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-02-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-03-15,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-05-03,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-06-14,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-07-26,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-09-20,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-11-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2017-12-13,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-01-31,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-03-21,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-05-02,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-06-13,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-08-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-09-26,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-11-08,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2018-12-19,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-01-30,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-03-20,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-05-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-06-19,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-07-31,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-09-18,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-10-30,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2019-12-11,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-01-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-03-15,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-04-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-06-10,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-07-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-09-16,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-11-05,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2020-12-16,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-01-27,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-03-17,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-04-28,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-06-16,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-07-28,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-09-22,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-11-03,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2021-12-15,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-01-26,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-03-16,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-05-04,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-06-15,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-07-27,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-09-21,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-11-02,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2022-12-14,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-02-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-03-22,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-05-03,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-06-14,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-07-26,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-09-20,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-11-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2023-12-13,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-01-31,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-03-20,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-05-01,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-06-12,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-07-31,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-09-18,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-11-07,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2024-12-18,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-01-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-03-19,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-05-07,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-06-18,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-07-30,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-09-17,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-10-29,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2025-12-10,18:00,fomc,,,,,federalreserve.gov FOMC calendar archive,2026-04-19T13:32:07.209090+00:00
+2026-01-28,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-03-18,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-04-29,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-06-17,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-07-29,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-09-16,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-10-28,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2026-12-09,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-01-27,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-03-17,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-04-28,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-06-09,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-07-28,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-09-15,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-10-27,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00
+2027-12-08,18:00,fomc,,,,,federalreserve.gov/monetarypolicy/fomccalendars.htm fetch 2026-05-18,2026-05-18T11:03:50.238751+00:00

--- a/docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md
+++ b/docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md
@@ -1,0 +1,128 @@
+# System8 — SPY オーバーナイト FOMC プレドリフト移植記録 (2026-07-16)
+
+## 1. 出所 (source of truth)
+
+本戦略は **別リポジトリ** で研究・凍結・独立レビュー・封印(sealed)テスト済みの
+検証済みエッジを、当リポジトリの System8 として移植したもの。**新規の探索・最適化は
+一切していない**（凍結ルール v03 をそのまま実装）。
+
+- 出所リポジトリ（ローカル参照）: `/home/user/mt5_Bundle-of-edges`
+- 戦略 ID: `n0150_fomc_macro_event_drift_spy`
+- 凍結ルール: `strategies/n0150_fomc_macro_event_drift_spy/rules_frozen.md`（v03, 唯一の正）
+- 証跡チェーン: `strategies/n0150_fomc_macro_event_drift_spy/STATUS.md`
+- FOMC カレンダー原本: `data/events/fomc.csv`（当リポジトリへ同一内容を複製）
+
+### 出所リポジトリでのステータスと主要証跡（再検証不要・参考）
+
+- ステータス: **GO_CANDIDATE**（2026-07-16 宣言, SEALED_PASS 後）
+- フルヒストリ 2006-2025 の canonical `passes_oos`: 3 レジーム軸すべて PASS,
+  **t = +3.280**, n = 159, MinTRL 35.3, **DSR(n_trials=3) = 0.9955**
+- 独立 GO レビュー（レビュアー ≠ 最適化者, ゼロからの再実装）: **CONFIRM**
+  （全ヘッドライン数値を完全再現）
+- 封印 2025 単発テスト: **SEALED_PASS**（2025 セル n=8 mean +8.76bp, 5/8 positive）
+
+## 2. 実装した凍結ルール（v03 そのまま）
+
+- **銘柄**: SPY のみ。**ロングのみ**。同時保有は1ポジション。
+- **イベント源**: `data/events/fomc.csv` の**予定された FOMC 声明日のみ**（年8回）。
+  電話会議・臨時/緊急会合・議事録公表日は対象外。声明日が**非取引日**に落ちた場合は
+  当該イベントを**丸ごと除外**（メイクアップ日なし）。
+- **エントリー**: 声明日 T の前営業日 **T-1 の引け（MOC）** でロング。
+- **エグジット**: 声明日 **T の寄り（MOO）**。1泊のオーバーナイト保有のみ。
+  14:00 ET の発表は**絶対に持ち越さない**。
+- **サイジング**: イベントごと等ノーショナル・無レバレッジ・ナンピン/マーチン禁止。
+- **ストップ**: なし（1泊のイベント保有。リスクはサイジングで制御）。
+- **コスト**: 往復 **2bp**（Alpaca 手数料 $0 + SPY スプレッド ~0.5-1bp/片道）。
+  → 当リポジトリのライブ執行ブローカーも Alpaca のため前提はそのまま引き継ぎ。
+
+### 明示的にスコープ外（出所リポジトリで却下/保留。実装しない）
+
+- 日中 2pm→2pm ウィンドウ版
+- QQQ 第2レッグ / CPI・NFP レッグ
+- VIX/vol/レジームゲート、サプライズ符号条件付け
+
+## 3. 当リポジトリでの実装（構造の違い）
+
+System8 は System1-6 の「広いユニバースから top-N を選ぶ」パターンにも、System7 の
+「指標セットアップ + ATR ストップ」にも当てはまらない**イベントカレンダー駆動**戦略。
+「今日が予定 FOMC 声明日の前営業日 (T-1) か」だけが setup。
+
+- `core/system8.py` — カレンダー読込 + setup 付与 + 候補生成
+  - `load_fomc_event_dates()` / `prepare_data_vectorized_system8()`（`setup`/`fomc_event`/
+    `fomc_event_date` 列を付与, 指標不要）/ `generate_candidates_system8()`
+  - 前方（ライブ/当日）エッジ: 最終行の翌 NYSE 取引日が声明日なら setup。
+    正準は `common.utils_spy.resolve_signal_entry_date`（System7 と同基準）、
+    それが import 不能な環境では `pandas_market_calendars` に直接フォールバック。
+- `strategies/system8_strategy.py` — `System8Strategy(AlpacaOrderMixin, StrategyBase)`
+  - `get_trading_side()="long"`, 等ノーショナル `calculate_position_size`（ストップ非依存）、
+    T-1 引け→T 寄りの 1 泊オーバーナイト `run_backtest`（往復2bp を控除）。
+- `data/events/fomc.csv` — git 追跡の静的参照データ（`data_cache/` はキャッシュで gitignore の
+  ため不可）。出所リポジトリと同一内容（2006-2027, 年8回）。
+
+## 4. 配線したもの / あえて配線しなかったもの
+
+### 配線した（バックテスト・診断・UI 可視化の範囲。ライブ発注ではない）
+
+| 箇所 | 内容 |
+|---|---|
+| `strategies/__init__.py` | `get_strategy("system8")` ファクトリ登録 |
+| `common/system_constants.py` | `SYSTEM8_*` 定数 + `SYSTEM_CONFIGS["system8"]`（指標不要） |
+| `common/system_groups.py` | side グルーピング（long 側）+ ラベル |
+| `common/system_setup_predicates.py` | `system8_setup_predicate` + レジストリ |
+| `common/notifier.py` | `SYSTEM_POSITION["system8"]="long"` |
+| `common/alpaca_order.py` | 既定オーダータイプ `system8:"market"`（MOC/MOO） |
+| `config/config.yaml` | `strategies.system8`（cost 2bp / position_pct / top_n）。**配分ウェイトではない** |
+| `apps/systems/app_system8.py` + `apps/app_integrated.py` + `common/ui_components.py` | Streamlit の System8 タブ（SPY 単一バックテスト/診断表示） |
+| `tests/test_system8.py` | 決定的テスト（ネットワーク無し, 12 件 PASS） |
+
+**side グルーピングの判断**: System8 は建玉方向としては long だが、System1/3/5 のような
+「普通株プールから top-N を選ぶ」ストックピッキングではなく、単一銘柄のイベント駆動
+スリーブ。新しいグループ概念は導入せず `SYSTEM_SIDE_GROUPS["long"]` に追加したが、
+これは**表示上の side 分類**に過ぎず、**資金配分プール（long_allocations /
+short_allocations）への参加を意味しない**（下記参照）。
+
+### あえて配線しなかった（人間の判断待ち）
+
+- **実資金の配分ウェイト**（`config/settings.py` の `long_allocations` /
+  `short_allocations`、`config/config.yaml` の同名セクション、
+  `core/final_allocation.py` の `DEFAULT_LONG/SHORT_ALLOCATIONS`）。
+  → System8 を加えると既存 7 システムからペーパー資金が黙って移動するため未登録。
+- **ライブ日次自動発注ループ**（`scripts/run_all_systems_today.py` /
+  `scripts/build_execution_recon.py` / スケジューラ `.ps1`）。これらは `range(1, 8)` で
+  システムを列挙しており、**あえて `range(1, 9)` に上げていない**。
+- 統合バックテスト/配分ビューの列挙ループ（`core/final_allocation.py:1064` order,
+  `common/integrated_backtest.py`, `common/stage_metrics.py` 等）も未変更のため、
+  System8 は**自分専用の System8 タブ**でのみ実行・可視化される（System7 と同様）。
+
+## 5. ライブに載せるとき（将来）に変える箇所
+
+コードパスは実装済みで壊れていない。ライブ化する際は以下を**人間の判断で**行う:
+
+1. **配分ウェイト付与**: `config/config.yaml` の `short_allocations`/`long_allocations`
+   （および `config/settings.py`・`core/final_allocation.py` の既定）を、合計 1.0 を
+   保ったまま再配分して `system8: <weight>` を追加。System8 を**別スリーブ**として
+   既存プールから独立させるか、既存プール内で薄めるかも経営判断。
+2. **ライブ列挙ループ**: `scripts/run_all_systems_today.py` の `range(1, 8)` 群
+   （L1259 / L3145 / L4084 / L5003 / L5362 / L5597）と `order_1_7`、
+   `scripts/build_execution_recon.py:38` を System8 込みに拡張。ただし System8 は
+   MOC/MOO 執行（当日引け発注 + 翌寄り決済）で他システム（翌寄り成行）と執行タイミングが
+   異なるため、`common/today_signals.py` の per-system 分岐と exit スケジューリング
+   （`schedulers/next_day_exits.py`）に System8 用の MOC/MOO 経路を追加する必要がある。
+3. **今日シグナル配線**: `common/today_signals.py` の `LONG_SYSTEMS` / `STOP_ATR_MULTIPLE`
+   / SPY 単一分岐に System8 を追加（当日 latest_only 経路は core 側で実装済み）。
+4. **フォワード監視**: 出所リポジトリの forward kill trigger（N=16 events で cum mean<0 →
+   demote, < −10bp/event → HARD_KILL）と、各イベントが実際に約定したかの発注ログ監査を
+   移植（Alpaca 版の attach 検証）。
+
+## 6. 検証結果
+
+- `pytest tests/test_system8.py`: **12 passed**（ネットワーク無し・決定的）。
+- `ruff check` / `black --check` / `isort --check`: 新規・変更ファイルすべて clean。
+- ライブ/ペーパー Alpaca 発注は一切実行していない。スケジューラ登録 `.ps1` も未変更。
+
+## 7. 監査証跡へのポインタ
+
+- 凍結ルール: 出所リポジトリ `strategies/n0150_fomc_macro_event_drift_spy/rules_frozen.md`
+- 証跡チェーン: 出所リポジトリ `strategies/n0150_fomc_macro_event_drift_spy/STATUS.md`
+- 独立レビュー: 出所リポジトリ
+  `reports/go_reviews/fomc_macro_event_drift_spy_n0150_go_review_20260716.md`

--- a/docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md
+++ b/docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md
@@ -1,5 +1,16 @@
 # System8 — SPY オーバーナイト FOMC プレドリフト移植記録 (2026-07-16)
 
+> **🧬 lineage: original (in-house) — Bensdorp 準拠ではない**
+>
+> System1-7 は Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+> （広いユニバース → 指標フィルター → セットアップ → 上位 N ランキングの
+> モメンタム / 平均回帰 × ロング / ショート）だが、**System8 だけは当リポジトリ
+> 独自開発**のイベントドリブン戦略で、設計思想が根本的に異なる。
+> 番号が連番だからといって「同じ枠組みの 8 番目」と扱わないこと。
+>
+> 血統の正準定義は `common/system_constants.py` の `SYSTEM_LINEAGE`、
+> 背景と記録場所の一覧は `docs/SYSTEM_LINEAGE.md`。
+
 ## 1. 出所 (source of truth)
 
 本戦略は **別リポジトリ** で研究・凍結・独立レビュー・封印(sealed)テスト済みの

--- a/docs/SYSTEM8_MIGRATION_PROMPT_20260716.md
+++ b/docs/SYSTEM8_MIGRATION_PROMPT_20260716.md
@@ -1,0 +1,80 @@
+# System8 移植作業 — 委譲時の元プロンプト (2026-07-16)
+
+`core/system8.py` / `strategies/system8_strategy.py` 等一式を実装したエージェント
+(opus, worktree 隔離)に与えた元の指示を、そのまま記録として残す。
+
+**目的**: 保留2件(下記 (a)(b))を人間が直接進める際、実装エージェントが最初に
+何を前提として作業したか(スコープ、禁止事項、参照ファイル)を再現できるようにする。
+続きを別セッション/別エージェントに投げる場合は、このプロンプトをベースに
+「(a) 資金配分ウェイトの決定」「(b) ライブ日次自動発注ループへの統合」の
+2点だけを追加指示すればよい設計にしてある。
+
+---
+
+## 元プロンプト(委譲時、原文ママ)
+
+```
+You are working in the repo at /workspace/quant_trading_system_0510to0906 (a Streamlit-based systematic trading app with 7 existing strategies, "System1" through "System7", each implemented as a paired core/systemN.py + strategies/systemN_strategy.py module, wired into shared allocation/backtest/live-Alpaca-trading infrastructure). The user (the repo's owner) wants a validated new strategy — an overnight SPY drift around scheduled FOMC statements — ported in and registered as "System8", following this repo's existing conventions as closely as possible.
+
+## Where the strategy comes from (a SEPARATE repo, already cloned locally at /home/user/mt5_Bundle-of-edges — you may read files there directly, e.g. via `cat` or a Read-equivalent tool, but do not modify anything in that repo)
+
+The strategy was fully researched, frozen, independently reviewed, and sealed-tested in that other repo as `n0150_fomc_macro_event_drift_spy`. Full evidence chain:
+- `strategies/n0150_fomc_macro_event_drift_spy/rules_frozen.md` — the frozen rule spec (read this file directly; it is the single source of truth for the exact mechanics)
+- `strategies/n0150_fomc_macro_event_drift_spy/STATUS.md` — full evidence chain / gate history
+- `data/events/fomc.csv` — the canonical FOMC scheduled-statement calendar (8 events/year, 2006-2027), which the strategy trades directly off of. You should copy/adapt this calendar into the quant repo as static, git-tracked reference data (NOT under `data_cache/` which is gitignored cache — check `.gitignore` and existing `data/` layout in the quant repo, or place it under `config/` if that fits this repo's convention better; use your judgment based on how this repo stores other static reference inputs, and document wherever you put it).
+
+Exact frozen mechanics (also verify by reading rules_frozen.md yourself, this is a paraphrase):
+- Instrument: SPY only, long only, one position at a time.
+- Event source: scheduled FOMC statement days only (8/yr) — conference calls, unscheduled/emergency meetings, minutes-release days are NOT events. A statement falling on a non-trading day drops that event entirely (no makeup day).
+- Entry: market-on-close (MOC) of the trading session T-1 (the session immediately before the FOMC statement day T).
+- Exit: market-on-open (MOO) of the statement day T itself. This is a single-overnight hold — NEVER hold through the 14:00 ET announcement itself.
+- Sizing: equal notional per event, no leverage, no averaging, no martingale.
+- Stop: none (single-night event hold; risk is bounded by position sizing, not a stop-loss).
+- Cost model used in research: 2bp round-trip (assumed $0 commission + ~0.5-1bp SPY spread per side — this matches Alpaca, which is also this repo's live broker, so the cost assumption should carry over cleanly).
+- Explicitly OUT of scope (do not implement, these were explicitly rejected/deferred in the source repo): any intraday 2pm-to-2pm window variant, any second instrument leg (QQQ), any CPI/NFP event legs, any vol/regime gate, any signal-sign conditioning. Implement ONLY the exact frozen v03 rule above.
+
+Evidence status (for your context/docs, not something you need to re-derive): full-history 2006-2025 canonical passes_oos (a statistical honesty-battery framework specific to the source repo) PASSED on all 3 regime axes, t=+3.280, DSR(n_trials=3)=0.9955; independent review (different reviewer than the original author) reproduced every number exactly; sealed 2025-only one-shot test also passed. Status in the source repo is `GO_CANDIDATE`. This is a well-validated, not speculative, strategy — implement it faithfully and exactly, do not add embellishments, filters, or "improvements" beyond the frozen spec.
+
+## What "register as System8" means in THIS repo — study before you write code
+
+Before writing anything, thoroughly study how System7 is built and wired, since it is the closest existing analog (SPY-only, single-fixed-symbol, NOT part of the "pick top-N candidates from a broad universe" pattern that Systems 1-6 use). Read in full:
+- `strategies/base_strategy.py` (the abstract base all systems inherit)
+- `strategies/system7_strategy.py` (the wrapper/orchestration layer)
+- `core/system7.py` (the core signal logic — find and read it; system7_strategy.py imports from it)
+- `common/alpaca_order.py` (AlpacaOrderMixin, used by System7Strategy — figure out if/how it should apply to System8 too)
+- `common/system_constants.py` (System7's constants block, e.g. `SYSTEM7_SYMBOL`, `SYSTEM7_MIN_ROWS`, `SYSTEM7_REQUIRED_INDICATORS`, and the `SYSTEM_CONFIG`-style dict keyed by "system7")
+- `common/system_groups.py` (`SYSTEM_SIDE_GROUPS`, `GROUP_DISPLAY_NAMES`, `SYSTEM_LABELS` — note System8 does NOT cleanly fit the existing "long"/"short" stock-picking-pool framing the same way System7 doesn't; use your judgment on whether it needs a new grouping concept, and clearly document your reasoning)
+- `config/settings.py` — find where systems are enumerated, where system-specific params live (`get_system_params`), and where the live capital-allocation weights live (there are `long_allocations` / `short_allocations`-style dicts, e.g. system7 currently gets a 20% weight within some short-side allocation pool). **Do NOT add System8 into these live capital-allocation weight dicts** — that would silently divert real (paper-trading) capital away from the 7 systems that are already running live. This decision (how much capital, if any, to give System8, and whether it shares the existing systems' allocation pool or runs as a separate sleeve) is a business decision for the repo owner, not something you should decide. Just make sure System8 is otherwise fully wired/registered/testable, and flag the allocation-weight question explicitly and prominently in your final report.
+- `tests/test_system7.py` (or the closest equivalent) for the testing pattern — determinism via `freezegun`/`monkeypatch`, no live network calls, uses cached/fixture data.
+- grep for other files that reference "system7" (you can run `grep -rl "system7" --include="*.py" .` from the repo root) to find the FULL set of integration touch-points (things like `common/system_setup_predicates.py`, `common/today_signals.py`, `common/strategy_runner.py`, `common/symbol_universe.py`, `common/notifier.py`, `apps/systems/app_system7.py`, `common/ui_tabs.py`, etc.) — for each, decide whether System8 genuinely needs the same wiring (likely yes for things like signal generation, backtest running, diagnostics, UI tab so the owner can see/run it in the Streamlit app) versus things that would put it into the LIVE DAILY AUTOMATED TRADING LOOP with real order placement (e.g. `scripts/run_all_systems_today.py`, live scheduler registration scripts like `register_task_scheduler.ps1`/`start_scheduler.ps1`, or anything that would cause Alpaca orders to actually fire automatically). For the live-automation / actual-order-placement layer specifically: implement the code path so it CAN be wired in later (i.e. don't leave it broken or half-implemented), but do NOT flip it live yourself — i.e. don't add System8 to whatever list/config currently drives the actual daily automated order-placement job, and clearly flag in your report exactly what would need to change to go live and where.
+
+## What to build
+
+1. `core/system8.py` — the core signal/candidate-generation logic (event-calendar-driven, not indicator-crossing like the other systems — this is a structurally different kind of system, so don't force-fit indicator/setup patterns that don't apply; a "setup" here is simply "is today T-1 relative to a scheduled FOMC date").
+2. `strategies/system8_strategy.py` — the wrapper, following the `StrategyBase` interface and System7Strategy's orchestration pattern (prepare_data / generate_candidates / run_backtest / position sizing — equal-notional sizing per the frozen spec, not ATR-risk sizing since there's no stop).
+3. The FOMC calendar as git-tracked static data, sourced from the other repo's `data/events/fomc.csv`, in whatever location/format fits this repo's conventions.
+4. Registration in `common/system_constants.py` and `common/system_groups.py` (with your documented reasoning on grouping) and `config/settings.py` (system-specific params — cost model 2bp RT, no stop, equal-notional sizing — but NOT the live capital-allocation weight, per above).
+5. `tests/test_system8.py` following this repo's existing test conventions (deterministic, no network, use a small fixture SPY price series + a few known FOMC dates).
+6. UI wiring so the owner can see/run System8 in the Streamlit app the same way they can for System7 (check `apps/systems/app_system7.py` and `common/ui_tabs.py` for the pattern) — backtest/diagnostics visibility, NOT live-order wiring.
+7. A short migration doc under `docs/` (follow this repo's existing naming convention, e.g. `docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md`) that records: where this strategy came from (source repo path, `n0150_fomc_macro_event_drift_spy`, GO_CANDIDATE status, the key evidence numbers above), the exact frozen rule, what you wired vs. explicitly did NOT wire (capital allocation weight, live daily automation), and a pointer back to the source repo's STATUS.md/rules_frozen.md for full audit trail.
+
+## Process requirements
+
+- Follow this repo's conventions closely: Japanese comments/docstrings (per `docs/internal/AGENTS.md`: "言語方針: 回答・コメントは日本語"), PEP8, type hints, `snake_case`/`PascalCase` naming, ruff/black/isort-clean.
+- Run `ruff check`, `black --check`, `isort --check` (or the repo's actual lint commands — check `.pre-commit-config.yaml` / `Makefile` for the exact invocations) on your new/changed files and fix any issues.
+- Run `pytest tests/test_system8.py -q` (and any other tests you touched) and make sure they pass.
+- Do NOT run or modify anything that would place a live/paper Alpaca order, and do NOT touch the live scheduler registration scripts.
+- Do NOT commit or push — just leave the changes in your isolated worktree. Report back the worktree path/branch, a summary of every file you created or changed and why, the lint/test results, and — most importantly — a clearly separated "PENDING DECISIONS FOR THE OWNER" section listing: (a) the capital-allocation-weight question, (b) exactly what would need to change to put System8 into the live daily automated trading loop, and (c) anything else you deliberately left unwired pending a human decision.
+
+Keep your final report focused and skimmable — file list with one-line rationale each, lint/test pass/fail, then the pending-decisions section. Don't dump full file contents into your report; the reviewer will read the diff directly.
+```
+
+## 実行結果サマリ(このプロンプトを与えた結果)
+
+- worktree: `system8-fomc-drift` ブランチ、12 ファイル変更(新規6 + 追記9、うち1件重複ノーカウント)。
+- `pytest tests/test_system8.py`: 12 passed(セッション本体でも独立再検証済み)。
+- `ruff check` / `black --check` / `isort --check`: 新規・変更ファイルすべて clean(独立再検証済み)。
+- `data/events/fomc.csv`: 出所リポジトリとバイト完全一致を確認済み。
+- 保留2件は本ドキュメントと同ディレクトリの
+  `docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md` §4-5 に詳細記載
+  (資金配分ウェイト / ライブ日次自動発注ループへの統合)。

--- a/docs/SYSTEM_LINEAGE.md
+++ b/docs/SYSTEM_LINEAGE.md
@@ -1,0 +1,81 @@
+# システムの血統 (lineage) — System1-7 と System8 は別系統
+
+**目的**: 「System8」という番号だけを見て「System1-7 と同じ枠組みの 8 番目」と
+誤解されるのを恒久的に防ぐ。番号は連番でも、**出自も設計思想も別物**である。
+
+作成: 2026-07-28（System8 を main に land した際に併設）
+
+---
+
+## 1. 2 つの血統
+
+| lineage | 該当 | 出自 | 骨格 |
+|---|---|---|---|
+| `bensdorp` | System1 – System7 | Laurens Bensdorp の自動売買システム本に準拠した定型システム群 | 広いユニバース → 指標フィルター → セットアップ → ランキング上位 N。モメンタム / 平均回帰 × ロング / ショートの組み合わせ |
+| `original` | System8 のみ | **当リポジトリ独自開発**（Bensdorp 準拠ではない） | イベントカレンダー駆動。指標クロスでも top-N ストックピッキングでもない |
+
+### System1-7 (`bensdorp`)
+
+Bensdorp 本の定型パターンに沿った 7 本。System7 だけは SPY 固定の
+カタストロフィー・ヘッジだが、**指標セットアップ + ATR ストップ**という
+骨格は共有しており、血統としては同じ `bensdorp` に属する。
+
+### System8 (`original`)
+
+SPY オーバーナイト FOMC プレドリフト。予定 FOMC 声明日 T の前営業日 T-1 の
+引け（MOC）でロングし、T の寄り（MOO）で手仕舞う 1 泊のイベント保有。
+
+- セットアップは指標ではなく **`data/events/fomc.csv` のカレンダー**が決める
+  （「翌営業日が予定 FOMC 声明日か」だけが条件）。
+- ストップなし・等ノーショナル・同時 1 ポジション。
+- 出所は別リポジトリの研究成果 `n0150_fomc_macro_event_drift_spy`（凍結ルール v03）。
+  証跡は `docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md` を参照。
+
+**思想が根本的に違う**ため、System1-7 に効くチューニング・共通化・
+リファクタの前提を System8 にそのまま当てはめてはいけない。
+逆も同じ（System8 のイベント駆動構造を 1-7 に一般化しない）。
+
+---
+
+## 2. どこに血統が記録されているか
+
+血統は 1 か所で決め、他はすべてそこを参照する。
+
+### 正準（single source of truth）
+
+- `common/system_constants.py`
+  - `SYSTEM_LINEAGE: dict[str, str]` — system 名 → `"bensdorp"` / `"original"`
+  - `LINEAGE_BENSDORP` / `LINEAGE_ORIGINAL` / `LINEAGE_LABELS`
+  - `get_system_lineage(system_name)` — 番号から推測せずここを引く
+  - `SYSTEM_CONFIGS[<system>]["lineage"]` — 既存の設定辞書からも辿れる
+    （`SYSTEM_LINEAGE` との一致は `tests/test_system_lineage.py` が強制）
+
+### 表示・派生
+
+- `common/system_groups.py`
+  - `LINEAGE_MARKER = "◆"`、`lineage_marker()` / `format_system_label()` /
+    `lineage_legend()`
+  - `GROUP_DISPLAY_NAMES["long"]` は System8 を 1/3/5 と同列に並べず
+    `Long (System1,3,5 / System8◆)` と区別して表示する
+- 各実装ファイルの先頭 `🧬 Lineage:` 行
+  - `core/system1..8.py`、`strategies/system1..8_strategy.py`
+- ダッシュボード `apps/dashboards/alpaca-next/lib/format.ts`
+  - `SYSTEM_LINEAGE` / `LINEAGE_MARKER` / `LINEAGE_LEGEND` / `sysLineage()`
+  - `sysShort('system8')` → `S8◆`（全チップに自動で印が付く）
+  - Signal Pipeline の System8 行には「独自」バッジ、凡例を各所に併記
+
+**新しい system を足すときは `common/system_constants.py` の `SYSTEM_LINEAGE` と
+`format.ts` の同名マップの両方を更新すること。** 片方だけだと表示と実体がずれる。
+
+---
+
+## 3. 血統と「ライブ配線」は別の話
+
+血統の区別は**分類**であって、稼働状態ではない。2026-07-28 時点で System8 は
+main に統合済みだが、以下は**意図的に未配線**（人間の判断待ち）:
+
+- 実資金の配分ウェイト（`long_allocations` / `short_allocations`）— 未登録
+- ライブ日次自動発注ループ（`scripts/run_all_systems_today.py` 等の `range(1, 8)`）— 未拡張
+- runner ツリー（`C:\tmp\qts-main-run`）への arm — 未実施
+
+詳細は `docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md` §4-5。

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -34,6 +34,7 @@ _CLASS_MAP = {
     "system5": ("strategies.system5_strategy", "System5Strategy"),
     "system6": ("strategies.system6_strategy", "System6Strategy"),
     "system7": ("strategies.system7_strategy", "System7Strategy"),
+    "system8": ("strategies.system8_strategy", "System8Strategy"),
 }
 
 

--- a/strategies/system1_strategy.py
+++ b/strategies/system1_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system1.py を Streamlit UI 用に適応させるラッパー層。バックテスト＆当日実行両対応
 #
 # 前提条件：

--- a/strategies/system2_strategy.py
+++ b/strategies/system2_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system2.py（ショート RSI スパイク）を UI 用に適応させるラッパー層
 #
 # 前提条件：

--- a/strategies/system3_strategy.py
+++ b/strategies/system3_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system3.py（ロング ミーン・リバージョン）を UI 用に適応させるラッパー層
 #
 # 前提条件：

--- a/strategies/system4_strategy.py
+++ b/strategies/system4_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system4.py（ロング トレンド ロー・ボラティリティ）を UI 用に適応させるラッパー層
 #
 # 前提条件：

--- a/strategies/system5_strategy.py
+++ b/strategies/system5_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system5.py（ロング ミーン・リバージョン 高 ADX）を UI 用に適応させるラッパー層
 #
 # 前提条件：

--- a/strategies/system6_strategy.py
+++ b/strategies/system6_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system6.py（ショート ミーン・リバージョン 高シックスデイサージ）を UI 用に適応させるラッパー層
 #
 # 前提条件：

--- a/strategies/system7_strategy.py
+++ b/strategies/system7_strategy.py
@@ -1,5 +1,9 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: bensdorp — Laurens Bensdorp の自動売買システム本に準拠した定型システム群
+#   (System1-7)。モメンタム / 平均回帰 × ロング / ショートの組み合わせという共通骨格を持つ。
+#   System8 だけは血統が異なる (独自開発の event-driven)。混同しないこと。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system7.py（SPY ショート カタストロフィー・ヘッジ）を UI 用に適応させるラッパー層
 #
 # ⚠️ CRITICAL: System7 は SPY 固定のヘッジ専用。ロジック変更・他銘柄割当は禁止

--- a/strategies/system8_strategy.py
+++ b/strategies/system8_strategy.py
@@ -1,0 +1,277 @@
+# ============================================================================
+# 🧠 Context Note
+# このファイルは core/system8.py（SPY オーバーナイト FOMC ドリフト）を UI/バックテスト
+# 向けに適応させるラッパー層
+#
+# ⚠️ CRITICAL: System8 は SPY 固定・ロング専用・イベント駆動（凍結ルール v03）。
+#   ロジック本体は core/system8.py。ここは orchestration とバックテスト約定のみ。
+#
+# 前提条件：
+#   - エントリー: 声明日 T の前営業日 T-1 の引け（MOC）でロング
+#   - エグジット: 声明日 T の寄り（MOO）で手仕舞い（1泊のオーバーナイト保有）
+#   - サイジング: イベントごと等ノーショナル・無レバレッジ・ストップなし
+#   - コスト: 往復 2bp
+#
+# Copilot へ：
+#   → core のロジック変更は core/system8.py で実施
+#   → ATR リスクサイジング/ストップは System8 には存在しない（等ノーショナル）
+#   → イベント種別追加・レジームゲート等の「改良」は凍結 v03 につき禁止
+# ============================================================================
+
+"""System8 strategy — SPY overnight FOMC pre-drift (event-calendar driven)。
+
+System1-6 の「広いユニバースから top-N を選ぶ」パターンにも、System7 の
+「指標セットアップ + ATR ストップ」パターンにも当てはまらない。setup は
+「翌営業日が予定 FOMC 声明日か」のみで、約定は T-1 引け → T 寄りの 1 泊。
+
+出所: 別リポジトリ n0150_fomc_macro_event_drift_spy（rules_frozen.md v03,
+GO_CANDIDATE）。監査証跡は docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md を参照。
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+import pandas as pd
+
+from common.alpaca_order import AlpacaOrderMixin
+from core.system8 import (
+    SYSTEM8_COST_BPS_ROUNDTRIP,
+    SYSTEM8_SYMBOL,
+    generate_candidates_system8,
+    get_total_days_system8,
+    prepare_data_vectorized_system8,
+)
+
+from .base_strategy import StrategyBase
+
+
+class System8Strategy(AlpacaOrderMixin, StrategyBase):
+    """SPY 専用のオーバーナイト FOMC プレドリフト（ロング）。
+
+    - セットアップ: 翌営業日が予定 FOMC 声明日 T（= 当日は T-1）
+    - エントリー: T-1 の引け（MOC）でロング
+    - エグジット: T の寄り（MOO）
+    - サイジング: 等ノーショナル（現在資本 × position_pct）、無レバレッジ、ストップなし
+    - コスト: 往復 2bp
+    """
+
+    SYSTEM_NAME = "system8"
+
+    def get_trading_side(self) -> str:
+        """System8 はロング戦略。"""
+        return "long"
+
+    # ------------------------------------------------------------------
+    # データ準備 / 候補生成
+    # ------------------------------------------------------------------
+    def prepare_data(
+        self,
+        raw_data_or_symbols: dict | list,
+        reuse_indicators: bool | None = None,
+        **kwargs,
+    ) -> dict:
+        """System8 のデータ準備（共通テンプレート使用）。
+
+        core 側は指標を必要とせず OHLC + FOMC カレンダーのみで setup を付与する。
+        """
+        kwargs.pop("single_mode", None)
+        return self._prepare_data_template(
+            raw_data_or_symbols,
+            prepare_data_vectorized_system8,
+            reuse_indicators=reuse_indicators,
+            **kwargs,
+        )
+
+    def generate_candidates(
+        self,
+        data_dict: dict,
+        market_df: pd.DataFrame | None = None,
+        **kwargs,
+    ) -> tuple[dict, pd.DataFrame | None]:
+        """T-1 setup 日を候補化して (candidates_by_date, merged_df) を返す。"""
+        kwargs.pop("single_mode", None)
+        result = generate_candidates_system8(
+            data_dict,
+            include_diagnostics=True,
+            **kwargs,
+        )
+        if isinstance(result, tuple) and len(result) == 3:
+            candidates_by_date, merged_df, diagnostics = result
+            self.last_diagnostics = diagnostics
+            return (candidates_by_date, merged_df)
+        if isinstance(result, tuple) and len(result) == 2:
+            self.last_diagnostics = None
+            return result
+        self.last_diagnostics = None
+        return (result, None)
+
+    # ------------------------------------------------------------------
+    # サイジング（等ノーショナル / ストップなし）
+    # ------------------------------------------------------------------
+    def calculate_position_size(
+        self,
+        capital: float,
+        entry_price: float,
+        stop_price: float | None = None,
+        *,
+        risk_pct: float | None = None,
+        max_pct: float | None = None,
+        **kwargs,
+    ) -> int:
+        """等ノーショナルのポジションサイズ（株数）を返す。
+
+        System8 にはストップが無いためリスク幅ベースのサイジングは使わない。
+        現在資本 × position_pct を entry_price で割った株数（切り捨て）。
+        position_pct は無レバレッジ前提で [0, 1] にクランプ（既定 1.0）。
+        """
+        capital_val = self._safe_float(capital)
+        entry_val = self._safe_float(entry_price)
+        if capital_val <= 0 or entry_val <= 0:
+            return 0
+        # 単一銘柄・同時1ポジション・無レバレッジのため既定は満額（1.0）。
+        position_pct = self._resolve_pct(max_pct, "position_pct", 1.0)
+        position_pct = max(0.0, min(1.0, position_pct))  # 無レバレッジ
+        if position_pct == 0.0:
+            return 0
+        shares = math.floor((capital_val * position_pct) / entry_val)
+        return max(int(shares), 0)
+
+    # ------------------------------------------------------------------
+    # バックテスト（T-1 引け → T 寄りの 1 泊オーバーナイト）
+    # ------------------------------------------------------------------
+    def run_backtest(
+        self,
+        data_dict: dict,
+        candidates_by_date: dict,
+        capital: float,
+        **kwargs,
+    ) -> pd.DataFrame:
+        """イベントごとに 1 泊のオーバーナイト損益を積み上げる。
+
+        同時保有は構造上発生しない（イベントは数週間以上離れている）。
+        """
+        results: list[dict] = []
+        if SYSTEM8_SYMBOL not in data_dict:
+            return pd.DataFrame()
+
+        df: pd.DataFrame = data_dict[SYSTEM8_SYMBOL]
+        if df is None or df.empty:
+            return pd.DataFrame()
+
+        on_progress = kwargs.get("on_progress")
+        on_log = kwargs.get("on_log")
+        start_time = time.time()
+
+        cost_bps = float(
+            self.config.get("cost_bps_roundtrip", SYSTEM8_COST_BPS_ROUNDTRIP)
+        )
+        cost_frac = cost_bps / 1e4  # 往復コスト（比率）
+
+        capital_current = float(capital)
+        items = sorted(candidates_by_date.items())
+        total = len(items)
+
+        for i, (setup_date, cand) in enumerate(items, 1):
+            for payload in self._iter_payloads(cand):
+                trade = self._simulate_event(
+                    df, setup_date, payload, capital_current, cost_frac
+                )
+                if trade is None:
+                    continue
+                capital_current += float(trade["pnl"])
+                results.append(trade)
+
+            if on_progress:
+                try:
+                    on_progress(i, total, start_time)
+                except Exception:
+                    pass
+            if on_log and (i % 10 == 0 or i == total):
+                try:
+                    on_log(f"💹 バックテスト進捗 {int(i)}/{int(total)} イベント")
+                except Exception:
+                    pass
+
+        return pd.DataFrame(results)
+
+    @staticmethod
+    def _iter_payloads(cand: Any) -> list[dict]:
+        """candidates_by_date の値（{"SPY": payload} / list / dict）を payload 列に正規化。"""
+        if isinstance(cand, dict):
+            # {"SPY": payload} 形式
+            if SYSTEM8_SYMBOL in cand and isinstance(cand[SYSTEM8_SYMBOL], dict):
+                return [cand[SYSTEM8_SYMBOL]]
+            # {symbol: payload, ...} 形式
+            payloads = [v for v in cand.values() if isinstance(v, dict)]
+            if payloads:
+                return payloads
+            # payload 自体が dict のケース
+            if "entry_date" in cand or "event_date" in cand:
+                return [cand]
+            return []
+        if isinstance(cand, list):
+            return [v for v in cand if isinstance(v, dict)]
+        return []
+
+    def _simulate_event(
+        self,
+        df: pd.DataFrame,
+        setup_date: Any,
+        payload: dict,
+        capital_current: float,
+        cost_frac: float,
+    ) -> dict | None:
+        """1 イベント分の約定を計算して結果 dict を返す（不成立時は None）。"""
+        setup_ts = pd.Timestamp(setup_date)
+        event_date = payload.get("event_date")
+        if event_date is None or pd.isna(event_date):
+            return None
+        event_ts = pd.Timestamp(event_date)
+
+        entry_idx = self._locate(df, setup_ts)
+        exit_idx = self._locate(df, event_ts)
+        if entry_idx < 0 or exit_idx < 0 or exit_idx <= entry_idx:
+            return None
+
+        try:
+            entry_price = float(df.iloc[entry_idx]["Close"])  # MOC of T-1
+            exit_price = float(df.iloc[exit_idx]["Open"])  # MOO of T
+        except Exception:
+            return None
+        if entry_price <= 0 or exit_price <= 0:
+            return None
+
+        shares = self.calculate_position_size(capital_current, entry_price)
+        if shares <= 0:
+            return None
+
+        gross_pnl = (exit_price - entry_price) * shares  # ロング
+        cost = cost_frac * entry_price * shares  # 往復 2bp（entry ノーショナル基準）
+        pnl = gross_pnl - cost
+        return_pct = (pnl / capital_current * 100.0) if capital_current else 0.0
+
+        return {
+            "symbol": SYSTEM8_SYMBOL,
+            "entry_date": df.index[entry_idx],
+            "exit_date": df.index[exit_idx],
+            "entry_price": round(entry_price, 4),
+            "exit_price": round(exit_price, 4),
+            "shares": int(shares),
+            "pnl": round(pnl, 2),
+            "return_%": round(return_pct, 4),
+        }
+
+    @staticmethod
+    def _locate(df: pd.DataFrame, ts: pd.Timestamp) -> int:
+        """df.index 内での ts の位置を返す（見つからなければ -1）。"""
+        try:
+            idxers = df.index.get_indexer([ts])
+            return int(idxers[0]) if len(idxers) else -1
+        except Exception:
+            return -1
+
+    def get_total_days(self, data_dict: dict) -> int:
+        return int(get_total_days_system8(data_dict))

--- a/strategies/system8_strategy.py
+++ b/strategies/system8_strategy.py
@@ -1,5 +1,10 @@
 # ============================================================================
 # 🧠 Context Note
+# 🧬 Lineage: original (in-house) — **Bensdorp 準拠ではない**。当リポジトリ独自開発の
+#   イベントドリブン戦略 (FOMC 声明日のオーバーナイト・ドリフト)。System1-7 (bensdorp 系)
+#   とは設計思想が根本的に異なり、指標クロスでも top-N ストックピッキングでもない。
+#   出所は別リポジトリの研究成果 n0150_fomc_macro_event_drift_spy (凍結ルール v03)。
+#   正準定義: common/system_constants.py の SYSTEM_LINEAGE / docs/SYSTEM_LINEAGE.md
 # このファイルは core/system8.py（SPY オーバーナイト FOMC ドリフト）を UI/バックテスト
 # 向けに適応させるラッパー層
 #

--- a/tests/test_system8.py
+++ b/tests/test_system8.py
@@ -1,0 +1,235 @@
+"""System8（SPY オーバーナイト FOMC プレドリフト）の決定的テスト。
+
+ネットワーク・ライブ発注は一切行わない。小さな SPY 価格系列と既知の FOMC 日付
+（テンポラリ CSV）だけで、カレンダー読込・setup 付与・候補生成・オーバーナイト
+バックテスト損益を検証する。
+
+出所戦略: 別リポジトリ n0150_fomc_macro_event_drift_spy（rules_frozen.md v03）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.system8 import (
+    SYSTEM8_SYMBOL,
+    generate_candidates_system8,
+    get_total_days_system8,
+    load_fomc_event_dates,
+    prepare_data_vectorized_system8,
+)
+from strategies.system8_strategy import System8Strategy
+
+# --- フィクスチャ -----------------------------------------------------------
+
+# 取引日（営業日）: 2024-01-15 .. 2024-02-15。
+_FIXTURE_DATES = pd.bdate_range("2024-01-15", "2024-02-15")
+
+# 予定 FOMC 声明日 T = 2024-01-31（水曜・取引日）。setup 日 T-1 = 2024-01-30。
+_EVENT_DATE = pd.Timestamp("2024-01-31")
+_SETUP_DATE = pd.Timestamp("2024-01-30")
+
+# エントリー（T-1 引け）とエグジット（T 寄り）の価格を固定して損益を計算可能にする。
+_ENTRY_CLOSE = 100.0  # Close of 2024-01-30 (MOC)
+_EXIT_OPEN = 101.0  # Open of 2024-01-31 (MOO) → +1.0/share overnight
+
+
+def _make_spy_df() -> pd.DataFrame:
+    """既知の Open/Close を持つ SPY 日足フィクスチャを作る。"""
+    n = len(_FIXTURE_DATES)
+    df = pd.DataFrame(
+        {
+            "Open": [100.0] * n,
+            "High": [102.0] * n,
+            "Low": [98.0] * n,
+            "Close": [100.0] * n,
+            "Volume": [1_000_000] * n,
+        },
+        index=_FIXTURE_DATES,
+    )
+    df.loc[_SETUP_DATE, "Close"] = _ENTRY_CLOSE
+    df.loc[_EVENT_DATE, "Open"] = _EXIT_OPEN
+    return df
+
+
+def _write_fomc_csv(tmp_path: Path, dates: list[str]) -> Path:
+    """テスト用 FOMC カレンダー CSV を書き出してパスを返す。"""
+    rows = "\n".join(
+        f"{d},18:00,fomc,,,,,test,2026-07-16T00:00:00+00:00" for d in dates
+    )
+    header = "event_date,event_time_utc,event_type,actual,forecast,previous,surprise_z,source,fetch_ts"
+    path = tmp_path / "fomc.csv"
+    path.write_text(f"{header}\n{rows}\n", encoding="utf-8")
+    return path
+
+
+# --- load_fomc_event_dates --------------------------------------------------
+
+
+def test_load_fomc_event_dates_parses_and_filters(tmp_path: Path) -> None:
+    # 予定 fomc 2 件 + 別種別 1 件（除外されるべき）。
+    path = tmp_path / "fomc.csv"
+    path.write_text(
+        "event_date,event_type\n"
+        "2024-01-31,fomc\n"
+        "2024-03-20,fomc\n"
+        "2024-02-14,cpi\n",
+        encoding="utf-8",
+    )
+    dates = load_fomc_event_dates(path)
+    assert list(dates) == [pd.Timestamp("2024-01-31"), pd.Timestamp("2024-03-20")]
+
+
+def test_load_fomc_event_dates_missing_file_returns_empty(tmp_path: Path) -> None:
+    dates = load_fomc_event_dates(tmp_path / "does_not_exist.csv")
+    assert len(dates) == 0
+
+
+def test_bundled_calendar_loads_and_covers_range() -> None:
+    """リポジトリ同梱の data/events/fomc.csv が読め、年8回×多年をカバーする。"""
+    dates = load_fomc_event_dates()  # 既定パス
+    assert len(dates) >= 8 * 15  # 2006-2027 なら 100+ 件
+    assert dates.min() <= pd.Timestamp("2006-12-31")
+    assert dates.max() >= pd.Timestamp("2027-01-01")
+
+
+# --- prepare_data -----------------------------------------------------------
+
+
+def test_prepare_data_marks_setup_on_t_minus_1(tmp_path: Path) -> None:
+    path = _write_fomc_csv(tmp_path, ["2024-01-31"])
+    prepared = prepare_data_vectorized_system8(
+        {SYSTEM8_SYMBOL: _make_spy_df()}, fomc_calendar_path=path
+    )
+    df = prepared[SYSTEM8_SYMBOL]
+    # setup は T-1 のみ True。
+    assert bool(df.loc[_SETUP_DATE, "setup"]) is True
+    assert bool(df.loc[_EVENT_DATE, "setup"]) is False
+    assert int(df["setup"].sum()) == 1
+    # fomc_event は T のみ True。
+    assert bool(df.loc[_EVENT_DATE, "fomc_event"]) is True
+    # setup 日に対応する event_date が T を指す。
+    assert pd.Timestamp(df.loc[_SETUP_DATE, "fomc_event_date"]) == _EVENT_DATE
+
+
+def test_prepare_data_drops_non_trading_day_event(tmp_path: Path) -> None:
+    # 2024-01-06 は土曜（非取引日）→ index に存在せず setup 生成されない。
+    path = _write_fomc_csv(tmp_path, ["2024-01-06"])
+    prepared = prepare_data_vectorized_system8(
+        {SYSTEM8_SYMBOL: _make_spy_df()}, fomc_calendar_path=path
+    )
+    df = prepared[SYSTEM8_SYMBOL]
+    assert int(df["setup"].sum()) == 0
+    assert int(df["fomc_event"].sum()) == 0
+
+
+# --- generate_candidates ----------------------------------------------------
+
+
+def test_generate_candidates_full_scan(tmp_path: Path) -> None:
+    path = _write_fomc_csv(tmp_path, ["2024-01-31"])
+    prepared = prepare_data_vectorized_system8(
+        {SYSTEM8_SYMBOL: _make_spy_df()}, fomc_calendar_path=path
+    )
+    candidates, merged = generate_candidates_system8(prepared)
+    assert merged is None
+    assert set(candidates.keys()) == {_SETUP_DATE}
+    payload = candidates[_SETUP_DATE][SYSTEM8_SYMBOL]
+    assert pd.Timestamp(payload["event_date"]) == _EVENT_DATE
+    assert pd.Timestamp(payload["exit_date"]) == _EVENT_DATE
+    assert payload["entry_price"] == pytest.approx(_ENTRY_CLOSE)
+    assert payload["stop_price"] is None  # ストップなし
+
+
+def test_generate_candidates_latest_only_no_setup_today(tmp_path: Path) -> None:
+    # 最終行が setup でない場合、latest_only は空。
+    path = _write_fomc_csv(tmp_path, ["2024-01-31"])
+    prepared = prepare_data_vectorized_system8(
+        {SYSTEM8_SYMBOL: _make_spy_df()}, fomc_calendar_path=path
+    )
+    candidates, _df, diag = generate_candidates_system8(
+        prepared, latest_only=True, include_diagnostics=True
+    )
+    assert candidates == {}
+    assert diag["ranking_source"] is None
+
+
+def test_generate_candidates_latest_only_setup_today(tmp_path: Path) -> None:
+    # 最終行が setup になるようフィクスチャを組む: 声明日を最終行の翌営業日にできない
+    # ため、setup 日（T-1）が末尾になるよう短い系列を作る。
+    dates = pd.bdate_range("2024-01-29", "2024-01-30")  # 30 が末尾（= T-1）
+    df = pd.DataFrame(
+        {
+            "Open": [100.0, 100.0],
+            "High": [101.0, 101.0],
+            "Low": [99.0, 99.0],
+            "Close": [100.0, _ENTRY_CLOSE],
+            "Volume": [1, 1],
+        },
+        index=dates,
+    )
+    path = _write_fomc_csv(tmp_path, ["2024-01-31"])
+    prepared = prepare_data_vectorized_system8(
+        {SYSTEM8_SYMBOL: df}, fomc_calendar_path=path
+    )
+    candidates, df_fast, diag = generate_candidates_system8(
+        prepared, latest_only=True, include_diagnostics=True
+    )
+    assert diag["ranking_source"] == "latest_only"
+    assert len(candidates) == 1
+    assert df_fast is not None and not df_fast.empty
+
+
+# --- run_backtest / sizing --------------------------------------------------
+
+
+def test_strategy_end_to_end_backtest(tmp_path: Path) -> None:
+    strat = System8Strategy()
+    # position_pct を満額に固定（config 依存を排除して決定的に）。
+    strat.config["position_pct"] = 1.0
+    strat.config["cost_bps_roundtrip"] = 2.0
+
+    path = _write_fomc_csv(tmp_path, ["2024-01-31"])
+    prepared = strat.prepare_data(
+        {SYSTEM8_SYMBOL: _make_spy_df()}, fomc_calendar_path=path
+    )
+    candidates, _ = strat.generate_candidates(prepared)
+    capital = 100_000.0
+    trades = strat.run_backtest(prepared, candidates, capital)
+
+    assert len(trades) == 1
+    row = trades.iloc[0]
+    assert row["symbol"] == SYSTEM8_SYMBOL
+    assert pd.Timestamp(row["entry_date"]) == _SETUP_DATE
+    assert pd.Timestamp(row["exit_date"]) == _EVENT_DATE
+    assert row["entry_price"] == pytest.approx(_ENTRY_CLOSE)
+    assert row["exit_price"] == pytest.approx(_EXIT_OPEN)
+    # shares = floor(100000 / 100) = 1000
+    assert int(row["shares"]) == 1000
+    # gross = (101-100)*1000 = 1000 ; cost = 2bp * 100 * 1000 = 20 ; pnl = 980
+    assert row["pnl"] == pytest.approx(980.0)
+
+
+def test_calculate_position_size_equal_notional_no_stop() -> None:
+    strat = System8Strategy()
+    strat.config["position_pct"] = 1.0
+    # ストップ引数なしでも等ノーショナルで株数を返す。
+    assert strat.calculate_position_size(100_000.0, 100.0) == 1000
+    # position_pct=0.5 → 半額。
+    strat.config["position_pct"] = 0.5
+    assert strat.calculate_position_size(100_000.0, 100.0) == 500
+    # レバレッジは掛からない（position_pct>1 は 1.0 にクランプ）。
+    strat.config["position_pct"] = 2.0
+    assert strat.calculate_position_size(100_000.0, 100.0) == 1000
+
+
+def test_get_trading_side_is_long() -> None:
+    assert System8Strategy().get_trading_side() == "long"
+
+
+def test_get_total_days() -> None:
+    df = _make_spy_df()
+    assert get_total_days_system8({SYSTEM8_SYMBOL: df}) == len(_FIXTURE_DATES)

--- a/tests/test_system_lineage.py
+++ b/tests/test_system_lineage.py
@@ -1,0 +1,125 @@
+"""システムの血統 (lineage) レジストリの契約テスト。
+
+System1-7 (Bensdorp 準拠) と System8 (独自開発) を **機械的に** 区別できる状態を
+守るためのテスト。血統の記録が消えたり、番号から推測する実装に退行したりすると
+ここで落ちる。背景は docs/SYSTEM_LINEAGE.md を参照。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from common.system_constants import (
+    LINEAGE_BENSDORP,
+    LINEAGE_LABELS,
+    LINEAGE_ORIGINAL,
+    SYSTEM_CONFIGS,
+    SYSTEM_LINEAGE,
+    get_system_lineage,
+)
+from common.system_groups import (
+    GROUP_DISPLAY_NAMES,
+    LINEAGE_MARKER,
+    format_system_label,
+    lineage_legend,
+    lineage_marker,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALL_SYSTEMS = tuple(f"system{i}" for i in range(1, 9))
+
+
+def test_all_systems_have_a_lineage() -> None:
+    """1-8 の全 system が血統を持つ（抜けがあると分類不能になる）。"""
+    assert set(SYSTEM_LINEAGE) == set(ALL_SYSTEMS)
+
+
+def test_system1_to_7_are_bensdorp() -> None:
+    for name in (f"system{i}" for i in range(1, 8)):
+        assert get_system_lineage(name) == LINEAGE_BENSDORP, name
+
+
+def test_system8_is_original_not_bensdorp() -> None:
+    """System8 は独自開発。ここが bensdorp に変わったら血統の取り違え。"""
+    assert get_system_lineage("system8") == LINEAGE_ORIGINAL
+    assert get_system_lineage("system8") != LINEAGE_BENSDORP
+
+
+def test_get_system_lineage_is_case_insensitive() -> None:
+    assert get_system_lineage("System8") == LINEAGE_ORIGINAL
+
+
+def test_get_system_lineage_rejects_unknown() -> None:
+    with pytest.raises(KeyError):
+        get_system_lineage("system99")
+
+
+def test_lineage_values_are_known() -> None:
+    assert set(SYSTEM_LINEAGE.values()) <= {LINEAGE_BENSDORP, LINEAGE_ORIGINAL}
+    assert set(LINEAGE_LABELS) == {LINEAGE_BENSDORP, LINEAGE_ORIGINAL}
+
+
+def test_system_configs_lineage_matches_registry() -> None:
+    """SYSTEM_CONFIGS の lineage が正準マップと食い違わない（二重管理の drift 防止）。"""
+    for name, lineage in SYSTEM_LINEAGE.items():
+        assert SYSTEM_CONFIGS[name]["lineage"] == lineage, name
+
+
+def test_marker_only_on_original_lineage() -> None:
+    assert lineage_marker("system8") == LINEAGE_MARKER
+    for i in range(1, 8):
+        assert lineage_marker(f"system{i}") == ""
+    # 未知の system にマーカーを付けない（誤って独自扱いしない）。
+    assert lineage_marker("unknown") == ""
+
+
+def test_format_system_label_marks_only_system8() -> None:
+    assert format_system_label("system8") == f"System8{LINEAGE_MARKER}"
+    assert format_system_label("system1") == "System1"
+
+
+def test_lineage_legend_explains_the_marker() -> None:
+    legend = lineage_legend()
+    assert LINEAGE_MARKER in legend
+    assert LINEAGE_LABELS[LINEAGE_ORIGINAL] in legend
+
+
+def test_long_group_label_does_not_equate_system8_with_bensdorp_longs() -> None:
+    """System8 を System1/3/5 と同列に並べない（配分プールも別扱い）。"""
+    label = GROUP_DISPLAY_NAMES["long"]
+    assert "System8" in label
+    assert LINEAGE_MARKER in label
+    assert "System1,3,5,8" not in label
+
+
+@pytest.mark.parametrize("system_no", range(1, 9))
+def test_source_files_declare_lineage(system_no: int) -> None:
+    """core/ と strategies/ の先頭に血統行が残っている（消えない形で残す要件）。"""
+    expected = "original" if system_no == 8 else "bensdorp"
+    for rel in (
+        f"core/system{system_no}.py",
+        f"strategies/system{system_no}_strategy.py",
+    ):
+        head = (REPO_ROOT / rel).read_text(encoding="utf-8")[:1200]
+        assert "Lineage:" in head, rel
+        assert expected in head, rel
+
+
+def test_dashboard_lineage_map_matches_python_registry() -> None:
+    """ダッシュ側 (format.ts) の写しが Python 側の正準マップと一致する。"""
+    ts = (REPO_ROOT / "apps/dashboards/alpaca-next/lib/format.ts").read_text(
+        encoding="utf-8"
+    )
+    for name, lineage in SYSTEM_LINEAGE.items():
+        assert f"{name}: '{lineage}'" in ts, name
+    assert f"LINEAGE_MARKER = '{LINEAGE_MARKER}'" in ts
+
+
+def test_lineage_doc_exists() -> None:
+    doc = REPO_ROOT / "docs/SYSTEM_LINEAGE.md"
+    assert doc.exists()
+    text = doc.read_text(encoding="utf-8")
+    assert "Bensdorp" in text
+    assert "System8" in text


### PR DESCRIPTION
## 何をしたか

`origin/system8-fomc-drift`（2026-07-16 実装・push 済み、以後 land 漏れ）を main へマージし、
あわせて **System1-7 (Bensdorp 準拠) と System8 (独自開発) を機械的に区別**できるようにした。

## 1. 意図確認 — 「意図的な見送り」ではなく land 漏れ

移行 doc (`docs/SYSTEM8_FOMC_DRIFT_MIGRATION_20260716.md` §4-5) と委譲プロンプト
(`docs/SYSTEM8_MIGRATION_PROMPT_20260716.md`) を読んだ結果、**意図的に保留されているのは
2 点だけ**で、「main に入れない」という判断はどこにも書かれていない:

- (a) 実資金の配分ウェイト（`long_allocations` / `short_allocations`）
- (b) ライブ日次自動発注ループ（`scripts/run_all_systems_today.py` 等の `range(1, 8)`）

委譲時の「Do NOT commit or push」は**実装エージェントへの指示**で、その後 branch は
push されている。07-28 の landing sweep (#150) が他の残枝を回収した際にもこの枝だけ
漏れていた（main には `system8` の参照が 1 件も無かった）。

**→ land 漏れと判断して統合。保留 2 件はそのまま保留を維持している。**

## 2. マージ内容

コンフリクトなしで自動マージ（1,560 行 / 16 ファイル）。自動マージ成功≠意味的に無事なので、
main 側の変更点との整合を個別に確認した:

- `SYSTEM_SIDE_GROUPS` に system8 が入るが、唯一の consumer は表示用のカウント整形のみ
- `LONG_SYSTEMS` / 配分ウェイト / ライブ列挙ループはいずれも **system8 を含まないまま**

## 3. 血統 (lineage) の恒久記録

System8 は番号こそ連番だが、System1-7（Laurens Bensdorp の自動売買システム本準拠の
定型システム群）とは出自も設計思想も別物（独自開発の FOMC イベントドリブン）。
後任が「同じ枠組みの 8 番目」と誤解しないよう、3 層に記録した:

| 層 | 内容 |
|---|---|
| registry（正準） | `common/system_constants.py`: `SYSTEM_LINEAGE` / `get_system_lineage()` / `SYSTEM_CONFIGS[*]["lineage"]` |
| code / doc | `core/system1..8.py` + `strategies/system1..8_strategy.py` の全 16 ファイルに `Lineage:` 行（1-7 = bensdorp / 8 = original）。新規 `docs/SYSTEM_LINEAGE.md` |
| 表示 | `system_groups.py` の `LINEAGE_MARKER="◆"` ほか。ダッシュは `sysShort('system8')` → `S8◆`、Signal Pipeline に「独自」バッジ、配分/漏斗に凡例、チップに tooltip |

二重管理（`SYSTEM_CONFIGS` の写し / `format.ts` の写し）が正準とずれないことは
`tests/test_system_lineage.py` が強制する。

## 4. 検証

- `tests/test_system8.py` **12 passed** / `tests/test_system_lineage.py` **21 passed**
- フルスイート: merged **2361 passed / 228 failed**、baseline `origin/main` **2328 passed / 228 failed**
  → 失敗は完全一致（既存のローカル環境要因）、**passed の差 +33 = 新規テストぶんのみ＝回帰なし**
- `black --check` / `ruff check` / `isort --check` clean
- ダッシュ: `tsc --noEmit` clean / `next build` 緑 / dev サーバ実描画で `S8◆`・「独自」バッジ・凡例・tooltip を DOM 確認、console エラーなし

## 5. やっていないこと（意図的）

- **runner (`C:\tmp\qts-main-run`) への arm はしていない**。main への land は統合であって、
  自動売買を有効化する話ではない。
- 配分ウェイト・ライブ日次ループも未配線のまま（上記の保留 2 件）。
- 発注は一切していない（paper 含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)